### PR TITLE
Move active cell interface to solid-liquid boundary interior; remove unneeded walls/solid cells

### DIFF
--- a/examples/Inp_AMBenchMultilayer.txt
+++ b/examples/Inp_AMBenchMultilayer.txt
@@ -16,7 +16,6 @@ Substrate grain spacing: 25
 Path to temperature file(s): examples/Temperatures
 Temperature filename(s): CA-FOAM-fluidflow.txt
 Number of temperature files: 2
-Extra set of wall cells in lateral domain directions: N
 Number of layers: 4
 Offset between layers: 3
 ***Output data printing options: (Y or N) which data should be printed***

--- a/examples/Inp_SimpleRaster.txt
+++ b/examples/Inp_SimpleRaster.txt
@@ -16,7 +16,6 @@ Substrate grain spacing: 25
 Path to temperature file(s): examples/Temperatures
 Temperature filename(s): Master-Raster-150um.txt
 Number of temperature files: 1
-Extra set of wall cells in lateral domain directions: N
 Number of layers: 1
 Offset between layers: 15
 ***Output data printing options: (Y or N) which data should be printed***

--- a/examples/Inp_WorkflowExample.txt
+++ b/examples/Inp_WorkflowExample.txt
@@ -16,7 +16,6 @@ Substrate grain spacing: 25
 Path to temperature file(s): examples/Temperatures
 Temperature filename(s): leg.txt
 Number of temperature files: 2
-Extra set of wall cells in lateral domain directions: N
 Number of layers: 20
 Offset between layers: 6
 ***Output data printing options: (Y or N) which data should be printed***

--- a/src/CAfunctions.cpp
+++ b/src/CAfunctions.cpp
@@ -34,7 +34,7 @@ double CrossP3(double TestVec1[3], double TestVec2[3]) {
 int XMPSlicesCalc(int p, int nx, int ProcessorsInXDirection, int ProcessorsInYDirection, int DecompositionStrategy) {
     int XRemoteMPSlices = 0;
     if (DecompositionStrategy == 1) {
-        XRemoteMPSlices = nx;
+        XRemoteMPSlices = nx; // no ghost nodes, domain not divided up in the x direction
     }
     else if (DecompositionStrategy >= 2) {
         int XSlicesPerP = nx / ProcessorsInXDirection;
@@ -52,8 +52,6 @@ int XMPSlicesCalc(int p, int nx, int ProcessorsInXDirection, int ProcessorsInYDi
             }
         }
     }
-    // Add "ghost nodes" for other processors
-    XRemoteMPSlices = XRemoteMPSlices + 2;
     return XRemoteMPSlices;
 }
 
@@ -61,6 +59,7 @@ int XMPSlicesCalc(int p, int nx, int ProcessorsInXDirection, int ProcessorsInYDi
 int XOffsetCalc(int p, int nx, int ProcessorsInXDirection, int ProcessorsInYDirection, int DecompositionStrategy) {
     int RemoteXOffset = 0;
     if (DecompositionStrategy == 1) {
+        // No decomposition in the x direction, so no ghost nodes to affect the local domain offset
         RemoteXOffset = 0;
     }
     else if (DecompositionStrategy >= 2) {
@@ -80,8 +79,7 @@ int XOffsetCalc(int p, int nx, int ProcessorsInXDirection, int ProcessorsInYDire
             }
         }
     }
-    // Account for "ghost nodes" for other processors
-    RemoteXOffset--;
+
     return RemoteXOffset;
 }
 
@@ -119,8 +117,6 @@ int YMPSlicesCalc(int p, int ny, int ProcessorsInYDirection, int np, int Decompo
             }
         }
     }
-    // Add "ghost nodes" for other processors
-    YRemoteMPSlices = YRemoteMPSlices + 2;
 
     return YRemoteMPSlices;
 }
@@ -160,9 +156,40 @@ int YOffsetCalc(int p, int ny, int ProcessorsInYDirection, int np, int Decomposi
             }
         }
     }
-    // Account for "ghost nodes" for other processors
-    RemoteYOffset--;
     return RemoteYOffset;
+}
+
+// Add ghost nodes to the appropriate subdomains (added where the subdomains overlap, but not at edges of physical
+// domain)
+void AddGhostNodes(int DecompositionStrategy, int NeighborRank_West, int NeighborRank_East, int NeighborRank_North,
+                   int NeighborRank_South, int &XRemoteMPSlices, int &RemoteXOffset, int &YRemoteMPSlices,
+                   int &RemoteYOffset) {
+
+    if (DecompositionStrategy > 1) {
+        // Decomposing domain in X and Y directions
+        // Add halo regions in X if this subdomain borders subdomains on other processors
+        // If only 1 rank in the x direction, no halo regions - subdomain is coincident with overall simulation domain
+        // If multiple ranks in the x direction, either 1 halo region (borders another rank's subdomain in either the +x
+        // or -x direction) or 2 halo regions (if it borders other rank's subdomains in both the +x and -x directions)
+        if (NeighborRank_West != MPI_PROC_NULL) {
+            XRemoteMPSlices++;
+            // Also adjust subdomain offset, as these ghost nodes were added on the -x side of the subdomain
+            RemoteXOffset--;
+        }
+        if (NeighborRank_East != MPI_PROC_NULL)
+            XRemoteMPSlices++;
+    }
+    // Add halo regions in Y direction if this subdomain borders subdomains on other processors
+    // If only 1 rank in the y direction, no halo regions - subdomain is coincident with overall simulation domain
+    // If multiple ranks in the y direction, either 1 halo region (borders another rank's subdomain in either the +y or
+    // -y direction) or 2 halo regions (if it borders other rank's subdomains in both the +y and -y directions)
+    if (NeighborRank_North != MPI_PROC_NULL)
+        YRemoteMPSlices++;
+    if (NeighborRank_South != MPI_PROC_NULL) {
+        YRemoteMPSlices++;
+        // Also adjust subdomain offset, as these ghost nodes were added on the -y side of the subdomain
+        RemoteYOffset--;
+    }
 }
 
 //*****************************************************************************/

--- a/src/CAfunctions.hpp
+++ b/src/CAfunctions.hpp
@@ -15,6 +15,9 @@ int XMPSlicesCalc(int p, int nx, int ProcessorsInXDirection, int ProcessorsInYDi
 int XOffsetCalc(int p, int nx, int ProcessorsInXDirection, int ProcessorsInYDirection, int DecompositionStrategy);
 int YMPSlicesCalc(int p, int ny, int ProcessorsInYDirection, int np, int DecompositionStrategy);
 int YOffsetCalc(int p, int ny, int ProcessorsInYDirection, int np, int DecompositionStrategy);
+void AddGhostNodes(int DecompositionStrategy, int NeighborRank_West, int NeighborRank_East, int NeighborRank_North,
+                   int NeighborRank_South, int &XRemoteMPSlices, int &RemoteXOffset, int &YRemoteMPSlices,
+                   int &RemoteYOffset);
 double MaxVal(double TestVec3[6], int NVals);
 void InitialDecomposition(int &DecompositionStrategy, int nx, int ny, int &ProcessorsInXDirection,
                           int &ProcessorsInYDirection, int id, int np, int &NeighborRank_North, int &NeighborRank_South,

--- a/src/CAghostnodes.cpp
+++ b/src/CAghostnodes.cpp
@@ -15,81 +15,81 @@
 void GhostNodesInit(int, int, int DecompositionStrategy, int NeighborRank_North, int NeighborRank_South,
                     int NeighborRank_East, int NeighborRank_West, int NeighborRank_NorthEast,
                     int NeighborRank_NorthWest, int NeighborRank_SouthEast, int NeighborRank_SouthWest, int MyXSlices,
-                    int MyYSlices, int MyXOffset, int MyYOffset, int ZBound_Low, int nzActive,
-                    int LocalActiveDomainSize, int NGrainOrientations, ViewI NeighborX, ViewI NeighborY,
-                    ViewI NeighborZ, ViewF GrainUnitVector, ViewI GrainOrientation, ViewI GrainID, ViewI CellType,
-                    ViewF DOCenter, ViewF DiagonalLength, ViewF CritDiagonalLength) {
+                    int MyYSlices, int MyXOffset, int MyYOffset, int ZBound_Low, int nzActive, int nz, int,
+                    int NGrainOrientations, ViewI NeighborX, ViewI NeighborY, ViewI NeighborZ, ViewF GrainUnitVector,
+                    ViewI GrainOrientation, ViewI GrainID, ViewI CellType, ViewF DOCenter, ViewF DiagonalLength,
+                    ViewF CritDiagonalLength) {
 
     // Fill buffers with ghost node data following initialization of data on GPUs
     // Similar to the calls to GhostNodes1D/GhostNodes2D, but the information sent/received in the halo regions is
     // different Need to send and receive cell type data, grain id data from other ranks
-    Buffer3D BufferSouthSend(Kokkos::ViewAllocateWithoutInitializing("BufferSouthSend"), MyXSlices, nzActive, 2);
-    Buffer3D BufferNorthSend(Kokkos::ViewAllocateWithoutInitializing("BufferNorthSend"), MyXSlices, nzActive, 2);
-    Buffer3D BufferSouthRecv(Kokkos::ViewAllocateWithoutInitializing("BufferSouthRecv"), MyXSlices, nzActive, 2);
-    Buffer3D BufferNorthRecv(Kokkos::ViewAllocateWithoutInitializing("BufferNorthRecv"), MyXSlices, nzActive, 2);
+    // Need to send and receive data for the entire domain height in Z, as powder layer grains were not initialized in
+    // the ghost nodes
+    Buffer3D BufferSouthSend(Kokkos::ViewAllocateWithoutInitializing("BufferSouthSend"), MyXSlices, nz, 2);
+    Buffer3D BufferNorthSend(Kokkos::ViewAllocateWithoutInitializing("BufferNorthSend"), MyXSlices, nz, 2);
+    Buffer3D BufferSouthRecv(Kokkos::ViewAllocateWithoutInitializing("BufferSouthRecv"), MyXSlices, nz, 2);
+    Buffer3D BufferNorthRecv(Kokkos::ViewAllocateWithoutInitializing("BufferNorthRecv"), MyXSlices, nz, 2);
 
     Buffer3D BufferWestSend, BufferEastSend, BufferWestRecv, BufferEastRecv;
     Buffer2D BufferNorthEastSend, BufferNorthWestSend, BufferSouthWestSend, BufferSouthEastSend;
     Buffer2D BufferNorthEastRecv, BufferNorthWestRecv, BufferSouthWestRecv, BufferSouthEastRecv;
     if (DecompositionStrategy > 1) {
-        BufferWestSend = Buffer3D(Kokkos::ViewAllocateWithoutInitializing("BufferWestSend"), MyYSlices, nzActive, 2);
-        BufferEastSend = Buffer3D(Kokkos::ViewAllocateWithoutInitializing("BufferEastSend"), MyYSlices, nzActive, 2);
-        BufferNorthEastSend = Buffer2D(Kokkos::ViewAllocateWithoutInitializing("BufferNorthEastSend"), nzActive, 2);
-        BufferNorthWestSend = Buffer2D(Kokkos::ViewAllocateWithoutInitializing("BufferNorthWestSend"), nzActive, 2);
-        BufferSouthWestSend = Buffer2D(Kokkos::ViewAllocateWithoutInitializing("BufferSouthWestSend"), nzActive, 2);
-        BufferSouthEastSend = Buffer2D(Kokkos::ViewAllocateWithoutInitializing("BufferSouthEastSend"), nzActive, 2);
-        BufferWestRecv = Buffer3D(Kokkos::ViewAllocateWithoutInitializing("BufferWestRecv"), MyYSlices, nzActive, 2);
-        BufferEastRecv = Buffer3D(Kokkos::ViewAllocateWithoutInitializing("BufferEastRecv"), MyYSlices, nzActive, 2);
-        BufferNorthEastRecv = Buffer2D(Kokkos::ViewAllocateWithoutInitializing("BufferNorthEastRecv"), nzActive, 2);
-        BufferNorthWestRecv = Buffer2D(Kokkos::ViewAllocateWithoutInitializing("BufferNorthWestRecv"), nzActive, 2);
-        BufferSouthWestRecv = Buffer2D(Kokkos::ViewAllocateWithoutInitializing("BufferSouthWestRecv"), nzActive, 2);
-        BufferSouthEastRecv = Buffer2D(Kokkos::ViewAllocateWithoutInitializing("BufferSouthEastRecv"), nzActive, 2);
+        BufferWestSend = Buffer3D(Kokkos::ViewAllocateWithoutInitializing("BufferWestSend"), MyYSlices, nz, 2);
+        BufferEastSend = Buffer3D(Kokkos::ViewAllocateWithoutInitializing("BufferEastSend"), MyYSlices, nz, 2);
+        BufferNorthEastSend = Buffer2D(Kokkos::ViewAllocateWithoutInitializing("BufferNorthEastSend"), nz, 2);
+        BufferNorthWestSend = Buffer2D(Kokkos::ViewAllocateWithoutInitializing("BufferNorthWestSend"), nz, 2);
+        BufferSouthWestSend = Buffer2D(Kokkos::ViewAllocateWithoutInitializing("BufferSouthWestSend"), nz, 2);
+        BufferSouthEastSend = Buffer2D(Kokkos::ViewAllocateWithoutInitializing("BufferSouthEastSend"), nz, 2);
+        BufferWestRecv = Buffer3D(Kokkos::ViewAllocateWithoutInitializing("BufferWestRecv"), MyYSlices, nz, 2);
+        BufferEastRecv = Buffer3D(Kokkos::ViewAllocateWithoutInitializing("BufferEastRecv"), MyYSlices, nz, 2);
+        BufferNorthEastRecv = Buffer2D(Kokkos::ViewAllocateWithoutInitializing("BufferNorthEastRecv"), nz, 2);
+        BufferNorthWestRecv = Buffer2D(Kokkos::ViewAllocateWithoutInitializing("BufferNorthWestRecv"), nz, 2);
+        BufferSouthWestRecv = Buffer2D(Kokkos::ViewAllocateWithoutInitializing("BufferSouthWestRecv"), nz, 2);
+        BufferSouthEastRecv = Buffer2D(Kokkos::ViewAllocateWithoutInitializing("BufferSouthEastRecv"), nz, 2);
     }
 
     // Load send buffers
     Kokkos::parallel_for(
-        "GNInit", LocalActiveDomainSize, KOKKOS_LAMBDA(const long int &D3D1ConvPosition) {
-            int RankZ = D3D1ConvPosition / (MyXSlices * MyYSlices);
-            int Rem = D3D1ConvPosition % (MyXSlices * MyYSlices);
+        "GNInit", MyXSlices * MyYSlices * nz, KOKKOS_LAMBDA(const long int &D3D1ConvPositionGlobal) {
+            int GlobalZ = D3D1ConvPositionGlobal / (MyXSlices * MyYSlices);
+            int Rem = D3D1ConvPositionGlobal % (MyXSlices * MyYSlices);
             int RankX = Rem / MyYSlices;
             int RankY = Rem % MyYSlices;
-            int GlobalZ = RankZ + ZBound_Low;
-            int D3D1ConvPositionGlobal = GlobalZ * MyXSlices * MyYSlices + RankX * MyYSlices + RankY;
             int GhostGID = GrainID(D3D1ConvPositionGlobal);
             int GhostCT = CellType(D3D1ConvPositionGlobal);
             // Collect data for the ghost nodes:
             if (RankY == 1) {
-                BufferSouthSend(RankX, RankZ, 0) = GhostGID;
-                BufferSouthSend(RankX, RankZ, 1) = GhostCT;
+                BufferSouthSend(RankX, GlobalZ, 0) = GhostGID;
+                BufferSouthSend(RankX, GlobalZ, 1) = GhostCT;
             }
             else if (RankY == MyYSlices - 2) {
-                BufferNorthSend(RankX, RankZ, 0) = GhostGID;
-                BufferNorthSend(RankX, RankZ, 1) = GhostCT;
+                BufferNorthSend(RankX, GlobalZ, 0) = GhostGID;
+                BufferNorthSend(RankX, GlobalZ, 1) = GhostCT;
             }
             if (DecompositionStrategy > 1) {
                 if (RankX == MyXSlices - 2) {
-                    BufferEastSend(RankY, RankZ, 0) = GhostGID;
-                    BufferEastSend(RankY, RankZ, 1) = GhostCT;
+                    BufferEastSend(RankY, GlobalZ, 0) = GhostGID;
+                    BufferEastSend(RankY, GlobalZ, 1) = GhostCT;
                 }
                 else if (RankX == 1) {
-                    BufferWestSend(RankY, RankZ, 0) = GhostGID;
-                    BufferWestSend(RankY, RankZ, 1) = GhostCT;
+                    BufferWestSend(RankY, GlobalZ, 0) = GhostGID;
+                    BufferWestSend(RankY, GlobalZ, 1) = GhostCT;
                 }
                 if ((RankY == 1) && (RankX == 1)) {
-                    BufferSouthWestSend(RankZ, 0) = GhostGID;
-                    BufferSouthWestSend(RankZ, 1) = GhostCT;
+                    BufferSouthWestSend(GlobalZ, 0) = GhostGID;
+                    BufferSouthWestSend(GlobalZ, 1) = GhostCT;
                 }
                 else if ((RankY == 1) && (RankX == MyXSlices - 2)) {
-                    BufferSouthEastSend(RankZ, 0) = GhostGID;
-                    BufferSouthEastSend(RankZ, 1) = GhostCT;
+                    BufferSouthEastSend(GlobalZ, 0) = GhostGID;
+                    BufferSouthEastSend(GlobalZ, 1) = GhostCT;
                 }
                 else if ((RankY == MyYSlices - 2) && (RankX == MyXSlices - 2)) {
-                    BufferNorthEastSend(RankZ, 0) = GhostGID;
-                    BufferNorthEastSend(RankZ, 1) = GhostCT;
+                    BufferNorthEastSend(GlobalZ, 0) = GhostGID;
+                    BufferNorthEastSend(GlobalZ, 1) = GhostCT;
                 }
                 else if ((RankY == MyYSlices - 2) && (RankX == 1)) {
-                    BufferNorthWestSend(RankZ, 0) = GhostGID;
-                    BufferNorthWestSend(RankZ, 1) = GhostCT;
+                    BufferNorthWestSend(GlobalZ, 0) = GhostGID;
+                    BufferNorthWestSend(GlobalZ, 1) = GhostCT;
                 }
             }
         });
@@ -104,42 +104,42 @@ void GhostNodesInit(int, int, int DecompositionStrategy, int NeighborRank_North,
     std::vector<MPI_Request> RecvRequests(NumberOfSends, MPI_REQUEST_NULL);
 
     // Send data to each other rank (MPI_Isend)
-    MPI_Isend(BufferSouthSend.data(), 2 * MyXSlices * nzActive, MPI_INT, NeighborRank_South, 0, MPI_COMM_WORLD,
+    MPI_Isend(BufferSouthSend.data(), 2 * MyXSlices * nz, MPI_INT, NeighborRank_South, 0, MPI_COMM_WORLD,
               &SendRequests[0]);
-    MPI_Isend(BufferNorthSend.data(), 2 * MyXSlices * nzActive, MPI_INT, NeighborRank_North, 0, MPI_COMM_WORLD,
+    MPI_Isend(BufferNorthSend.data(), 2 * MyXSlices * nz, MPI_INT, NeighborRank_North, 0, MPI_COMM_WORLD,
               &SendRequests[1]);
     if (DecompositionStrategy > 1) {
-        MPI_Isend(BufferEastSend.data(), 2 * MyYSlices * nzActive, MPI_INT, NeighborRank_East, 0, MPI_COMM_WORLD,
+        MPI_Isend(BufferEastSend.data(), 2 * MyYSlices * nz, MPI_INT, NeighborRank_East, 0, MPI_COMM_WORLD,
                   &SendRequests[2]);
-        MPI_Isend(BufferWestSend.data(), 2 * MyYSlices * nzActive, MPI_INT, NeighborRank_West, 0, MPI_COMM_WORLD,
+        MPI_Isend(BufferWestSend.data(), 2 * MyYSlices * nz, MPI_INT, NeighborRank_West, 0, MPI_COMM_WORLD,
                   &SendRequests[3]);
-        MPI_Isend(BufferNorthWestSend.data(), 2 * nzActive, MPI_INT, NeighborRank_NorthWest, 0, MPI_COMM_WORLD,
+        MPI_Isend(BufferNorthWestSend.data(), 2 * nz, MPI_INT, NeighborRank_NorthWest, 0, MPI_COMM_WORLD,
                   &SendRequests[4]);
-        MPI_Isend(BufferNorthEastSend.data(), 2 * nzActive, MPI_INT, NeighborRank_NorthEast, 0, MPI_COMM_WORLD,
+        MPI_Isend(BufferNorthEastSend.data(), 2 * nz, MPI_INT, NeighborRank_NorthEast, 0, MPI_COMM_WORLD,
                   &SendRequests[5]);
-        MPI_Isend(BufferSouthWestSend.data(), 2 * nzActive, MPI_INT, NeighborRank_SouthWest, 0, MPI_COMM_WORLD,
+        MPI_Isend(BufferSouthWestSend.data(), 2 * nz, MPI_INT, NeighborRank_SouthWest, 0, MPI_COMM_WORLD,
                   &SendRequests[6]);
-        MPI_Isend(BufferSouthEastSend.data(), 2 * nzActive, MPI_INT, NeighborRank_SouthEast, 0, MPI_COMM_WORLD,
+        MPI_Isend(BufferSouthEastSend.data(), 2 * nz, MPI_INT, NeighborRank_SouthEast, 0, MPI_COMM_WORLD,
                   &SendRequests[7]);
     }
 
     // Receive buffers for all neighbors (MPI_Irecv)
-    MPI_Irecv(BufferSouthRecv.data(), 2 * MyXSlices * nzActive, MPI_INT, NeighborRank_South, 0, MPI_COMM_WORLD,
+    MPI_Irecv(BufferSouthRecv.data(), 2 * MyXSlices * nz, MPI_INT, NeighborRank_South, 0, MPI_COMM_WORLD,
               &RecvRequests[0]);
-    MPI_Irecv(BufferNorthRecv.data(), 2 * MyXSlices * nzActive, MPI_INT, NeighborRank_North, 0, MPI_COMM_WORLD,
+    MPI_Irecv(BufferNorthRecv.data(), 2 * MyXSlices * nz, MPI_INT, NeighborRank_North, 0, MPI_COMM_WORLD,
               &RecvRequests[1]);
     if (DecompositionStrategy > 1) {
-        MPI_Irecv(BufferEastRecv.data(), 2 * MyYSlices * nzActive, MPI_INT, NeighborRank_East, 0, MPI_COMM_WORLD,
+        MPI_Irecv(BufferEastRecv.data(), 2 * MyYSlices * nz, MPI_INT, NeighborRank_East, 0, MPI_COMM_WORLD,
                   &RecvRequests[2]);
-        MPI_Irecv(BufferWestRecv.data(), 2 * MyYSlices * nzActive, MPI_INT, NeighborRank_West, 0, MPI_COMM_WORLD,
+        MPI_Irecv(BufferWestRecv.data(), 2 * MyYSlices * nz, MPI_INT, NeighborRank_West, 0, MPI_COMM_WORLD,
                   &RecvRequests[3]);
-        MPI_Irecv(BufferNorthWestRecv.data(), 2 * nzActive, MPI_INT, NeighborRank_NorthWest, 0, MPI_COMM_WORLD,
+        MPI_Irecv(BufferNorthWestRecv.data(), 2 * nz, MPI_INT, NeighborRank_NorthWest, 0, MPI_COMM_WORLD,
                   &RecvRequests[4]);
-        MPI_Irecv(BufferNorthEastRecv.data(), 2 * nzActive, MPI_INT, NeighborRank_NorthEast, 0, MPI_COMM_WORLD,
+        MPI_Irecv(BufferNorthEastRecv.data(), 2 * nz, MPI_INT, NeighborRank_NorthEast, 0, MPI_COMM_WORLD,
                   &RecvRequests[5]);
-        MPI_Irecv(BufferSouthWestRecv.data(), 2 * nzActive, MPI_INT, NeighborRank_SouthWest, 0, MPI_COMM_WORLD,
+        MPI_Irecv(BufferSouthWestRecv.data(), 2 * nz, MPI_INT, NeighborRank_SouthWest, 0, MPI_COMM_WORLD,
                   &RecvRequests[6]);
-        MPI_Irecv(BufferSouthEastRecv.data(), 2 * nzActive, MPI_INT, NeighborRank_SouthEast, 0, MPI_COMM_WORLD,
+        MPI_Irecv(BufferSouthEastRecv.data(), 2 * nz, MPI_INT, NeighborRank_SouthEast, 0, MPI_COMM_WORLD,
                   &RecvRequests[7]);
     }
 
@@ -157,9 +157,8 @@ void GhostNodesInit(int, int, int DecompositionStrategy, int NeighborRank_North,
         // Otherwise unpack the next buffer.
         else {
             Kokkos::parallel_for(
-                "BufferUnpack", nzActive, KOKKOS_LAMBDA(const int &RankZ) {
+                "BufferUnpack", nz, KOKKOS_LAMBDA(const int &GlobalZ) {
                     int RankX, RankY;
-                    int GlobalZ = RankZ + ZBound_Low;
 
                     // Which rank was the data received from?
                     if (((unpack_index == 0) && (NeighborRank_South != MPI_PROC_NULL)) ||
@@ -181,12 +180,12 @@ void GhostNodesInit(int, int, int DecompositionStrategy, int NeighborRank_North,
                         for (int RankX = XIterationRangeStart; RankX < XIterationRangeEnd; RankX++) {
                             int GlobalCellLocation = GlobalZ * MyXSlices * MyYSlices + RankX * MyYSlices + RankY;
                             if (unpack_index == 0) {
-                                GrainID(GlobalCellLocation) = BufferSouthRecv(RankX, RankZ, 0);
-                                CellType(GlobalCellLocation) = BufferSouthRecv(RankX, RankZ, 1);
+                                GrainID(GlobalCellLocation) = BufferSouthRecv(RankX, GlobalZ, 0);
+                                CellType(GlobalCellLocation) = BufferSouthRecv(RankX, GlobalZ, 1);
                             }
                             else {
-                                GrainID(GlobalCellLocation) = BufferNorthRecv(RankX, RankZ, 0);
-                                CellType(GlobalCellLocation) = BufferNorthRecv(RankX, RankZ, 1);
+                                GrainID(GlobalCellLocation) = BufferNorthRecv(RankX, GlobalZ, 0);
+                                CellType(GlobalCellLocation) = BufferNorthRecv(RankX, GlobalZ, 1);
                             }
                             if (CellType(GlobalCellLocation) == Active) {
                                 // Mark cell for later placement of octahedra, critical diagonal length calculations
@@ -207,12 +206,12 @@ void GhostNodesInit(int, int, int DecompositionStrategy, int NeighborRank_North,
                         for (int RankY = 1; RankY < MyYSlices - 1; RankY++) {
                             int GlobalCellLocation = GlobalZ * MyXSlices * MyYSlices + RankX * MyYSlices + RankY;
                             if (unpack_index == 2) {
-                                GrainID(GlobalCellLocation) = BufferEastRecv(RankY, RankZ, 0);
-                                CellType(GlobalCellLocation) = BufferEastRecv(RankY, RankZ, 1);
+                                GrainID(GlobalCellLocation) = BufferEastRecv(RankY, GlobalZ, 0);
+                                CellType(GlobalCellLocation) = BufferEastRecv(RankY, GlobalZ, 1);
                             }
                             else {
-                                GrainID(GlobalCellLocation) = BufferWestRecv(RankY, RankZ, 0);
-                                CellType(GlobalCellLocation) = BufferWestRecv(RankY, RankZ, 1);
+                                GrainID(GlobalCellLocation) = BufferWestRecv(RankY, GlobalZ, 0);
+                                CellType(GlobalCellLocation) = BufferWestRecv(RankY, GlobalZ, 1);
                             }
                             if (CellType(GlobalCellLocation) == Active) {
                                 // Mark cell for later placement of octahedra, critical diagonal length calculations
@@ -226,8 +225,8 @@ void GhostNodesInit(int, int, int DecompositionStrategy, int NeighborRank_North,
                             RankX = 0;
                             RankY = MyYSlices - 1;
                             int GlobalCellLocation = GlobalZ * MyXSlices * MyYSlices + RankX * MyYSlices + RankY;
-                            GrainID(GlobalCellLocation) = BufferNorthWestRecv(RankZ, 0);
-                            CellType(GlobalCellLocation) = BufferNorthWestRecv(RankZ, 1);
+                            GrainID(GlobalCellLocation) = BufferNorthWestRecv(GlobalZ, 0);
+                            CellType(GlobalCellLocation) = BufferNorthWestRecv(GlobalZ, 1);
                             // Mark cell for later placement of octahedra, critical diagonal length calculations
                             if (CellType(GlobalCellLocation) == Active)
                                 CellType(GlobalCellLocation) = Ghost;
@@ -237,8 +236,8 @@ void GhostNodesInit(int, int, int DecompositionStrategy, int NeighborRank_North,
                             RankX = MyXSlices - 1;
                             RankY = MyYSlices - 1;
                             int GlobalCellLocation = GlobalZ * MyXSlices * MyYSlices + RankX * MyYSlices + RankY;
-                            GrainID(GlobalCellLocation) = BufferNorthEastRecv(RankZ, 0);
-                            CellType(GlobalCellLocation) = BufferNorthEastRecv(RankZ, 1);
+                            GrainID(GlobalCellLocation) = BufferNorthEastRecv(GlobalZ, 0);
+                            CellType(GlobalCellLocation) = BufferNorthEastRecv(GlobalZ, 1);
                             // Mark cell for later placement of octahedra, critical diagonal length calculations
                             if (CellType(GlobalCellLocation) == Active)
                                 CellType(GlobalCellLocation) = Ghost;
@@ -248,8 +247,8 @@ void GhostNodesInit(int, int, int DecompositionStrategy, int NeighborRank_North,
                             RankX = 0;
                             RankY = 0;
                             int GlobalCellLocation = GlobalZ * MyXSlices * MyYSlices + RankX * MyYSlices + RankY;
-                            GrainID(GlobalCellLocation) = BufferSouthWestRecv(RankZ, 0);
-                            CellType(GlobalCellLocation) = BufferSouthWestRecv(RankZ, 1);
+                            GrainID(GlobalCellLocation) = BufferSouthWestRecv(GlobalZ, 0);
+                            CellType(GlobalCellLocation) = BufferSouthWestRecv(GlobalZ, 1);
                             // Mark cell for later placement of octahedra, critical diagonal length calculations
                             if (CellType(GlobalCellLocation) == Active)
                                 CellType(GlobalCellLocation) = Ghost;
@@ -259,8 +258,8 @@ void GhostNodesInit(int, int, int DecompositionStrategy, int NeighborRank_North,
                             RankX = MyXSlices - 1;
                             RankY = 0;
                             int GlobalCellLocation = GlobalZ * MyXSlices * MyYSlices + RankX * MyYSlices + RankY;
-                            GrainID(GlobalCellLocation) = BufferSouthEastRecv(RankZ, 0);
-                            CellType(GlobalCellLocation) = BufferSouthEastRecv(RankZ, 1);
+                            GrainID(GlobalCellLocation) = BufferSouthEastRecv(GlobalZ, 0);
+                            CellType(GlobalCellLocation) = BufferSouthEastRecv(GlobalZ, 1);
                             // Mark cell for later placement of octahedra, critical diagonal length calculations
                             if (CellType(GlobalCellLocation) == Active)
                                 CellType(GlobalCellLocation) = Ghost;
@@ -276,118 +275,120 @@ void GhostNodesInit(int, int, int DecompositionStrategy, int NeighborRank_North,
     // Octahedra for active cells that were marked in the previous loop, initially have centers aligned with cell
     // centers, Diagonal lengths of 0.01
     Kokkos::parallel_for(
-        "GNInit", LocalActiveDomainSize, KOKKOS_LAMBDA(const int &CellLocation) {
-            int RankZ = CellLocation / (MyXSlices * MyYSlices);
-            int Rem = CellLocation % (MyXSlices * MyYSlices);
+        "GNInit", MyXSlices * MyYSlices * nz, KOKKOS_LAMBDA(const int &GlobalCellLocation) {
+            int GlobalZ = GlobalCellLocation / (MyXSlices * MyYSlices);
+            int Rem = GlobalCellLocation % (MyXSlices * MyYSlices);
             int RankX = Rem / MyYSlices;
             int RankY = Rem % MyYSlices;
-            int GlobalZ = RankZ + ZBound_Low;
-            int GlobalCellLocation = GlobalZ * MyXSlices * MyYSlices + RankX * MyYSlices + RankY;
+            int RankZ = GlobalZ - ZBound_Low;
+            int LocalCellLocation = RankZ * MyXSlices * MyYSlices + RankX * MyYSlices + RankY;
             if (CellType(GlobalCellLocation) == Ghost) {
                 CellType(GlobalCellLocation) = Active;
-                DOCenter((long int)(3) * CellLocation) = RankX + MyXOffset + 0.5;
-                DOCenter((long int)(3) * CellLocation + (long int)(1)) = RankY + MyYOffset + 0.5;
-                DOCenter((long int)(3) * CellLocation + (long int)(2)) = GlobalZ + 0.5;
-                int MyOrientation = GrainOrientation(((abs(GrainID(GlobalCellLocation)) - 1) % NGrainOrientations));
-                DiagonalLength(CellLocation) = 0.01;
-                // Global coordinates of cell center
-                double xp = RankX + MyXOffset + 0.5;
-                double yp = RankY + MyYOffset + 0.5;
-                double zp = GlobalZ + 0.5;
-                // Calculate critical values at which this active cell leads to the activation of a neighboring liquid
-                // cell
-                for (int n = 0; n < 26; n++) {
+                if (GlobalZ < nzActive) {
+                    DOCenter((long int)(3) * LocalCellLocation) = RankX + MyXOffset + 0.5;
+                    DOCenter((long int)(3) * LocalCellLocation + (long int)(1)) = RankY + MyYOffset + 0.5;
+                    DOCenter((long int)(3) * LocalCellLocation + (long int)(2)) = GlobalZ + 0.5;
+                    int MyOrientation = GrainOrientation(((abs(GrainID(GlobalCellLocation)) - 1) % NGrainOrientations));
+                    DiagonalLength(LocalCellLocation) = 0.01;
+                    // Global coordinates of cell center
+                    double xp = RankX + MyXOffset + 0.5;
+                    double yp = RankY + MyYOffset + 0.5;
+                    double zp = GlobalZ + 0.5;
+                    // Calculate critical values at which this active cell leads to the activation of a neighboring
+                    // liquid cell
+                    for (int n = 0; n < 26; n++) {
 
-                    int MyNeighborX = RankX + NeighborX(n);
-                    int MyNeighborY = RankY + NeighborY(n);
-                    int MyNeighborZ = RankZ + NeighborZ(n);
-                    long int NeighborPosition =
-                        MyNeighborZ * MyXSlices * MyYSlices + MyNeighborX * MyYSlices + MyNeighborY;
+                        int MyNeighborX = RankX + NeighborX(n);
+                        int MyNeighborY = RankY + NeighborY(n);
+                        int MyNeighborZ = RankZ + NeighborZ(n);
+                        long int NeighborPosition =
+                            MyNeighborZ * MyXSlices * MyYSlices + MyNeighborX * MyYSlices + MyNeighborY;
 
-                    if (NeighborPosition == CellLocation) {
-                        // Do not calculate critical diagonal length req'd for the newly captured cell to capture the
-                        // original
-                        CritDiagonalLength((long int)(26) * NeighborPosition + (long int)(n)) = 10000000.0;
-                    }
+                        if (NeighborPosition == LocalCellLocation) {
+                            // Do not calculate critical diagonal length req'd for the newly captured cell to capture
+                            // the original
+                            CritDiagonalLength((long int)(26) * NeighborPosition + (long int)(n)) = 10000000.0;
+                        }
 
-                    // (x0,y0,z0) is a vector pointing from this decentered octahedron center to the global coordinates
-                    // of the center of a neighbor cell
-                    double x0 = xp + NeighborX(n) - (RankX + MyXOffset + 0.5);
-                    double y0 = yp + NeighborY(n) - (RankY + MyYOffset + 0.5);
-                    double z0 = zp + NeighborZ(n) - (GlobalZ + 0.5);
-                    // mag0 is the magnitude of (x0,y0,z0)
-                    double mag0 = pow(pow(x0, 2.0) + pow(y0, 2.0) + pow(z0, 2.0), 0.5);
+                        // (x0,y0,z0) is a vector pointing from this decentered octahedron center to the global
+                        // coordinates of the center of a neighbor cell
+                        double x0 = xp + NeighborX(n) - (RankX + MyXOffset + 0.5);
+                        double y0 = yp + NeighborY(n) - (RankY + MyYOffset + 0.5);
+                        double z0 = zp + NeighborZ(n) - (GlobalZ + 0.5);
+                        // mag0 is the magnitude of (x0,y0,z0)
+                        double mag0 = pow(pow(x0, 2.0) + pow(y0, 2.0) + pow(z0, 2.0), 0.5);
 
-                    // Calculate unit vectors for the octahedron that intersect the new cell center
-                    double Diag1X, Diag1Y, Diag1Z, Diag2X, Diag2Y, Diag2Z, Diag3X, Diag3Y, Diag3Z;
-                    double Angle1 =
-                        (GrainUnitVector(9 * MyOrientation) * x0 + GrainUnitVector(9 * MyOrientation + 1) * y0 +
-                         GrainUnitVector(9 * MyOrientation + 2) * z0) /
-                        mag0;
-                    if (Angle1 < 0) {
-                        Diag1X = GrainUnitVector(9 * MyOrientation);
-                        Diag1Y = GrainUnitVector(9 * MyOrientation + 1);
-                        Diag1Z = GrainUnitVector(9 * MyOrientation + 2);
-                    }
-                    else {
-                        Diag1X = -GrainUnitVector(9 * MyOrientation);
-                        Diag1Y = -GrainUnitVector(9 * MyOrientation + 1);
-                        Diag1Z = -GrainUnitVector(9 * MyOrientation + 2);
-                    }
+                        // Calculate unit vectors for the octahedron that intersect the new cell center
+                        double Diag1X, Diag1Y, Diag1Z, Diag2X, Diag2Y, Diag2Z, Diag3X, Diag3Y, Diag3Z;
+                        double Angle1 =
+                            (GrainUnitVector(9 * MyOrientation) * x0 + GrainUnitVector(9 * MyOrientation + 1) * y0 +
+                             GrainUnitVector(9 * MyOrientation + 2) * z0) /
+                            mag0;
+                        if (Angle1 < 0) {
+                            Diag1X = GrainUnitVector(9 * MyOrientation);
+                            Diag1Y = GrainUnitVector(9 * MyOrientation + 1);
+                            Diag1Z = GrainUnitVector(9 * MyOrientation + 2);
+                        }
+                        else {
+                            Diag1X = -GrainUnitVector(9 * MyOrientation);
+                            Diag1Y = -GrainUnitVector(9 * MyOrientation + 1);
+                            Diag1Z = -GrainUnitVector(9 * MyOrientation + 2);
+                        }
 
-                    double Angle2 =
-                        (GrainUnitVector(9 * MyOrientation + 3) * x0 + GrainUnitVector(9 * MyOrientation + 4) * y0 +
-                         GrainUnitVector(9 * MyOrientation + 5) * z0) /
-                        mag0;
-                    if (Angle2 < 0) {
-                        Diag2X = GrainUnitVector(9 * MyOrientation + 3);
-                        Diag2Y = GrainUnitVector(9 * MyOrientation + 4);
-                        Diag2Z = GrainUnitVector(9 * MyOrientation + 5);
-                    }
-                    else {
-                        Diag2X = -GrainUnitVector(9 * MyOrientation + 3);
-                        Diag2Y = -GrainUnitVector(9 * MyOrientation + 4);
-                        Diag2Z = -GrainUnitVector(9 * MyOrientation + 5);
-                    }
+                        double Angle2 =
+                            (GrainUnitVector(9 * MyOrientation + 3) * x0 + GrainUnitVector(9 * MyOrientation + 4) * y0 +
+                             GrainUnitVector(9 * MyOrientation + 5) * z0) /
+                            mag0;
+                        if (Angle2 < 0) {
+                            Diag2X = GrainUnitVector(9 * MyOrientation + 3);
+                            Diag2Y = GrainUnitVector(9 * MyOrientation + 4);
+                            Diag2Z = GrainUnitVector(9 * MyOrientation + 5);
+                        }
+                        else {
+                            Diag2X = -GrainUnitVector(9 * MyOrientation + 3);
+                            Diag2Y = -GrainUnitVector(9 * MyOrientation + 4);
+                            Diag2Z = -GrainUnitVector(9 * MyOrientation + 5);
+                        }
 
-                    double Angle3 =
-                        (GrainUnitVector(9 * MyOrientation + 6) * x0 + GrainUnitVector(9 * MyOrientation + 7) * y0 +
-                         GrainUnitVector(9 * MyOrientation + 8) * z0) /
-                        mag0;
-                    if (Angle3 < 0) {
-                        Diag3X = GrainUnitVector(9 * MyOrientation + 6);
-                        Diag3Y = GrainUnitVector(9 * MyOrientation + 7);
-                        Diag3Z = GrainUnitVector(9 * MyOrientation + 8);
-                    }
-                    else {
-                        Diag3X = -GrainUnitVector(9 * MyOrientation + 6);
-                        Diag3Y = -GrainUnitVector(9 * MyOrientation + 7);
-                        Diag3Z = -GrainUnitVector(9 * MyOrientation + 8);
-                    }
+                        double Angle3 =
+                            (GrainUnitVector(9 * MyOrientation + 6) * x0 + GrainUnitVector(9 * MyOrientation + 7) * y0 +
+                             GrainUnitVector(9 * MyOrientation + 8) * z0) /
+                            mag0;
+                        if (Angle3 < 0) {
+                            Diag3X = GrainUnitVector(9 * MyOrientation + 6);
+                            Diag3Y = GrainUnitVector(9 * MyOrientation + 7);
+                            Diag3Z = GrainUnitVector(9 * MyOrientation + 8);
+                        }
+                        else {
+                            Diag3X = -GrainUnitVector(9 * MyOrientation + 6);
+                            Diag3Y = -GrainUnitVector(9 * MyOrientation + 7);
+                            Diag3Z = -GrainUnitVector(9 * MyOrientation + 8);
+                        }
 
-                    double U1[3], U2[3], UU[3], Norm[3];
-                    U1[0] = Diag2X - Diag1X;
-                    U1[1] = Diag2Y - Diag1Y;
-                    U1[2] = Diag2Z - Diag1Z;
-                    U2[0] = Diag3X - Diag1X;
-                    U2[1] = Diag3Y - Diag1Y;
-                    U2[2] = Diag3Z - Diag1Z;
-                    UU[0] = U1[1] * U2[2] - U1[2] * U2[1];
-                    UU[1] = U1[2] * U2[0] - U1[0] * U2[2];
-                    UU[2] = U1[0] * U2[1] - U1[1] * U2[0];
-                    double NDem = sqrt(UU[0] * UU[0] + UU[1] * UU[1] + UU[2] * UU[2]);
-                    Norm[0] = UU[0] / NDem;
-                    Norm[1] = UU[1] / NDem;
-                    Norm[2] = UU[2] / NDem;
-                    // normal to capturing plane
-                    double normx = Norm[0];
-                    double normy = Norm[1];
-                    double normz = Norm[2];
-                    double ParaT =
-                        (normx * x0 + normy * y0 + normz * z0) / (normx * Diag1X + normy * Diag1Y + normz * Diag1Z);
-                    float CDLVal =
-                        pow(pow(ParaT * Diag1X, 2.0) + pow(ParaT * Diag1Y, 2.0) + pow(ParaT * Diag1Z, 2.0), 0.5);
-                    CritDiagonalLength((long int)(26) * CellLocation + (long int)(n)) = CDLVal;
+                        double U1[3], U2[3], UU[3], Norm[3];
+                        U1[0] = Diag2X - Diag1X;
+                        U1[1] = Diag2Y - Diag1Y;
+                        U1[2] = Diag2Z - Diag1Z;
+                        U2[0] = Diag3X - Diag1X;
+                        U2[1] = Diag3Y - Diag1Y;
+                        U2[2] = Diag3Z - Diag1Z;
+                        UU[0] = U1[1] * U2[2] - U1[2] * U2[1];
+                        UU[1] = U1[2] * U2[0] - U1[0] * U2[2];
+                        UU[2] = U1[0] * U2[1] - U1[1] * U2[0];
+                        double NDem = sqrt(UU[0] * UU[0] + UU[1] * UU[1] + UU[2] * UU[2]);
+                        Norm[0] = UU[0] / NDem;
+                        Norm[1] = UU[1] / NDem;
+                        Norm[2] = UU[2] / NDem;
+                        // normal to capturing plane
+                        double normx = Norm[0];
+                        double normy = Norm[1];
+                        double normz = Norm[2];
+                        double ParaT =
+                            (normx * x0 + normy * y0 + normz * z0) / (normx * Diag1X + normy * Diag1Y + normz * Diag1Z);
+                        float CDLVal =
+                            pow(pow(ParaT * Diag1X, 2.0) + pow(ParaT * Diag1Y, 2.0) + pow(ParaT * Diag1Z, 2.0), 0.5);
+                        CritDiagonalLength((long int)(26) * LocalCellLocation + (long int)(n)) = CDLVal;
+                    }
                 }
             }
         });

--- a/src/CAghostnodes.hpp
+++ b/src/CAghostnodes.hpp
@@ -13,7 +13,7 @@
 void GhostNodesInit(int, int, int DecompositionStrategy, int NeighborRank_North, int NeighborRank_South,
                     int NeighborRank_East, int NeighborRank_West, int NeighborRank_NorthEast,
                     int NeighborRank_NorthWest, int NeighborRank_SouthEast, int NeighborRank_SouthWest, int MyXSlices,
-                    int MyYSlices, int MyXOffset, int MyYOffset, int ZBound_Low, int nzActive,
+                    int MyYSlices, int MyXOffset, int MyYOffset, int ZBound_Low, int nzActive, int nz,
                     int LocalActiveDomainSize, int NGrainOrientations, ViewI NeighborX, ViewI NeighborY,
                     ViewI NeighborZ, ViewF GrainUnitVector, ViewI GrainOrientation, ViewI GrainID, ViewI CellType,
                     ViewF DOCenter, ViewF DiagonalLength, ViewF CritDiagonalLength);

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -17,8 +17,8 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
                        double &AConst, double &BConst, double &CConst, double &DConst, double &FreezingRange,
                        double &deltax, double &NMax, double &dTN, double &dTsigma, std::string &OutputFile,
                        std::string &GrainOrientationFile, std::string &temppath, std::string &tempfile,
-                       int &TempFilesInSeries, std::vector<std::string> &temp_paths, bool &ExtraWalls,
-                       double &HT_deltax, bool &RemeltingYN, double &deltat, int &NumberOfLayers, int &LayerHeight,
+                       int &TempFilesInSeries, std::vector<std::string> &temp_paths, double &HT_deltax,
+                       bool &RemeltingYN, double &deltat, int &NumberOfLayers, int &LayerHeight,
                        std::string &SubstrateFileName, float &SubstrateGrainSpacing, bool &UseSubstrateFile, double &G,
                        double &R, int &nx, int &ny, int &nz, double &FractSurfaceSitesActive, std::string &PathToOutput,
                        int &PrintDebug, bool &PrintMisorientation, bool &PrintFullOutput, int &NSpotsX, int &NSpotsY,
@@ -34,46 +34,44 @@ void DomainDecomposition(int DecompositionStrategy, int id, int np, int &MyXSlic
                          int &NeighborRank_West, int &NeighborRank_NorthEast, int &NeighborRank_NorthWest,
                          int &NeighborRank_SouthEast, int &NeighborRank_SouthWest, int &nx, int &ny, int &nz,
                          int &ProcessorsInXDirection, int &ProcessorsInYDirection, long int &LocalDomainSize);
-void ReadTemperatureData(double deltax, double HT_deltax, int MyXSlices, int MyYSlices, int MyXOffset, int MyYOffset,
-                         int nx, int ny, float XMin, float YMin, std::vector<std::string> &temp_paths,
+void ReadTemperatureData(int id, double deltax, double HT_deltax, int MyXSlices, int MyYSlices, int MyXOffset,
+                         int MyYOffset, float XMin, float YMin, std::vector<std::string> &temp_paths,
                          int NumberOfLayers, int TempFilesInSeries, unsigned int &NumberOfTemperatureDataPoints,
                          std::vector<double> &RawData, int *FirstValue, int *LastValue);
-void TempInit_DirSolidification(double G, double R, int id, int &MyXSlices, int &MyYSlices, int &MyXOffset,
-                                int &MyYOffset, double deltax, double deltat, int nx, int ny, int nz,
-                                ViewI_H CritTimeStep, ViewF_H UndercoolingChange, ViewF_H UndercoolingCurrent,
-                                bool *Melted, int &nzActive, int &ZBound_Low, int &ZBound_High, ViewI_H LayerID);
+void TempInit_DirSolidification(double G, double R, int id, int &MyXSlices, int &MyYSlices, double deltax,
+                                double deltat, int nz, ViewI_H CritTimeStep, ViewF_H UndercoolingChange,
+                                ViewF_H UndercoolingCurrent, bool *Melted, int &nzActive, int &ZBound_Low,
+                                int &ZBound_High, ViewI_H LayerID);
 void TempInit_SpotMelt(double G, double R, std::string SimulationType, int id, int &MyXSlices, int &MyYSlices,
                        int &MyXOffset, int &MyYOffset, double deltax, double deltat, int nz, ViewI_H CritTimeStep,
                        ViewF_H UndercoolingChange, ViewF_H UndercoolingCurrent, bool *Melted, int LayerHeight,
                        int NumberOfLayers, int &nzActive, int &ZBound_Low, int &ZBound_High, double FreezingRange,
                        ViewI_H LayerID, int NSpotsX, int NSpotsY, int SpotRadius, int SpotOffset);
 void TempInit_Reduced(int id, int &MyXSlices, int &MyYSlices, int &MyXOffset, int &MyYOffset, double &deltax,
-                      double HT_deltax, double deltat, int &nx, int &ny, int &nz, ViewI_H CritTimeStep,
-                      ViewF_H UndercoolingChange, ViewF_H UndercoolingCurrent, float XMin, float YMin, float ZMin,
-                      bool *Melted, float *ZMinLayer, float *ZMaxLayer, int LayerHeight, int NumberOfLayers,
-                      int &nzActive, int &ZBound_Low, int &ZBound_High, int *FinishTimeStep, double FreezingRange,
-                      ViewI_H LayerID, int *FirstValue, int *LastValue, std::vector<double> RawData);
+                      double HT_deltax, double deltat, int &nz, ViewI_H CritTimeStep, ViewF_H UndercoolingChange,
+                      ViewF_H UndercoolingCurrent, float XMin, float YMin, float ZMin, bool *Melted, float *ZMinLayer,
+                      float *ZMaxLayer, int LayerHeight, int NumberOfLayers, int &nzActive, int &ZBound_Low,
+                      int &ZBound_High, int *FinishTimeStep, double FreezingRange, ViewI_H LayerID, int *FirstValue,
+                      int *LastValue, std::vector<double> RawData);
 void OrientationInit(int id, int NGrainOrientations, ViewI_H GrainOrientation, ViewF_H GrainUnitVector,
                      std::string GrainOrientationFile);
 void SubstrateInit_ConstrainedGrowth(double FractSurfaceSitesActive, int MyXSlices, int MyYSlices, int nx, int ny,
                                      int nz, int MyXOffset, int MyYOffset, int pid, int np, ViewI_H CellType,
                                      ViewI_H GrainID);
 void SubstrateInit_FromFile(std::string SubstrateFileName, int nz, int MyXSlices, int MyYSlices, int MyXOffset,
-                            int MyYOffset, int pid, ViewI_H CritTimeStep, ViewI_H GrainID);
+                            int MyYOffset, int pid, ViewI_H GrainID);
 void SubstrateInit_FromGrainSpacing(float SubstrateGrainSpacing, int nx, int ny, int nz, int nzActive, int MyXSlices,
                                     int MyYSlices, int MyXOffset, int MyYOffset, int LocalActiveDomainSize, int pid,
-                                    int np, double deltax, ViewI_H GrainID, ViewI_H CritTimeStep);
-void ActiveCellWallInit(int id, int MyXSlices, int MyYSlices, int nx, int ny, int nz, int MyXOffset, int MyYOffset,
-                        ViewI_H CellType_H, ViewI_H GrainID_H, ViewI_H CritTimeStep_H, ViewI2D_H ItList_H,
-                        ViewI_H NeighborX_H, ViewI_H NeighborY_H, ViewI_H NeighborZ_H, ViewF_H UndercoolingChange_H,
-                        bool ExtraWalls);
-void GrainInit(int layernumber, int NGrainOrientations, int DecompositionStrategy, int nz, int LocalActiveDomainSize,
-               int MyXSlices, int MyYSlices, int MyXOffset, int MyYOffset, int id, int np, int NeighborRank_North,
-               int NeighborRank_South, int NeighborRank_East, int NeighborRank_West, int NeighborRank_NorthEast,
-               int NeighborRank_NorthWest, int NeighborRank_SouthEast, int NeighborRank_SouthWest, ViewI2D_H ItList,
-               ViewI_H NeighborX, ViewI_H NeighborY, ViewI_H NeighborZ, ViewI_H GrainOrientation,
-               ViewF_H GrainUnitVector, ViewF_H DiagonalLength, ViewI_H CellType, ViewI_H GrainID,
-               ViewF_H CritDiagonalLength, ViewF_H DOCenter, ViewI_H CritTimeStep, double deltax, double NMax,
+                                    int np, double deltax, ViewI_H GrainID);
+void ActiveCellInit(int id, int MyXSlices, int MyYSlices, int nz, ViewI_H CellType, ViewI_H CritTimeStep,
+                    ViewI_H NeighborX, ViewI_H NeighborY, ViewI_H NeighborZ);
+void GrainInit(int layernumber, int NGrainOrientations, int DecompositionStrategy, int nx, int ny, int nz,
+               int LocalActiveDomainSize, int MyXSlices, int MyYSlices, int MyXOffset, int MyYOffset, int id, int np,
+               int NeighborRank_North, int NeighborRank_South, int NeighborRank_East, int NeighborRank_West,
+               int NeighborRank_NorthEast, int NeighborRank_NorthWest, int NeighborRank_SouthEast,
+               int NeighborRank_SouthWest, ViewI2D_H ItList, ViewI_H NeighborX, ViewI_H NeighborY, ViewI_H NeighborZ,
+               ViewI_H GrainOrientation, ViewF_H GrainUnitVector, ViewF_H DiagonalLength, ViewI_H CellType,
+               ViewI_H GrainID, ViewF_H CritDiagonalLength, ViewF_H DOCenter, double deltax, double NMax,
                int &NextLayer_FirstNucleatedGrainID, int &PossibleNuclei_ThisRank, int ZBound_High, int ZBound_Low);
 void NucleiInit(int DecompositionStrategy, int MyXSlices, int MyYSlices, int nz, int id, double dTN, double dTsigma,
                 int NeighborRank_North, int NeighborRank_South, int NeighborRank_East, int NeighborRank_West,

--- a/src/CAprint.cpp
+++ b/src/CAprint.cpp
@@ -20,9 +20,9 @@ void CollectIntField(ViewI3D_H IntVar_WholeDomain, ViewI_H IntVar, int nz, int M
                      ViewI_H RBufSize) {
 
     for (int k = 0; k < nz; k++) {
-        for (int i = 1; i < MyXSlices - 1; i++) {
-            for (int j = 1; j < MyYSlices - 1; j++) {
-                IntVar_WholeDomain(k, i - 1, j - 1) = IntVar(k * MyXSlices * MyYSlices + i * MyYSlices + j);
+        for (int i = 0; i < MyXSlices; i++) {
+            for (int j = 0; j < MyYSlices; j++) {
+                IntVar_WholeDomain(k, i, j) = IntVar(k * MyXSlices * MyYSlices + i * MyYSlices + j);
             }
         }
     }
@@ -52,9 +52,9 @@ void CollectFloatField(ViewF3D_H FloatVar_WholeDomain, ViewF_H FloatVar, int nz,
 
     // Set float variable to 0 for whole domain and place values for rank 0
     for (int k = 0; k < nz; k++) {
-        for (int i = 1; i < MyXSlices - 1; i++) {
-            for (int j = 1; j < MyYSlices - 1; j++) {
-                FloatVar_WholeDomain(k, i - 1, j - 1) = FloatVar(k * MyXSlices * MyYSlices + i * MyYSlices + j);
+        for (int i = 0; i < MyXSlices; i++) {
+            for (int j = 0; j < MyYSlices; j++) {
+                FloatVar_WholeDomain(k, i, j) = FloatVar(k * MyXSlices * MyYSlices + i * MyYSlices + j);
             }
         }
     }
@@ -84,10 +84,10 @@ void CollectBoolField(ViewI3D_H IntVar_WholeDomain, bool *BoolVar, int nz, int M
 
     // Resize bool variable for whole domain and place values for rank 0
     for (int k = 0; k < nz; k++) {
-        for (int i = 1; i < MyXSlices - 1; i++) {
-            for (int j = 1; j < MyYSlices - 1; j++) {
+        for (int i = 0; i < MyXSlices; i++) {
+            for (int j = 0; j < MyYSlices; j++) {
                 if (BoolVar[k * MyXSlices * MyYSlices + i * MyYSlices + j])
-                    IntVar_WholeDomain(k, i - 1, j - 1) = 1;
+                    IntVar_WholeDomain(k, i, j) = 1;
             }
         }
     }
@@ -112,14 +112,15 @@ void CollectBoolField(ViewI3D_H IntVar_WholeDomain, bool *BoolVar, int nz, int M
 
 //*****************************************************************************/
 // On rank > 0, send data for an integer view to rank 0
-void SendIntField(ViewI_H VarToSend, int nz, int MyXSlices, int MyYSlices, int SendBufSize) {
+void SendIntField(ViewI_H VarToSend, int nz, int MyXSlices, int MyYSlices, int SendBufSize, int SendBufStartX,
+                  int SendBufEndX, int SendBufStartY, int SendBufEndY) {
 
     // Send non-ghost node data to rank 0
     int DataCounter = 0;
     ViewI_H SendBuf(Kokkos::ViewAllocateWithoutInitializing("SendBuf"), SendBufSize);
     for (int k = 0; k < nz; k++) {
-        for (int i = 1; i < MyXSlices - 1; i++) {
-            for (int j = 1; j < MyYSlices - 1; j++) {
+        for (int i = SendBufStartX; i < SendBufEndX; i++) {
+            for (int j = SendBufStartY; j < SendBufEndY; j++) {
                 SendBuf(DataCounter) = VarToSend(k * MyXSlices * MyYSlices + i * MyYSlices + j);
                 DataCounter++;
             }
@@ -129,14 +130,15 @@ void SendIntField(ViewI_H VarToSend, int nz, int MyXSlices, int MyYSlices, int S
 }
 
 // On rank > 0, send data for an float view to rank 0
-void SendFloatField(ViewF_H VarToSend, int nz, int MyXSlices, int MyYSlices, int SendBufSize) {
+void SendFloatField(ViewF_H VarToSend, int nz, int MyXSlices, int MyYSlices, int SendBufSize, int SendBufStartX,
+                    int SendBufEndX, int SendBufStartY, int SendBufEndY) {
 
     // Send non-ghost node data to rank 0
     int DataCounter = 0;
     ViewF_H SendBuf(Kokkos::ViewAllocateWithoutInitializing("SendBuf"), SendBufSize);
     for (int k = 0; k < nz; k++) {
-        for (int i = 1; i < MyXSlices - 1; i++) {
-            for (int j = 1; j < MyYSlices - 1; j++) {
+        for (int i = SendBufStartX; i < SendBufEndX; i++) {
+            for (int j = SendBufStartY; j < SendBufEndY; j++) {
                 SendBuf(DataCounter) = VarToSend(k * MyXSlices * MyYSlices + i * MyYSlices + j);
                 DataCounter++;
             }
@@ -146,14 +148,15 @@ void SendFloatField(ViewF_H VarToSend, int nz, int MyXSlices, int MyYSlices, int
 }
 
 // On rank > 0, send data for a bool array (converted into integers for MPI) to rank 0
-void SendBoolField(bool *VarToSend, int nz, int MyXSlices, int MyYSlices, int SendBufSize) {
+void SendBoolField(bool *VarToSend, int nz, int MyXSlices, int MyYSlices, int SendBufSize, int SendBufStartX,
+                   int SendBufEndX, int SendBufStartY, int SendBufEndY) {
 
     // Send non-ghost node data to rank 0
     int DataCounter = 0;
     ViewI_H SendBuf(Kokkos::ViewAllocateWithoutInitializing("SendBuf"), SendBufSize);
     for (int k = 0; k < nz; k++) {
-        for (int i = 1; i < MyXSlices - 1; i++) {
-            for (int j = 1; j < MyYSlices - 1; j++) {
+        for (int i = SendBufStartX; i < SendBufEndX; i++) {
+            for (int j = SendBufStartY; j < SendBufEndY; j++) {
                 if (VarToSend[k * MyXSlices * MyYSlices + i * MyYSlices + j])
                     SendBuf(DataCounter) = 1;
                 else
@@ -168,13 +171,13 @@ void SendBoolField(bool *VarToSend, int nz, int MyXSlices, int MyYSlices, int Se
 //*****************************************************************************/
 // Prints values of selected data structures to Paraview files
 void PrintExaCAData(int id, int layernumber, int np, int nx, int ny, int nz, int MyXSlices, int MyYSlices,
-                    int ProcessorsInXDirection, int ProcessorsInYDirection, ViewI_H GrainID, ViewI_H GrainOrientation,
-                    ViewI_H CritTimeStep, ViewF_H GrainUnitVector, ViewI_H LayerID, ViewI_H CellType,
-                    ViewF_H UndercoolingChange, ViewF_H UndercoolingCurrent, std::string BaseFileName,
-                    int DecompositionStrategy, int NGrainOrientations, bool *Melted, std::string PathToOutput,
-                    int PrintDebug, bool PrintMisorientation, bool PrintFullOutput, bool PrintTimeSeries,
-                    int IntermediateFileCounter, int ZBound_Low, int nzActive, double deltax, float XMin, float YMin,
-                    float ZMin) {
+                    int MyXOffset, int MyYOffset, int ProcessorsInXDirection, int ProcessorsInYDirection,
+                    ViewI_H GrainID, ViewI_H GrainOrientation, ViewI_H CritTimeStep, ViewF_H GrainUnitVector,
+                    ViewI_H LayerID, ViewI_H CellType, ViewF_H UndercoolingChange, ViewF_H UndercoolingCurrent,
+                    std::string BaseFileName, int DecompositionStrategy, int NGrainOrientations, bool *Melted,
+                    std::string PathToOutput, int PrintDebug, bool PrintMisorientation, bool PrintFullOutput,
+                    bool PrintTimeSeries, int IntermediateFileCounter, int ZBound_Low, int nzActive, double deltax,
+                    float XMin, float YMin, float ZMin) {
 
     // Collect all data on rank 0, for all data structures of interest
     if (id == 0) {
@@ -189,17 +192,8 @@ void PrintExaCAData(int id, int layernumber, int np, int nx, int ny, int nz, int
             RecvXOffset(p) = XOffsetCalc(p, nx, ProcessorsInXDirection, ProcessorsInYDirection, DecompositionStrategy);
             RecvXSlices(p) =
                 XMPSlicesCalc(p, nx, ProcessorsInXDirection, ProcessorsInYDirection, DecompositionStrategy);
-
             RecvYOffset(p) = YOffsetCalc(p, ny, ProcessorsInYDirection, np, DecompositionStrategy);
             RecvYSlices(p) = YMPSlicesCalc(p, ny, ProcessorsInYDirection, np, DecompositionStrategy);
-
-            // No ghost nodes in send and recieved data
-            RecvYSlices(p) = RecvYSlices(p) - 2;
-            RecvXSlices(p) = RecvXSlices(p) - 2;
-
-            // Readjust X and Y offsets of incoming data based on the lack of ghost nodes
-            RecvYOffset(p)++;
-            RecvXOffset(p)++;
 
             RBufSize(p) = RecvXSlices(p) * RecvYSlices(p) * nz;
         }
@@ -270,24 +264,51 @@ void PrintExaCAData(int id, int layernumber, int np, int nx, int ny, int nz, int
                                         GrainUnitVector, NGrainOrientations, deltax, XMin, YMin, ZMin);
     }
     else {
-        int SendBufSize = (MyXSlices - 2) * (MyYSlices - 2) * nz;
+
+        // No ghost nodes in sent data:
+        int SendBufStartX, SendBufEndX, SendBufStartY, SendBufEndY;
+        if (MyYOffset == 0)
+            SendBufStartY = 0;
+        else
+            SendBufStartY = 1;
+        if (MyYSlices + MyYOffset == ny)
+            SendBufEndY = MyYSlices;
+        else
+            SendBufEndY = MyYSlices - 1;
+        if (MyXOffset == 0)
+            SendBufStartX = 0;
+        else
+            SendBufStartX = 1;
+        if (MyXSlices + MyXOffset == nx)
+            SendBufEndX = MyXSlices;
+        else
+            SendBufEndX = MyXSlices - 1;
+
+        int SendBufSize = (SendBufEndX - SendBufStartX) * (SendBufEndY - SendBufStartY) * nz;
 
         // Collect Melted/Grain ID data on rank 0
         if ((PrintTimeSeries) || (PrintMisorientation) || (PrintDebug == 2) || (PrintFullOutput))
-            SendIntField(GrainID, nz, MyXSlices, MyYSlices, SendBufSize);
+            SendIntField(GrainID, nz, MyXSlices, MyYSlices, SendBufSize, SendBufStartX, SendBufEndX, SendBufStartY,
+                         SendBufEndY);
         if ((PrintMisorientation) || (PrintFullOutput) || (PrintDebug == 2))
-            SendBoolField(Melted, nz, MyXSlices, MyYSlices, SendBufSize);
+            SendBoolField(Melted, nz, MyXSlices, MyYSlices, SendBufSize, SendBufStartX, SendBufEndX, SendBufStartY,
+                          SendBufEndY);
         if ((PrintFullOutput) || (PrintDebug > 0))
-            SendIntField(LayerID, nz, MyXSlices, MyYSlices, SendBufSize);
+            SendIntField(LayerID, nz, MyXSlices, MyYSlices, SendBufSize, SendBufStartX, SendBufEndX, SendBufStartY,
+                         SendBufEndY);
         if ((PrintDebug > 0) || (PrintTimeSeries)) {
-            SendIntField(CellType, nz, MyXSlices, MyYSlices, SendBufSize);
+            SendIntField(CellType, nz, MyXSlices, MyYSlices, SendBufSize, SendBufStartX, SendBufEndX, SendBufStartY,
+                         SendBufEndY);
         }
         if (PrintDebug > 0) {
-            SendIntField(CritTimeStep, nz, MyXSlices, MyYSlices, SendBufSize);
+            SendIntField(CritTimeStep, nz, MyXSlices, MyYSlices, SendBufSize, SendBufStartX, SendBufEndX, SendBufStartY,
+                         SendBufEndY);
         }
         if (PrintDebug == 2) {
-            SendFloatField(UndercoolingChange, nz, MyXSlices, MyYSlices, SendBufSize);
-            SendFloatField(UndercoolingCurrent, nz, MyXSlices, MyYSlices, SendBufSize);
+            SendFloatField(UndercoolingChange, nz, MyXSlices, MyYSlices, SendBufSize, SendBufStartX, SendBufEndX,
+                           SendBufStartY, SendBufEndY);
+            SendFloatField(UndercoolingCurrent, nz, MyXSlices, MyYSlices, SendBufSize, SendBufStartX, SendBufEndX,
+                           SendBufStartY, SendBufEndY);
         }
     }
 }
@@ -317,9 +338,7 @@ void PrintCAFields(int nx, int ny, int nz, ViewI3D_H GrainID_WholeDomain, ViewI3
     Grainplot << "ASCII" << std::endl;
     Grainplot << "DATASET STRUCTURED_POINTS" << std::endl;
     Grainplot << "DIMENSIONS " << nx << " " << ny << " " << nz << std::endl;
-    // The CA domain is technically 2 cells bigger than the temperature field in all dimensions (except the top surface)
-    // The start of the data in X, Y, Z is actually the XMin, YMin, ZMin from the temperature file minus 1 cell size
-    Grainplot << "ORIGIN " << XMin - deltax << " " << YMin - deltax << " " << ZMin - deltax << std::endl;
+    Grainplot << "ORIGIN " << XMin << " " << YMin << " " << ZMin << std::endl;
     Grainplot << "SPACING " << deltax << " " << deltax << " " << deltax << std::endl;
     Grainplot << std::fixed << "POINT_DATA " << nx * ny * nz << std::endl;
     // Print Layer ID data
@@ -424,12 +443,10 @@ void PrintGrainMisorientations(std::string BaseFileName, std::string PathToOutpu
     GrainplotM << "vtk output" << std::endl;
     GrainplotM << "ASCII" << std::endl;
     GrainplotM << "DATASET STRUCTURED_POINTS" << std::endl;
-    GrainplotM << "DIMENSIONS " << nx - 2 << " " << ny - 2 << " " << nz - 1 << std::endl;
-    // The CA domain is technically 2 cells bigger than the temperature field in all dimensions (except the top surface)
-    // The start of the data in X, Y, Z is actually the XMin, YMin, ZMin from the temperature file minus 1 cell size
-    GrainplotM << "ORIGIN " << XMin - deltax << " " << YMin - deltax << " " << ZMin - deltax << std::endl;
+    GrainplotM << "DIMENSIONS " << nx << " " << ny << " " << nz << std::endl;
+    GrainplotM << "ORIGIN " << XMin << " " << YMin << " " << ZMin << std::endl;
     GrainplotM << "SPACING " << deltax << " " << deltax << " " << deltax << std::endl;
-    GrainplotM << std::fixed << "POINT_DATA " << (nx - 2) * (ny - 2) * (nz - 1) << std::endl;
+    GrainplotM << std::fixed << "POINT_DATA " << nx * ny * nz << std::endl;
     GrainplotM << "SCALARS Angle_z int 1" << std::endl;
     GrainplotM << "LOOKUP_TABLE default" << std::endl;
 
@@ -450,9 +467,9 @@ void PrintGrainMisorientations(std::string BaseFileName, std::string PathToOutpu
         }
         GrainMisorientation_Round(n) = round(AngleZmin);
     }
-    for (int k = 1; k < nz; k++) {
-        for (int j = 1; j < ny - 1; j++) {
-            for (int i = 1; i < nx - 1; i++) {
+    for (int k = 0; k < nz; k++) {
+        for (int j = 0; j < ny; j++) {
+            for (int i = 0; i < nx; i++) {
                 if (Melted_WholeDomain(k, i, j) == 0)
                     GrainplotM << 200 << " ";
                 else {
@@ -629,17 +646,15 @@ void PrintIntermediateExaCAState(int IntermediateFileCounter, int layernumber, s
     GrainplotM << "vtk output" << std::endl;
     GrainplotM << "ASCII" << std::endl;
     GrainplotM << "DATASET STRUCTURED_POINTS" << std::endl;
-    GrainplotM << "DIMENSIONS " << nx - 2 << " " << ny - 2 << " " << ZPrintSize << std::endl;
-    // The CA domain is technically 2 cells bigger than the temperature field in all dimensions (except the top surface)
-    // The start of the data in X, Y, Z is actually the XMin, YMin, ZMin from the temperature file minus 1 cell size
-    GrainplotM << "ORIGIN " << XMin - deltax << " " << YMin - deltax << " " << ZMin - deltax << std::endl;
+    GrainplotM << "DIMENSIONS " << nx << " " << ny << " " << ZPrintSize << std::endl;
+    GrainplotM << "ORIGIN " << XMin << " " << YMin << " " << ZMin << std::endl;
     GrainplotM << "SPACING " << deltax << " " << deltax << " " << deltax << std::endl;
-    GrainplotM << std::fixed << "POINT_DATA " << (nx - 2) * (ny - 2) * ZPrintSize << std::endl;
+    GrainplotM << std::fixed << "POINT_DATA " << nx * ny * ZPrintSize << std::endl;
     GrainplotM << "SCALARS Angle_z float 1" << std::endl;
     GrainplotM << "LOOKUP_TABLE default" << std::endl;
-    for (int k = 1; k <= ZPrintSize; k++) {
-        for (int j = 1; j < ny - 1; j++) {
-            for (int i = 1; i < nx - 1; i++) {
+    for (int k = 0; k <= ZPrintSize; k++) {
+        for (int j = 0; j < ny; j++) {
+            for (int i = 0; i < nx; i++) {
                 if (CellType_WholeDomain(k, i, j) != Liquid) {
                     if (GrainID_WholeDomain(k, i, j) == 0)
                         std::cout << i << " " << j << " " << k << " " << CellType_WholeDomain(k, i, j) << std::endl;

--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -23,17 +23,20 @@ void CollectFloatField(ViewF3D_H FloatVar_WholeDomain, ViewF_H FloatVar, int nx,
 void CollectBoolField(ViewI3D_H IntVar_WholeDomain, bool *BoolVar, int nx, int ny, int nz, int MyXSlices, int MyYSlices,
                       int np, ViewI_H RecvXOffset, ViewI_H RecvYOffset, ViewI_H RecvXSlices, ViewI_H RecvYSlices,
                       ViewI_H RBufSize);
-void SendIntField(ViewI_H VarToSend, int nz, int MyXSlices, int MyYSlices, int SendBufSize);
-void SendFloatField(ViewF_H VarToSend, int nz, int MyXSlices, int MyYSlices, int SendBufSize);
-void SendBoolField(bool *VarToSend, int nz, int MyXSlices, int MyYSlices, int SendBufSize);
+void SendIntField(ViewI_H VarToSend, int nz, int MyXSlices, int MyYSlices, int SendBufSize, int SendBufStartX,
+                  int SendBufEndX, int SendBufStartY, int SendBufEndY);
+void SendFloatField(ViewF_H VarToSend, int nz, int MyXSlices, int MyYSlices, int SendBufSize, int SendBufStartX,
+                    int SendBufEndX, int SendBufStartY, int SendBufEndY);
+void SendBoolField(bool *VarToSend, int nz, int MyXSlices, int MyYSlices, int SendBufSize, int SendBufStartX,
+                   int SendBufEndX, int SendBufStartY, int SendBufEndY);
 void PrintExaCAData(int id, int layernumber, int np, int nx, int ny, int nz, int MyXSlices, int MyYSlices,
-                    int ProcessorsInXDirection, int ProcessorsInYDirection, ViewI_H GrainID, ViewI_H GrainOrientation,
-                    ViewI_H CritTimeStep, ViewF_H GrainUnitVector, ViewI_H LayerID, ViewI_H CellType,
-                    ViewF_H UndercoolingChange, ViewF_H UndercoolingCurrent, std::string BaseFileName,
-                    int DecompositionStrategy, int NGrainOrientations, bool *Melted, std::string PathToOutput,
-                    int PrintDebug, bool PrintMisorientation, bool PrintFullOutput, bool PrintTimeSeries,
-                    int IntermediateFileCounter, int ZBound_Low, int nzActive, double deltax, float XMin, float YMin,
-                    float ZMin);
+                    int MyXOffset, int MyYOffset, int ProcessorsInXDirection, int ProcessorsInYDirection,
+                    ViewI_H GrainID, ViewI_H GrainOrientation, ViewI_H CritTimeStep, ViewF_H GrainUnitVector,
+                    ViewI_H LayerID, ViewI_H CellType, ViewF_H UndercoolingChange, ViewF_H UndercoolingCurrent,
+                    std::string BaseFileName, int DecompositionStrategy, int NGrainOrientations, bool *Melted,
+                    std::string PathToOutput, int PrintDebug, bool PrintMisorientation, bool PrintFullOutput,
+                    bool PrintTimeSeries, int IntermediateFileCounter, int ZBound_Low, int nzActive, double deltax,
+                    float XMin, float YMin, float ZMin);
 void PrintExaCALog(int id, int np, std::string InputFile, std::string SimulationType, int DecompositionStrategy,
                    int MyXSlices, int MyYSlices, int MyXOffset, int MyYOffset, double AConst, double BConst,
                    double CConst, double DConst, double FreezingRange, double deltax, double NMax, double dTN,

--- a/src/CAupdate.cpp
+++ b/src/CAupdate.cpp
@@ -326,7 +326,7 @@ void CellCapture(int np, int cycle, int DecompositionStrategy, int LocalActiveDo
                 int MyNeighborY = RankY + NeighborY(l);
                 int MyNeighborZ = RankZ + NeighborZ(l);
 
-                if (MyNeighborZ < nzActive) {
+                if ((MyNeighborZ < nzActive) && (MyNeighborZ >= 0)) {
                     long int NeighborD3D1ConvPosition =
                         MyNeighborZ * MyXSlices * MyYSlices + MyNeighborX * MyYSlices + MyNeighborY;
                     long int GlobalNeighborD3D1ConvPosition =
@@ -730,9 +730,9 @@ void CellCapture(int np, int cycle, int DecompositionStrategy, int LocalActiveDo
 
 //*****************************************************************************/
 // Prints intermediate code output to stdout, checks to see if solidification is complete
-void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyXSlices, int MyYSlices, int LocalDomainSize,
-                                int LocalActiveDomainSize, int nx, int ny, int nz, int nzActive, double deltax,
-                                float XMin, float YMin, float ZMin, int DecompositionStrategy,
+void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyXSlices, int MyYSlices, int MyXOffset, int MyYOffset,
+                                int LocalDomainSize, int LocalActiveDomainSize, int nx, int ny, int nz, int nzActive,
+                                double deltax, float XMin, float YMin, float ZMin, int DecompositionStrategy,
                                 int ProcessorsInXDirection, int ProcessorsInYDirection, int nn, int &XSwitch,
                                 ViewI CellType, ViewI_H CellType_H, ViewI CritTimeStep, ViewI_H CritTimeStep_H,
                                 ViewI GrainID, ViewI_H GrainID_H, std::string TemperatureDataType, int *FinishTimeStep,
@@ -825,12 +825,13 @@ void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyXSlices, int M
                             // Print current state of ExaCA simulation (up to and including the current layer's data)
                             Kokkos::deep_copy(GrainID_H, GrainID);
                             Kokkos::deep_copy(CellType_H, CellType);
-                            PrintExaCAData(
-                                id, layernumber, np, nx, ny, nz, MyXSlices, MyYSlices, ProcessorsInXDirection,
-                                ProcessorsInYDirection, GrainID_H, GrainOrientation_H, CritTimeStep_H,
-                                GrainUnitVector_H, LayerID_H, CellType_H, UndercoolingChange_H, UndercoolingCurrent_H,
-                                OutputFile, DecompositionStrategy, NGrainOrientations, Melted, PathToOutput, 0, false,
-                                false, true, IntermediateFileCounter, ZBound_Low, nzActive, deltax, XMin, YMin, ZMin);
+                            PrintExaCAData(id, layernumber, np, nx, ny, nz, MyXSlices, MyYSlices, MyXOffset, MyYOffset,
+                                           ProcessorsInXDirection, ProcessorsInYDirection, GrainID_H,
+                                           GrainOrientation_H, CritTimeStep_H, GrainUnitVector_H, LayerID_H, CellType_H,
+                                           UndercoolingChange_H, UndercoolingCurrent_H, OutputFile,
+                                           DecompositionStrategy, NGrainOrientations, Melted, PathToOutput, 0, false,
+                                           false, true, IntermediateFileCounter, ZBound_Low, nzActive, deltax, XMin,
+                                           YMin, ZMin);
                             IntermediateFileCounter++;
                         }
                     }

--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -27,9 +27,9 @@ void CellCapture(int np, int cycle, int DecompositionStrategy, int LocalActiveDo
                  Buffer2D BufferNorthWestSend, Buffer2D BufferSouthEastSend, Buffer2D BufferSouthWestSend, int BufSizeX,
                  int BufSizeY, int ZBound_Low, int nzActive, int nz, int layernumber, ViewI LayerID,
                  ViewI SteeringVector, ViewI numSteer_G, ViewI_H numSteer_H);
-void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyXSlices, int MyYSlices, int LocalDomainSize,
-                                int LocalActiveDomainSize, int nx, int ny, int nz, int nzActive, double deltax,
-                                float XMin, float YMin, float ZMin, int DecompositionStrategy,
+void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyXSlices, int MyYSlices, int MyXOffset, int MyYOffset,
+                                int LocalDomainSize, int LocalActiveDomainSize, int nx, int ny, int nz, int nzActive,
+                                double deltax, float XMin, float YMin, float ZMin, int DecompositionStrategy,
                                 int ProcessorsInXDirection, int ProcessorsInYDirection, int nn, int &XSwitch,
                                 ViewI CellType, ViewI_H CellType_H, ViewI CritTimeStep, ViewI_H CritTimeStep_H,
                                 ViewI GrainID, ViewI_H GrainID_H, std::string TemperatureDataType, int *FinishTimeStep,


### PR DESCRIPTION
The active cells initialized at the solid-liquid interface were previously always placed just outside of the cells with available temperature data, which artificially added to the problem size. The active cells are now initialized just inside of the solid-liquid interface, so that their solidification is governed by the temperature data of the problem, as opposed to liquidus time/cooling rates being assigned from neighboring cell data.

With this change, the need for wall and solid cell "padding" of the solidification domain is no longer necessary, and the CA domain coordinates match with the coordinates of temperature fields read. Additionally, halo regions are no longer allocated for subdomains on the physical problem boundaries (as they were previously filled with unused wall cells). The subroutines "X/YOffsetCalc" and "X/YMPSlicesCalc" no longer add in ghost nodes/halo regions, they simply subdivide the domain based on the decomposition and number of MPI ranks, with a separate routine adjusting the domains with halo regions where appropriate. 

Performance for the example problems appears unchanged using Cuda and OpenMP backends on Summit; however, there was a notable (around 40%) speedup using the Serial backend, likely related to a combination of fewer cells undergoing solidification (only the ones with temperature data) and fewer cells to iterate over (removal of wall and solid cell padding)