### PR TITLE
Added default RVE printing option to ExaCA

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -73,6 +73,7 @@ Some additional inputs are optional while others are required. As was the case f
 | Extra set of wall cells in lateral domain directions | Y | (Y or N value) should wall cells bound the domain in X and Y, rather than substrate grains (Y or N)?
 | Heat transport data mesh size | N | Resolution of temperature data provided, in microns (if argument not provided, assumed to be equal to CA cell size)
 | Path to temperature file(s) | N | Location of temperature data (if not provided, assumed to be located in examples/Temperatures)
+| default RVE output | N | Whether or not to print representative volume element (RVE) data for ExaConstit, for a 0.5 cubic mm region in the domain center in X and Y, and at the domain top in Z excluding the final layer's grain structure
 
 ## Additional optional inputs for all problem types 
 These values govern the printing intermediate data, for debugging or visualization, either following initialization or at specified increments during simulation

--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -32,7 +32,8 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
                        double &R, int &nx, int &ny, int &nz, double &FractSurfaceSitesActive, std::string &PathToOutput,
                        int &PrintDebug, bool &PrintMisorientation, bool &PrintFinalUndercoolingVals,
                        bool &PrintFullOutput, int &NSpotsX, int &NSpotsY, int &SpotOffset, int &SpotRadius,
-                       bool &PrintTimeSeries, int &TimeSeriesInc, bool &PrintIdleTimeSeriesFrames) {
+                       bool &PrintTimeSeries, int &TimeSeriesInc, bool &PrintIdleTimeSeriesFrames,
+                       bool &PrintDefaultRVE) {
 
     // For now, assuming no remelting
     RemeltingYN = false;
@@ -110,12 +111,13 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
         RequiredInputs_ProblemSpecific[2] = "Number of temperature files";
         RequiredInputs_ProblemSpecific[3] = "Number of layers";
         RequiredInputs_ProblemSpecific[4] = "Offset between layers";
-        OptionalInputs_ProblemSpecific.resize(5);
+        OptionalInputs_ProblemSpecific.resize(6);
         OptionalInputs_ProblemSpecific[0] = "Substrate grain spacing";
         OptionalInputs_ProblemSpecific[1] = "Substrate filename";
         OptionalInputs_ProblemSpecific[2] = "Heat transport data mesh size";
         OptionalInputs_ProblemSpecific[3] = "Path to temperature file(s)";
         OptionalInputs_ProblemSpecific[4] = "Extra set of wall cells";
+        OptionalInputs_ProblemSpecific[5] = "default RVE output";
     }
     else {
         std::string error = "Error: problem type must be C, S, or R: the value given was " + SimulationType;
@@ -348,6 +350,11 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
             std::cout << "Note: optional input ExtraWalls is no longer used, all simulations by default have no walls "
                          "cells along domain boundaries"
                       << std::endl;
+        // Should optional RVE data be printed for the standard location (center of domain in X and Y, as close to the
+        // top of the domain in Z as possiblewithout including the last layer's microstructure)?
+        PrintDefaultRVE = false;
+        if (!(OptionalInputsRead_ProblemSpecific[5].empty()))
+            PrintDefaultRVE = getInputBool(OptionalInputsRead_ProblemSpecific[5]);
     }
 
     // Path to file of materials constants based on install/source location

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -23,7 +23,8 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
                        double &R, int &nx, int &ny, int &nz, double &FractSurfaceSitesActive, std::string &PathToOutput,
                        int &PrintDebug, bool &PrintMisorientation, bool &PrintFinalUndercoolingVals,
                        bool &PrintFullOutput, int &NSpotsX, int &NSpotsY, int &SpotOffset, int &SpotRadius,
-                       bool &PrintTimeSeries, int &TimeSeriesInc, bool &PrintIdleTimeSeriesFrames);
+                       bool &PrintTimeSeries, int &TimeSeriesInc, bool &PrintIdleTimeSeriesFrames,
+                       bool &PrintDefaultRVE);
 void NeighborListInit(ViewI_H NeighborX, ViewI_H NeighborY, ViewI_H NeighborZ);
 void FindXYZBounds(std::string SimulationType, int id, double &deltax, int &nx, int &ny, int &nz,
                    std::vector<std::string> &temp_paths, float &XMin, float &XMax, float &YMin, float &YMax,

--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -35,8 +35,8 @@ void PrintExaCAData(int id, int layernumber, int np, int nx, int ny, int nz, int
                     ViewF_H UndercoolingChange, ViewF_H UndercoolingCurrent, std::string BaseFileName,
                     int DecompositionStrategy, int NGrainOrientations, bool *Melted, std::string PathToOutput,
                     int PrintDebug, bool PrintMisorientation, bool PrintFinalUndercooling, bool PrintFullOutput,
-                    bool PrintTimeSeries, int IntermediateFileCounter, int ZBound_Low, int nzActive, double deltax,
-                    float XMin, float YMin, float ZMin);
+                    bool PrintTimeSeries, bool PrintDefaultRVE, int IntermediateFileCounter, int ZBound_Low,
+                    int nzActive, double deltax, float XMin, float YMin, float ZMin, int NumberOfLayers);
 void PrintExaCALog(int id, int np, std::string InputFile, std::string SimulationType, int DecompositionStrategy,
                    int MyXSlices, int MyYSlices, int MyXOffset, int MyYOffset, double AConst, double BConst,
                    double CConst, double DConst, double FreezingRange, double deltax, double NMax, double dTN,
@@ -59,6 +59,9 @@ void PrintGrainMisorientations(std::string BaseFileName, std::string PathToOutpu
 void PrintFinalUndercooling(std::string BaseFileName, std::string PathToOutput, int nx, int ny, int nz,
                             ViewI3D_H Melted_WholeDomain, ViewF3D_H UndercoolingCurrent_WholeDomain, double deltax,
                             float XMin, float YMin, float ZMin);
+void PrintExaConstitDefaultRVE(std::string BaseFileName, std::string PathToOutput, int nx, int ny, int nz,
+                               ViewI3D_H LayerID_WholeDomain, ViewI3D_H GrainID_WholeDomain, double deltax,
+                               int NumberOfLayers);
 void PrintIntermediateExaCAState(int IntermediateFileCounter, int layernumber, std::string BaseFileName,
                                  std::string PathToOutput, int ZBound_Low, int nzActive, int nx, int ny,
                                  ViewI3D_H GrainID_WholeDomain, ViewI3D_H CellType_WholeDomain, ViewF_H GrainUnitVector,

--- a/src/CAupdate.cpp
+++ b/src/CAupdate.cpp
@@ -658,7 +658,7 @@ void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyXSlices, int M
                                 ViewI LayerID, ViewI_H LayerID_H, ViewF_H GrainUnitVector_H,
                                 ViewF_H UndercoolingChange_H, ViewF_H UndercoolingCurrent_H, std::string PathToOutput,
                                 std::string OutputFile, bool PrintIdleMovieFrames, int MovieFrameInc,
-                                int &IntermediateFileCounter) {
+                                int &IntermediateFileCounter, int NumberOfLayers) {
 
     sample::ValueType CellTypeStorage;
     Kokkos::parallel_reduce(
@@ -747,8 +747,9 @@ void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyXSlices, int M
                                            ProcessorsInXDirection, ProcessorsInYDirection, GrainID_H, CritTimeStep_H,
                                            GrainUnitVector_H, LayerID_H, CellType_H, UndercoolingChange_H,
                                            UndercoolingCurrent_H, OutputFile, DecompositionStrategy, NGrainOrientations,
-                                           Melted, PathToOutput, 0, false, false, false, true, IntermediateFileCounter,
-                                           ZBound_Low, nzActive, deltax, XMin, YMin, ZMin);
+                                           Melted, PathToOutput, 0, false, false, false, true, false,
+                                           IntermediateFileCounter, ZBound_Low, nzActive, deltax, XMin, YMin, ZMin,
+                                           NumberOfLayers);
                             IntermediateFileCounter++;
                         }
                     }

--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -49,6 +49,6 @@ void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyXSlices, int M
                                 ViewI LayerID, ViewI_H LayerID_H, ViewF_H GrainUnitVector_H,
                                 ViewF_H UndercoolingChange_H, ViewF_H UndercoolingCurrent_H, std::string PathToOutput,
                                 std::string OutputFile, bool PrintIdleMovieFrames, int MovieFrameInc,
-                                int &IntermediateFileCounter);
+                                int &IntermediateFileCounter, int NumberOfLayers);
 
 #endif

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -26,7 +26,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     unsigned int NumberOfTemperatureDataPoints = 0; // Initialized to 0 - updated if/when temperature files are read
     int PrintDebug, TimeSeriesInc;
     bool PrintMisorientation, PrintFinalUndercoolingVals, PrintFullOutput, RemeltingYN, UseSubstrateFile,
-        PrintTimeSeries, PrintIdleTimeSeriesFrames;
+        PrintTimeSeries, PrintIdleTimeSeriesFrames, PrintDefaultRVE;
     float SubstrateGrainSpacing;
     double HT_deltax, deltax, deltat, FractSurfaceSitesActive, G, R, AConst, BConst, CConst, DConst, FreezingRange,
         NMax, dTN, dTsigma;
@@ -40,7 +40,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                       SubstrateFileName, SubstrateGrainSpacing, UseSubstrateFile, G, R, nx, ny, nz,
                       FractSurfaceSitesActive, PathToOutput, PrintDebug, PrintMisorientation,
                       PrintFinalUndercoolingVals, PrintFullOutput, NSpotsX, NSpotsY, SpotOffset, SpotRadius,
-                      PrintTimeSeries, TimeSeriesInc, PrintIdleTimeSeriesFrames);
+                      PrintTimeSeries, TimeSeriesInc, PrintIdleTimeSeriesFrames, PrintDefaultRVE);
 
     // Grid decomposition
     int ProcessorsInXDirection, ProcessorsInYDirection;
@@ -284,8 +284,8 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
         PrintExaCAData(id, -1, np, nx, ny, nz, MyXSlices, MyYSlices, MyXOffset, MyYOffset, ProcessorsInXDirection,
                        ProcessorsInYDirection, GrainID_H, CritTimeStep_H, GrainUnitVector_H, LayerID_H, CellType_H,
                        UndercoolingChange_H, UndercoolingCurrent_H, OutputFile, DecompositionStrategy,
-                       NGrainOrientations, Melted, PathToOutput, PrintDebug, false, false, false, false, 0, ZBound_Low,
-                       nzActive, deltax, XMin, YMin, ZMin);
+                       NGrainOrientations, Melted, PathToOutput, PrintDebug, false, false, false, false, false, 0,
+                       ZBound_Low, nzActive, deltax, XMin, YMin, ZMin, NumberOfLayers);
         MPI_Barrier(MPI_COMM_WORLD);
         if (id == 0)
             std::cout << "Initialization data file(s) printed" << std::endl;
@@ -310,8 +310,8 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                                ProcessorsInXDirection, ProcessorsInYDirection, GrainID_H, CritTimeStep_H,
                                GrainUnitVector_H, LayerID_H, CellType_H, UndercoolingChange_H, UndercoolingCurrent_H,
                                OutputFile, DecompositionStrategy, NGrainOrientations, Melted, PathToOutput, 0, false,
-                               false, false, true, IntermediateFileCounter, ZBound_Low, nzActive, deltax, XMin, YMin,
-                               ZMin);
+                               false, false, true, false, IntermediateFileCounter, ZBound_Low, nzActive, deltax, XMin,
+                               YMin, ZMin, NumberOfLayers);
                 IntermediateFileCounter++;
             }
             cycle++;
@@ -367,7 +367,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                     GrainID_G, GrainID_H, SimulationType, FinishTimeStep, layernumber, NumberOfLayers, ZBound_Low,
                     NGrainOrientations, Melted, LayerID_G, LayerID_H, GrainUnitVector_H, UndercoolingChange_H,
                     UndercoolingCurrent_H, PathToOutput, OutputFile, PrintIdleTimeSeriesFrames, TimeSeriesInc,
-                    IntermediateFileCounter);
+                    IntermediateFileCounter, NumberOfLayers);
             }
 
         } while (XSwitch == 0);
@@ -503,15 +503,15 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
-    if ((PrintMisorientation) || (PrintFinalUndercoolingVals) || (PrintFullOutput)) {
+    if (((PrintMisorientation) || (PrintFinalUndercoolingVals) || (PrintFullOutput)) || (PrintDefaultRVE)) {
         if (id == 0)
             std::cout << "Collecting data on rank 0 and printing to files" << std::endl;
         PrintExaCAData(id, NumberOfLayers - 1, np, nx, ny, nz, MyXSlices, MyYSlices, MyXOffset, MyYOffset,
                        ProcessorsInXDirection, ProcessorsInYDirection, GrainID_H, CritTimeStep_H, GrainUnitVector_H,
                        LayerID_H, CellType_H, UndercoolingChange_H, UndercoolingCurrent_H, OutputFile,
                        DecompositionStrategy, NGrainOrientations, Melted, PathToOutput, 0, PrintMisorientation,
-                       PrintFinalUndercoolingVals, PrintFullOutput, false, 0, ZBound_Low, nzActive, deltax, XMin, YMin,
-                       ZMin);
+                       PrintFinalUndercoolingVals, PrintFullOutput, false, PrintDefaultRVE, 0, ZBound_Low, nzActive,
+                       deltax, XMin, YMin, ZMin, NumberOfLayers);
     }
     else {
         if (id == 0)

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -127,4 +127,4 @@ endmacro()
 
 ExaCA_add_tests_nobackend(NAMES Init)
 
-ExaCA_add_tests(NAMES KokkosInit)
+ExaCA_add_tests(NAMES KokkosInit Print)

--- a/unit_test/tstInit.cpp
+++ b/unit_test/tstInit.cpp
@@ -136,6 +136,7 @@ void testInputReadFromFile() {
         TestDataFile << "File of grain orientations: GrainOrientationVectors_Robert.csv" << std::endl;
         TestDataFile << "Print file of grain misorientation values: Y" << std::endl;
         TestDataFile << "Print file of final undercooling values: Y" << std::endl;
+        TestDataFile << "Print default RVE output: Y" << std::endl;
         TestDataFile << "Print file of all ExaCA data: N" << std::endl;
         TestDataFile << "Time step: 1.5" << std::endl;
         TestDataFile << "Temperature filename(s): DummyTemperature.txt" << std::endl;
@@ -173,7 +174,7 @@ void testInputReadFromFile() {
         double AConst, BConst, CConst, DConst, FreezingRange, deltax, NMax, dTN, dTsigma, HT_deltax, deltat, G, R,
             FractSurfaceSitesActive;
         bool RemeltingYN, PrintMisorientation, PrintFinalUndercoolingVals, PrintFullOutput, PrintTimeSeries,
-            UseSubstrateFile, PrintIdleTimeSeriesFrames;
+            UseSubstrateFile, PrintIdleTimeSeriesFrames, PrintDefaultRVE = false;
         std::string SimulationType, OutputFile, GrainOrientationFile, temppath, tempfile, SubstrateFileName,
             PathToOutput;
         std::vector<std::string> temp_paths;
@@ -183,7 +184,7 @@ void testInputReadFromFile() {
                           LayerHeight, SubstrateFileName, SubstrateGrainSpacing, UseSubstrateFile, G, R, nx, ny, nz,
                           FractSurfaceSitesActive, PathToOutput, PrintDebug, PrintMisorientation,
                           PrintFinalUndercoolingVals, PrintFullOutput, NSpotsX, NSpotsY, SpotOffset, SpotRadius,
-                          PrintTimeSeries, TimeSeriesInc, PrintIdleTimeSeriesFrames);
+                          PrintTimeSeries, TimeSeriesInc, PrintIdleTimeSeriesFrames, PrintDefaultRVE);
 
         // Check the results
         // The existence of the specified orientation, substrate, and temperature filenames was already checked within
@@ -246,6 +247,7 @@ void testInputReadFromFile() {
             EXPECT_TRUE(OutputFile == "Test");
             EXPECT_TRUE(PrintMisorientation);
             EXPECT_TRUE(PrintFinalUndercoolingVals);
+            EXPECT_TRUE(PrintDefaultRVE);
             EXPECT_FALSE(PrintFullOutput);
         }
     }

--- a/unit_test/tstPrint.hpp
+++ b/unit_test/tstPrint.hpp
@@ -1,0 +1,80 @@
+
+#include <Kokkos_Core.hpp>
+
+#include "CAprint.hpp"
+#include "CAtypes.hpp"
+
+#include <gtest/gtest.h>
+
+#include "mpi.h"
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace Test {
+//---------------------------------------------------------------------------//
+void testPrintExaConstitDefaultRVE() {
+
+    int id, np;
+    // Get individual process ID
+    MPI_Comm_rank(MPI_COMM_WORLD, &id);
+    // Get number of processes
+    MPI_Comm_size(MPI_COMM_WORLD, &np);
+
+    // File name/path for test RVE output (each rank writes/reads different file)
+    std::string BaseFileName = "TestRVERank_" + std::to_string(id);
+    std::string PathToOutput = "";
+
+    // Create test grid - set up so that the RVE is 5 cells in X, Y, and Z
+    int nx = 10;
+    int ny = 10;
+    int nz = 10;
+    int NumberOfLayers = 10;
+    double deltax = 0.0001; // in meters
+
+    // Create test data
+    ViewI3D_H GrainID_WholeDomain(Kokkos::ViewAllocateWithoutInitializing("GrainID_WholeDomain"), nz, nx, ny);
+    ViewI3D_H LayerID_WholeDomain(Kokkos::ViewAllocateWithoutInitializing("LayerID_WholeDomain"), nz, nx, ny);
+    for (int k = 0; k < nz; k++) {
+        for (int i = 0; i < nx; i++) {
+            for (int j = 0; j < ny; j++) {
+                LayerID_WholeDomain(k, i, j) = k;
+                GrainID_WholeDomain(k, i, j) = id * i + j;
+            }
+        }
+    }
+
+    // Print RVE
+    PrintExaConstitDefaultRVE(BaseFileName, PathToOutput, nx, ny, nz, LayerID_WholeDomain, GrainID_WholeDomain, deltax,
+                              NumberOfLayers);
+
+    // Check printed RVE
+    std::ifstream GrainplotE;
+    std::string ExpectedFilename = BaseFileName + "_ExaConstit.csv";
+    GrainplotE.open(ExpectedFilename);
+    std::string line;
+    std::getline(GrainplotE, line);
+    EXPECT_TRUE(line == "Coordinates are in CA units, 1 cell = 0.0001 m. Data is cell-centered. Origin at 3,3,4 , "
+                        "domain size is 5 by 5 by 5 cells");
+    std::getline(GrainplotE, line);
+    EXPECT_TRUE(line == "X coord, Y coord, Z coord, Grain ID");
+    for (int k = 4; k < 9; k++) {
+        for (int i = 3; i < 8; i++) {
+            for (int j = 3; j < 8; j++) {
+                std::string ExpectedLine = std::to_string(i) + "," + std::to_string(j) + "," + std::to_string(k) + "," +
+                                           std::to_string(id * i + j);
+                std::getline(GrainplotE, line);
+                EXPECT_TRUE(line == ExpectedLine);
+            }
+        }
+    }
+    GrainplotE.close();
+}
+
+//---------------------------------------------------------------------------//
+// RUN TESTS
+//---------------------------------------------------------------------------//
+TEST(TEST_CATEGORY, print_test) { testPrintExaConstitDefaultRVE(); }
+
+} // end namespace Test


### PR DESCRIPTION
Optional input for test problems using input time-temperature history data to print a "default" (center of domain in X and Y, closest position to the top surface in Z while avoiding last layer's microstructure) 0.5 cubic mm representative volume element (RVE) used by ExaConstit as part of the main ExaCA code. The ability to print "custom" RVE data (various sizes and locations in the domain) still requires running the separate analysis executable, which reads ExaCA output data and parses it.

Part of #2 (output)