### PR TITLE
Use double (not float) for Buffer2D type; removed unused Buffer3D type

### DIFF
--- a/src/CAghostnodes.cpp
+++ b/src/CAghostnodes.cpp
@@ -32,39 +32,39 @@ void GhostNodes2D(int, int, int NeighborRank_North, int NeighborRank_South, int 
     std::vector<MPI_Request> RecvRequests(8, MPI_REQUEST_NULL);
 
     // Send data to each other rank (MPI_Isend)
-    MPI_Isend(BufferSouthSend.data(), 5 * BufSizeX * BufSizeZ, MPI_FLOAT, NeighborRank_South, 0, MPI_COMM_WORLD,
+    MPI_Isend(BufferSouthSend.data(), 5 * BufSizeX * BufSizeZ, MPI_DOUBLE, NeighborRank_South, 0, MPI_COMM_WORLD,
               &SendRequests[0]);
-    MPI_Isend(BufferNorthSend.data(), 5 * BufSizeX * BufSizeZ, MPI_FLOAT, NeighborRank_North, 0, MPI_COMM_WORLD,
+    MPI_Isend(BufferNorthSend.data(), 5 * BufSizeX * BufSizeZ, MPI_DOUBLE, NeighborRank_North, 0, MPI_COMM_WORLD,
               &SendRequests[1]);
-    MPI_Isend(BufferEastSend.data(), 5 * BufSizeY * BufSizeZ, MPI_FLOAT, NeighborRank_East, 0, MPI_COMM_WORLD,
+    MPI_Isend(BufferEastSend.data(), 5 * BufSizeY * BufSizeZ, MPI_DOUBLE, NeighborRank_East, 0, MPI_COMM_WORLD,
               &SendRequests[2]);
-    MPI_Isend(BufferWestSend.data(), 5 * BufSizeY * BufSizeZ, MPI_FLOAT, NeighborRank_West, 0, MPI_COMM_WORLD,
+    MPI_Isend(BufferWestSend.data(), 5 * BufSizeY * BufSizeZ, MPI_DOUBLE, NeighborRank_West, 0, MPI_COMM_WORLD,
               &SendRequests[3]);
-    MPI_Isend(BufferNorthWestSend.data(), 5 * BufSizeZ, MPI_FLOAT, NeighborRank_NorthWest, 0, MPI_COMM_WORLD,
+    MPI_Isend(BufferNorthWestSend.data(), 5 * BufSizeZ, MPI_DOUBLE, NeighborRank_NorthWest, 0, MPI_COMM_WORLD,
               &SendRequests[4]);
-    MPI_Isend(BufferNorthEastSend.data(), 5 * BufSizeZ, MPI_FLOAT, NeighborRank_NorthEast, 0, MPI_COMM_WORLD,
+    MPI_Isend(BufferNorthEastSend.data(), 5 * BufSizeZ, MPI_DOUBLE, NeighborRank_NorthEast, 0, MPI_COMM_WORLD,
               &SendRequests[5]);
-    MPI_Isend(BufferSouthWestSend.data(), 5 * BufSizeZ, MPI_FLOAT, NeighborRank_SouthWest, 0, MPI_COMM_WORLD,
+    MPI_Isend(BufferSouthWestSend.data(), 5 * BufSizeZ, MPI_DOUBLE, NeighborRank_SouthWest, 0, MPI_COMM_WORLD,
               &SendRequests[6]);
-    MPI_Isend(BufferSouthEastSend.data(), 5 * BufSizeZ, MPI_FLOAT, NeighborRank_SouthEast, 0, MPI_COMM_WORLD,
+    MPI_Isend(BufferSouthEastSend.data(), 5 * BufSizeZ, MPI_DOUBLE, NeighborRank_SouthEast, 0, MPI_COMM_WORLD,
               &SendRequests[7]);
 
     // Receive buffers for all neighbors (MPI_Irecv)
-    MPI_Irecv(BufferSouthRecv.data(), 5 * BufSizeX * BufSizeZ, MPI_FLOAT, NeighborRank_South, 0, MPI_COMM_WORLD,
+    MPI_Irecv(BufferSouthRecv.data(), 5 * BufSizeX * BufSizeZ, MPI_DOUBLE, NeighborRank_South, 0, MPI_COMM_WORLD,
               &RecvRequests[0]);
-    MPI_Irecv(BufferNorthRecv.data(), 5 * BufSizeX * BufSizeZ, MPI_FLOAT, NeighborRank_North, 0, MPI_COMM_WORLD,
+    MPI_Irecv(BufferNorthRecv.data(), 5 * BufSizeX * BufSizeZ, MPI_DOUBLE, NeighborRank_North, 0, MPI_COMM_WORLD,
               &RecvRequests[1]);
-    MPI_Irecv(BufferEastRecv.data(), 5 * BufSizeY * BufSizeZ, MPI_FLOAT, NeighborRank_East, 0, MPI_COMM_WORLD,
+    MPI_Irecv(BufferEastRecv.data(), 5 * BufSizeY * BufSizeZ, MPI_DOUBLE, NeighborRank_East, 0, MPI_COMM_WORLD,
               &RecvRequests[2]);
-    MPI_Irecv(BufferWestRecv.data(), 5 * BufSizeY * BufSizeZ, MPI_FLOAT, NeighborRank_West, 0, MPI_COMM_WORLD,
+    MPI_Irecv(BufferWestRecv.data(), 5 * BufSizeY * BufSizeZ, MPI_DOUBLE, NeighborRank_West, 0, MPI_COMM_WORLD,
               &RecvRequests[3]);
-    MPI_Irecv(BufferNorthWestRecv.data(), 5 * BufSizeZ, MPI_FLOAT, NeighborRank_NorthWest, 0, MPI_COMM_WORLD,
+    MPI_Irecv(BufferNorthWestRecv.data(), 5 * BufSizeZ, MPI_DOUBLE, NeighborRank_NorthWest, 0, MPI_COMM_WORLD,
               &RecvRequests[4]);
-    MPI_Irecv(BufferNorthEastRecv.data(), 5 * BufSizeZ, MPI_FLOAT, NeighborRank_NorthEast, 0, MPI_COMM_WORLD,
+    MPI_Irecv(BufferNorthEastRecv.data(), 5 * BufSizeZ, MPI_DOUBLE, NeighborRank_NorthEast, 0, MPI_COMM_WORLD,
               &RecvRequests[5]);
-    MPI_Irecv(BufferSouthWestRecv.data(), 5 * BufSizeZ, MPI_FLOAT, NeighborRank_SouthWest, 0, MPI_COMM_WORLD,
+    MPI_Irecv(BufferSouthWestRecv.data(), 5 * BufSizeZ, MPI_DOUBLE, NeighborRank_SouthWest, 0, MPI_COMM_WORLD,
               &RecvRequests[6]);
-    MPI_Irecv(BufferSouthEastRecv.data(), 5 * BufSizeZ, MPI_FLOAT, NeighborRank_SouthEast, 0, MPI_COMM_WORLD,
+    MPI_Irecv(BufferSouthEastRecv.data(), 5 * BufSizeZ, MPI_DOUBLE, NeighborRank_SouthEast, 0, MPI_COMM_WORLD,
               &RecvRequests[7]);
 
     // unpack in any order
@@ -95,7 +95,7 @@ void GhostNodes2D(int, int, int NeighborRank_North, int NeighborRank_South, int 
                     int RankX, RankY, RankZ, NewGrainID;
                     long int CellLocation;
                     bool Place = false;
-                    float DOCenterX, DOCenterY, DOCenterZ, NewDiagonalLength;
+                    double DOCenterX, DOCenterY, DOCenterZ, NewDiagonalLength;
                     // Which rank was the data received from?
                     if ((unpack_index == 0) && (NeighborRank_South != MPI_PROC_NULL)) {
                         // Data receieved from South
@@ -228,11 +228,11 @@ void GhostNodes2D(int, int, int NeighborRank_North, int NeighborRank_South, int 
                         int GlobalCellLocation = GlobalZ * MyXSlices * MyYSlices + RankX * MyYSlices + RankY;
                         CellType(GlobalCellLocation) = Active;
                         GrainID(GlobalCellLocation) = NewGrainID;
-                        DOCenter((long int)(3) * CellLocation) = DOCenterX;
-                        DOCenter((long int)(3) * CellLocation + (long int)(1)) = DOCenterY;
-                        DOCenter((long int)(3) * CellLocation + (long int)(2)) = DOCenterZ;
+                        DOCenter((long int)(3) * CellLocation) = (float)(DOCenterX);
+                        DOCenter((long int)(3) * CellLocation + (long int)(1)) = (float)(DOCenterY);
+                        DOCenter((long int)(3) * CellLocation + (long int)(2)) = (float)(DOCenterZ);
                         int MyOrientation = getGrainOrientation(GrainID(GlobalCellLocation), NGrainOrientations);
-                        DiagonalLength(CellLocation) = NewDiagonalLength;
+                        DiagonalLength(CellLocation) = (float)(NewDiagonalLength);
                         // Global coordinates of cell center
                         double xp = RankX + MyXOffset + 0.5;
                         double yp = RankY + MyYOffset + 0.5;
@@ -352,15 +352,15 @@ void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int 
     std::vector<MPI_Request> RecvRequests(2, MPI_REQUEST_NULL);
 
     // Send data to each other rank (MPI_Isend)
-    MPI_Isend(BufferSouthSend.data(), 5 * BufSizeX * BufSizeZ, MPI_FLOAT, NeighborRank_South, 0, MPI_COMM_WORLD,
+    MPI_Isend(BufferSouthSend.data(), 5 * BufSizeX * BufSizeZ, MPI_DOUBLE, NeighborRank_South, 0, MPI_COMM_WORLD,
               &SendRequests[0]);
-    MPI_Isend(BufferNorthSend.data(), 5 * BufSizeX * BufSizeZ, MPI_FLOAT, NeighborRank_North, 0, MPI_COMM_WORLD,
+    MPI_Isend(BufferNorthSend.data(), 5 * BufSizeX * BufSizeZ, MPI_DOUBLE, NeighborRank_North, 0, MPI_COMM_WORLD,
               &SendRequests[1]);
 
     // Receive buffers for all neighbors (MPI_Irecv)
-    MPI_Irecv(BufferSouthRecv.data(), 5 * BufSizeX * BufSizeZ, MPI_FLOAT, NeighborRank_South, 0, MPI_COMM_WORLD,
+    MPI_Irecv(BufferSouthRecv.data(), 5 * BufSizeX * BufSizeZ, MPI_DOUBLE, NeighborRank_South, 0, MPI_COMM_WORLD,
               &RecvRequests[0]);
-    MPI_Irecv(BufferNorthRecv.data(), 5 * BufSizeX * BufSizeZ, MPI_FLOAT, NeighborRank_North, 0, MPI_COMM_WORLD,
+    MPI_Irecv(BufferNorthRecv.data(), 5 * BufSizeX * BufSizeZ, MPI_DOUBLE, NeighborRank_North, 0, MPI_COMM_WORLD,
               &RecvRequests[1]);
 
     // unpack in any order
@@ -380,7 +380,7 @@ void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int 
                 "BufferUnpack", RecvBufSize, KOKKOS_LAMBDA(const int &BufPosition) {
                     int RankX, RankY, RankZ, NewGrainID;
                     long int CellLocation;
-                    float DOCenterX, DOCenterY, DOCenterZ, NewDiagonalLength;
+                    double DOCenterX, DOCenterY, DOCenterZ, NewDiagonalLength;
                     bool Place = false;
                     RankZ = BufPosition / BufSizeX;
                     RankX = BufPosition % BufSizeX;
@@ -417,11 +417,11 @@ void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int 
 
                         // Update this ghost node cell's information with data from other rank
                         GrainID(GlobalCellLocation) = NewGrainID;
-                        DOCenter((long int)(3) * CellLocation) = DOCenterX;
-                        DOCenter((long int)(3) * CellLocation + (long int)(1)) = DOCenterY;
-                        DOCenter((long int)(3) * CellLocation + (long int)(2)) = DOCenterZ;
+                        DOCenter((long int)(3) * CellLocation) = (float)(DOCenterX);
+                        DOCenter((long int)(3) * CellLocation + (long int)(1)) = (float)(DOCenterY);
+                        DOCenter((long int)(3) * CellLocation + (long int)(2)) = (float)(DOCenterZ);
                         int MyOrientation = getGrainOrientation(GrainID(GlobalCellLocation), NGrainOrientations);
-                        DiagonalLength(CellLocation) = NewDiagonalLength;
+                        DiagonalLength(CellLocation) = (float)(NewDiagonalLength);
                         // Global coordinates of cell center
                         double xp = RankX + MyXOffset + 0.5;
                         double yp = RankY + MyYOffset + 0.5;

--- a/src/CAghostnodes.hpp
+++ b/src/CAghostnodes.hpp
@@ -11,8 +11,8 @@
 #include <Kokkos_Core.hpp>
 
 // Load data (GrainID, DOCenter, DiagonalLength) into ghost nodes if the given RankY is associated with a 1D halo region
-KOKKOS_INLINE_FUNCTION void loadghostnodes(const float GhostGID, const float GhostDOCX, const float GhostDOCY,
-                                           const float GhostDOCZ, const float GhostDL, const int BufSizeX,
+KOKKOS_INLINE_FUNCTION void loadghostnodes(const double GhostGID, const double GhostDOCX, const double GhostDOCY,
+                                           const double GhostDOCZ, const double GhostDL, const int BufSizeX,
                                            const int MyYSlices, const int RankX, const int RankY, const int RankZ,
                                            const bool AtNorthBoundary, const bool AtSouthBoundary,
                                            Buffer2D BufferSouthSend, Buffer2D BufferNorthSend) {
@@ -38,8 +38,8 @@ KOKKOS_INLINE_FUNCTION void loadghostnodes(const float GhostGID, const float Gho
 // Load data (GrainID, DOCenter, DiagonalLength) into ghost nodes if the given RankX and RankY is associated with a 2D
 // halo region
 KOKKOS_INLINE_FUNCTION void
-loadghostnodes(const float GhostGID, const float GhostDOCX, const float GhostDOCY, const float GhostDOCZ,
-               const float GhostDL, const int BufSizeX, const int BufSizeY, const int MyXSlices, const int MyYSlices,
+loadghostnodes(const double GhostGID, const double GhostDOCX, const double GhostDOCY, const double GhostDOCZ,
+               const double GhostDL, const int BufSizeX, const int BufSizeY, const int MyXSlices, const int MyYSlices,
                const int RankX, const int RankY, const int RankZ, const bool AtNorthBoundary,
                const bool AtSouthBoundary, const bool AtWestBoundary, const bool AtEastBoundary,
                Buffer2D BufferSouthSend, Buffer2D BufferNorthSend, Buffer2D BufferWestSend, Buffer2D BufferEastSend,

--- a/src/CAtypes.hpp
+++ b/src/CAtypes.hpp
@@ -24,8 +24,7 @@ typedef Kokkos::View<float *> ViewF;
 typedef Kokkos::View<int *> ViewI;
 typedef Kokkos::View<int **> ViewI2D;
 typedef Kokkos::View<int *, Kokkos::MemoryTraits<Kokkos::Atomic>> View_a;
-typedef Kokkos::View<float **> Buffer2D;
-typedef Kokkos::View<int ***> Buffer3D; // Used in ghost node initialization of integer structures CellType and GrainID
+typedef Kokkos::View<double **> Buffer2D;
 typedef Kokkos::View<float *> TestView;
 
 using exe_space = Kokkos::DefaultExecutionSpace::execution_space;

--- a/src/CAupdate.cpp
+++ b/src/CAupdate.cpp
@@ -441,11 +441,11 @@ void CellCapture(int np, int cycle, int DecompositionStrategy, int LocalActiveDo
 
                                 if (np > 1) {
 
-                                    float GhostGID = h;
-                                    float GhostDOCX = cx;
-                                    float GhostDOCY = cy;
-                                    float GhostDOCZ = cz;
-                                    float GhostDL = NewODiagL;
+                                    double GhostGID = (double)(h);
+                                    double GhostDOCX = cx;
+                                    double GhostDOCY = cy;
+                                    double GhostDOCZ = cz;
+                                    double GhostDL = NewODiagL;
                                     // Collect data for the ghost nodes, if necessary
                                     // Data loaded into the ghost nodes is for the cell that was just captured
                                     if (DecompositionStrategy == 1)
@@ -584,11 +584,11 @@ void CellCapture(int np, int cycle, int DecompositionStrategy, int LocalActiveDo
                 }
                 if (np > 1) {
 
-                    float GhostGID = MyGrainID;
-                    float GhostDOCX = GlobalX + 0.5;
-                    float GhostDOCY = GlobalY + 0.5;
-                    float GhostDOCZ = GlobalZ + 0.5;
-                    float GhostDL = 0.01;
+                    double GhostGID = (double)(MyGrainID);
+                    double GhostDOCX = (double)(GlobalX + 0.5);
+                    double GhostDOCY = (double)(GlobalY + 0.5);
+                    double GhostDOCZ = (double)(GlobalZ + 0.5);
+                    double GhostDL = 0.01;
                     // Collect data for the ghost nodes, if necessary
                     if (DecompositionStrategy == 1)
                         loadghostnodes(GhostGID, GhostDOCX, GhostDOCY, GhostDOCZ, GhostDL, BufSizeX, MyYSlices, RankX,


### PR DESCRIPTION
For large values of GrainID (integers) that are often encountered in large multilayer problems, the conversion to float and back to int during the loading, sending, and unpacking of halo data was leading to values being erroneously altered. Redefining the Buffer2D type to use double values instead of float values mitigates this issue.