### PR TITLE
Calculation of grid size ratio, deltax adjustment moved

### DIFF
--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -34,8 +34,8 @@ void DomainDecomposition(int DecompositionStrategy, int id, int np, int &MyXSlic
                          int &NeighborRank_West, int &NeighborRank_NorthEast, int &NeighborRank_NorthWest,
                          int &NeighborRank_SouthEast, int &NeighborRank_SouthWest, int &nx, int &ny, int &nz,
                          int &ProcessorsInXDirection, int &ProcessorsInYDirection, long int &LocalDomainSize);
-void ReadTemperatureData(int id, double deltax, double HT_deltax, int MyXSlices, int MyYSlices, int MyXOffset,
-                         int MyYOffset, float XMin, float YMin, std::vector<std::string> &temp_paths,
+void ReadTemperatureData(int id, double &deltax, double HT_deltax, int &HTtoCAratio, int MyXSlices, int MyYSlices,
+                         int MyXOffset, int MyYOffset, float XMin, float YMin, std::vector<std::string> &temp_paths,
                          int NumberOfLayers, int TempFilesInSeries, unsigned int &NumberOfTemperatureDataPoints,
                          std::vector<double> &RawData, int *FirstValue, int *LastValue);
 void TempInit_DirSolidification(double G, double R, int id, int &MyXSlices, int &MyYSlices, double deltax,
@@ -47,8 +47,8 @@ void TempInit_SpotMelt(double G, double R, std::string SimulationType, int id, i
                        ViewF_H UndercoolingChange, ViewF_H UndercoolingCurrent, bool *Melted, int LayerHeight,
                        int NumberOfLayers, int &nzActive, int &ZBound_Low, int &ZBound_High, double FreezingRange,
                        ViewI_H LayerID, int NSpotsX, int NSpotsY, int SpotRadius, int SpotOffset);
-void TempInit_Reduced(int id, int &MyXSlices, int &MyYSlices, int &MyXOffset, int &MyYOffset, double &deltax,
-                      double HT_deltax, double deltat, int &nz, ViewI_H CritTimeStep, ViewF_H UndercoolingChange,
+void TempInit_Reduced(int id, int &MyXSlices, int &MyYSlices, int &MyXOffset, int &MyYOffset, double deltax,
+                      int HTtoCAratio, double deltat, int &nz, ViewI_H CritTimeStep, ViewF_H UndercoolingChange,
                       ViewF_H UndercoolingCurrent, float XMin, float YMin, float ZMin, bool *Melted, float *ZMinLayer,
                       float *ZMaxLayer, int LayerHeight, int NumberOfLayers, int &nzActive, int &ZBound_Low,
                       int &ZBound_High, int *FinishTimeStep, double FreezingRange, ViewI_H LayerID, int *FirstValue,

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -22,7 +22,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     double StartInitTime = MPI_Wtime();
 
     int nx, ny, nz, DecompositionStrategy, NumberOfLayers, LayerHeight, TempFilesInSeries;
-    int NSpotsX, NSpotsY, SpotOffset, SpotRadius;
+    int NSpotsX, NSpotsY, SpotOffset, SpotRadius, HTtoCAratio;
     unsigned int NumberOfTemperatureDataPoints = 0; // Initialized to 0 - updated if/when temperature files are read
     int PrintDebug, TimeSeriesInc;
     bool PrintMisorientation, PrintFullOutput, RemeltingYN, UseSubstrateFile, PrintTimeSeries,
@@ -90,9 +90,9 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     // Read in temperature data from files, stored in "RawData", with the appropriate MPI ranks storing the appropriate
     // data
     if (SimulationType == "R")
-        ReadTemperatureData(id, deltax, HT_deltax, MyXSlices, MyYSlices, MyXOffset, MyYOffset, XMin, YMin, temp_paths,
-                            NumberOfLayers, TempFilesInSeries, NumberOfTemperatureDataPoints, RawData, FirstValue,
-                            LastValue);
+        ReadTemperatureData(id, deltax, HT_deltax, HTtoCAratio, MyXSlices, MyYSlices, MyXOffset, MyYOffset, XMin, YMin,
+                            temp_paths, NumberOfLayers, TempFilesInSeries, NumberOfTemperatureDataPoints, RawData,
+                            FirstValue, LastValue);
 
     MPI_Barrier(MPI_COMM_WORLD);
     if (id == 0)
@@ -115,10 +115,10 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     // Initialize the temperature fields
     if (SimulationType == "R") {
         // input temperature data from files using reduced/sparse data format
-        TempInit_Reduced(id, MyXSlices, MyYSlices, MyXOffset, MyYOffset, deltax, HT_deltax, deltat, nz, CritTimeStep_H,
-                         UndercoolingChange_H, UndercoolingCurrent_H, XMin, YMin, ZMin, Melted, ZMinLayer, ZMaxLayer,
-                         LayerHeight, NumberOfLayers, nzActive, ZBound_Low, ZBound_High, FinishTimeStep, FreezingRange,
-                         LayerID_H, FirstValue, LastValue, RawData);
+        TempInit_Reduced(id, MyXSlices, MyYSlices, MyXOffset, MyYOffset, deltax, HTtoCAratio, deltat, nz,
+                         CritTimeStep_H, UndercoolingChange_H, UndercoolingCurrent_H, XMin, YMin, ZMin, Melted,
+                         ZMinLayer, ZMaxLayer, LayerHeight, NumberOfLayers, nzActive, ZBound_Low, ZBound_High,
+                         FinishTimeStep, FreezingRange, LayerID_H, FirstValue, LastValue, RawData);
     }
     else if (SimulationType == "S") {
         // spot melt array test problem

--- a/unit_test/tstInit.cpp
+++ b/unit_test/tstInit.cpp
@@ -23,6 +23,7 @@ void testReadTemperatureData() {
     // Create test data
     double deltax = 1 * pow(10, -6);
     double HT_deltax = 1 * pow(10, -6);
+    int HTtoCAratio;
     // Domain size in y is variable based on the number of ranks
     // Each MPI rank contains a 3 by 3 subdomain
     int nx = 6;
@@ -68,13 +69,15 @@ void testReadTemperatureData() {
     MPI_Barrier(MPI_COMM_WORLD);
     // Read in data to "RawData"
     std::vector<double> RawData(12);
-    ReadTemperatureData(id, deltax, HT_deltax, MyXSlices, MyYSlices, MyXOffset, MyYOffset, XMin, YMin, temp_paths,
-                        NumberOfLayers, TempFilesInSeries, NumberOfTemperatureDataPoints, RawData, FirstValue,
-                        LastValue);
+    ReadTemperatureData(id, deltax, HT_deltax, HTtoCAratio, MyXSlices, MyYSlices, MyXOffset, MyYOffset, XMin, YMin,
+                        temp_paths, NumberOfLayers, TempFilesInSeries, NumberOfTemperatureDataPoints, RawData,
+                        FirstValue, LastValue);
     // Check the results.
     // Does each rank have the right number of temperature data points? Each rank should have six (x,y,z,tm,tl,cr) for
     // each of the 9 cells in the subdomain
     EXPECT_EQ(NumberOfTemperatureDataPoints, 54);
+    // Ratio of HT cell size and CA cell size should be 1
+    EXPECT_EQ(HTtoCAratio, 1);
     int NumberOfCellsPerRank = 9;
     // Does each rank have the right temperature data values?
     for (int n = 0; n < NumberOfCellsPerRank; n++) {


### PR DESCRIPTION
The adjustment of deltax to ensure that the ratio of temperature data and CA data grid sizes (HTtoCAratio) is calculated when the quantities are first used in the reading of temperature data. HTtoCAratio is calculated in ReadTemperatureData (modifying the ReadTemperatureData unit test to accommodate this), and used again in TempInit_Reduced, rather than recalculated