### PR TITLE
Added fence to end of ghost nodes subroutines

### DIFF
--- a/src/CAghostnodes.cpp
+++ b/src/CAghostnodes.cpp
@@ -338,6 +338,7 @@ void GhostNodes2D(int, int, int NeighborRank_North, int NeighborRank_South, int 
     }
     // Wait on send requests
     MPI_Waitall(8, SendRequests.data(), MPI_STATUSES_IGNORE);
+    Kokkos::fence();
 }
 
 //*****************************************************************************/
@@ -527,4 +528,5 @@ void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int 
 
     // Wait on send requests
     MPI_Waitall(2, SendRequests.data(), MPI_STATUSES_IGNORE);
+    Kokkos::fence();
 }


### PR DESCRIPTION
As subroutines GhostNodes1D and GhostNodes2D involve the potential update of CellType(index) from Liquid to Active (due to halo exchange), and the subroutine Nucleation on the next time step involves the potential update of CellType(index) from Liquid to FutureActive (due to successful nucleation events), Kokkos:fence() should be called at the ends of GhostNodes1D/GhostNodes2D to avoid a potential race condition with view access for CellType 