### PR TITLE
Replaced parseCommaSeparatedArgs function usage

### DIFF
--- a/analysis/src/GAutils.cpp
+++ b/analysis/src/GAutils.cpp
@@ -366,7 +366,7 @@ void ParseAnalysisFile(std::string AnalysisFile, std::string RotationFilename, i
         std::vector<std::string> CS(4);
         if (NewOrientationFormatYN) {
             // Should be 4 inputs on this line - break it into its components
-            splitString(CSline, CS, 3);
+            splitString(CSline, CS, 4);
             if (CS[2] == "Y")
                 PrintSectionPF.push_back(true);
             else

--- a/analysis/src/GAutils.cpp
+++ b/analysis/src/GAutils.cpp
@@ -366,7 +366,7 @@ void ParseAnalysisFile(std::string AnalysisFile, std::string RotationFilename, i
         std::vector<std::string> CS(4);
         if (NewOrientationFormatYN) {
             // Should be 4 inputs on this line - break it into its components
-            splitString(CSline, CS);
+            splitString(CSline, CS, 3);
             if (CS[2] == "Y")
                 PrintSectionPF.push_back(true);
             else

--- a/analysis/src/GAutils.cpp
+++ b/analysis/src/GAutils.cpp
@@ -366,7 +366,7 @@ void ParseAnalysisFile(std::string AnalysisFile, std::string RotationFilename, i
         std::vector<std::string> CS(4);
         if (NewOrientationFormatYN) {
             // Should be 4 inputs on this line - break it into its components
-            parseCommaSeparatedArgs(AnalysisFile, CSline, CS);
+            splitString(CSline, CS);
             if (CS[2] == "Y")
                 PrintSectionPF.push_back(true);
             else

--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -492,12 +492,12 @@ void FindXYZBounds(std::string SimulationType, int id, double &deltax, int &nx, 
             std::vector<double> XCoordinates(1000000), YCoordinates(1000000), ZCoordinates(1000000);
             long unsigned int XYZPointCounter = 0;
             while (!TemperatureFile.eof()) {
-                std::vector<std::string> ParsedLine(6); // Each line has an x, y, z, tm, tl, cr
+                std::vector<std::string> ParsedLine(3); // Get x, y, z - ignore tm, tl, cr
                 std::string ReadLine;
                 if (!getline(TemperatureFile, ReadLine))
                     break;
+                splitString(ReadLine, ParsedLine, ",", 3);
                 // Only get x, y, and z values from ParsedLine
-                parseCommaSeparatedArgs(tempfile_thislayer, ReadLine, ParsedLine);
                 XCoordinates[XYZPointCounter] = getInputDouble(ParsedLine[0]);
                 YCoordinates[XYZPointCounter] = getInputDouble(ParsedLine[1]);
                 ZCoordinates[XYZPointCounter] = getInputDouble(ParsedLine[2]);
@@ -693,8 +693,8 @@ void ReadTemperatureData(int id, double &deltax, double HT_deltax, int &HTtoCAra
             std::string ReadLine;
             if (!getline(TemperatureFile, ReadLine))
                 break;
+            splitString(ReadLine, ParsedLine);
             // Only get x and y values from ParsedLine, for now
-            parseCommaSeparatedArgs(tempfile_thislayer, ReadLine, ParsedLine);
             double XTemperaturePoint = getInputDouble(ParsedLine[0]);
             double YTemperaturePoint = getInputDouble(ParsedLine[1]);
             // Check the CA grid positions of the data point to see which rank(s) should store it
@@ -1181,7 +1181,7 @@ void OrientationInit(int, int &NGrainOrientations, ViewF &GrainOrientationData, 
         std::string ReadLine;
         if (!getline(O, ReadLine))
             break;
-        parseCommaSeparatedArgs(GrainOrientationFile, ReadLine, ParsedLine);
+        splitString(ReadLine, ParsedLine);
         // Place the 3 grain orientation angles or 9 rotation matrix components into the orientation data view
         for (int Comp = 0; Comp < ValsPerLine; Comp++) {
             GrainOrientationData_Host(ValsPerLine * i + Comp) = getInputFloat(ParsedLine[Comp]);

--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -496,7 +496,7 @@ void FindXYZBounds(std::string SimulationType, int id, double &deltax, int &nx, 
                 std::string ReadLine;
                 if (!getline(TemperatureFile, ReadLine))
                     break;
-                splitString(ReadLine, ParsedLine, 5);
+                splitString(ReadLine, ParsedLine, 6);
                 // Only get x, y, and z values from ParsedLine
                 XCoordinates[XYZPointCounter] = getInputDouble(ParsedLine[0]);
                 YCoordinates[XYZPointCounter] = getInputDouble(ParsedLine[1]);
@@ -693,7 +693,7 @@ void ReadTemperatureData(int id, double &deltax, double HT_deltax, int &HTtoCAra
             std::string ReadLine;
             if (!getline(TemperatureFile, ReadLine))
                 break;
-            splitString(ReadLine, ParsedLine, 5);
+            splitString(ReadLine, ParsedLine, 6);
             // Only get x and y values from ParsedLine, for now
             double XTemperaturePoint = getInputDouble(ParsedLine[0]);
             double YTemperaturePoint = getInputDouble(ParsedLine[1]);
@@ -1181,7 +1181,7 @@ void OrientationInit(int, int &NGrainOrientations, ViewF &GrainOrientationData, 
         std::string ReadLine;
         if (!getline(O, ReadLine))
             break;
-        splitString(ReadLine, ParsedLine, ValsPerLine - 1);
+        splitString(ReadLine, ParsedLine, ValsPerLine);
         // Place the 3 grain orientation angles or 9 rotation matrix components into the orientation data view
         for (int Comp = 0; Comp < ValsPerLine; Comp++) {
             GrainOrientationData_Host(ValsPerLine * i + Comp) = getInputFloat(ParsedLine[Comp]);

--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -496,7 +496,7 @@ void FindXYZBounds(std::string SimulationType, int id, double &deltax, int &nx, 
                 std::string ReadLine;
                 if (!getline(TemperatureFile, ReadLine))
                     break;
-                splitString(ReadLine, ParsedLine, ",", 3);
+                splitString(ReadLine, ParsedLine, 5);
                 // Only get x, y, and z values from ParsedLine
                 XCoordinates[XYZPointCounter] = getInputDouble(ParsedLine[0]);
                 YCoordinates[XYZPointCounter] = getInputDouble(ParsedLine[1]);
@@ -693,7 +693,7 @@ void ReadTemperatureData(int id, double &deltax, double HT_deltax, int &HTtoCAra
             std::string ReadLine;
             if (!getline(TemperatureFile, ReadLine))
                 break;
-            splitString(ReadLine, ParsedLine);
+            splitString(ReadLine, ParsedLine, 5);
             // Only get x and y values from ParsedLine, for now
             double XTemperaturePoint = getInputDouble(ParsedLine[0]);
             double YTemperaturePoint = getInputDouble(ParsedLine[1]);
@@ -1181,7 +1181,7 @@ void OrientationInit(int, int &NGrainOrientations, ViewF &GrainOrientationData, 
         std::string ReadLine;
         if (!getline(O, ReadLine))
             break;
-        splitString(ReadLine, ParsedLine);
+        splitString(ReadLine, ParsedLine, ValsPerLine - 1);
         // Place the 3 grain orientation angles or 9 rotation matrix components into the orientation data view
         for (int Comp = 0; Comp < ValsPerLine; Comp++) {
             GrainOrientationData_Host(ValsPerLine * i + Comp) = getInputFloat(ParsedLine[Comp]);

--- a/src/CAparsefiles.cpp
+++ b/src/CAparsefiles.cpp
@@ -123,18 +123,13 @@ double getInputDouble(std::string val_input, int factor = 0) {
 
 // Given a string ("line"), parse at "separator" (commas used by default)
 // Modifies "parsed_line" to hold the comma separated values
-void splitString(std::string line, std::vector<std::string> &parsed_line, std::string separator = ",",
-                 int expected_num_commas = -1) {
+// expected_num_commas may be larger than the size of parsed_line, if only a portion of the line is being parsed
+void splitString(std::string line, std::vector<std::string> &parsed_line, int expected_num_commas,
+                 char separator = ',') {
     std::size_t line_size = parsed_line.size();
     // If reading a comma-separated line, make sure the right number of commas are present
-    if (separator == ",") {
-        int num_commas = std::count(line.begin(), line.end(), ',');
-        // If expected_num_commas was not given (i.e., is the default value of -1), it is equivalent to one less than
-        // the number of elements in parsed_line
-        if (expected_num_commas == -1)
-            expected_num_commas = line_size - 1;
-        // If expected_num_commas is given, we are only parsing some of the line, so the size of parsed_line is
-        // unrelated
+    if (separator == ',') {
+        int num_commas = std::count(line.begin(), line.end(), separator);
         if (expected_num_commas > num_commas) {
             std::string error = "Error: Expected " + std::to_string(line_size - 1) +
                                 " commas while reading file; but " + std::to_string(num_commas) + " were found";
@@ -155,7 +150,7 @@ void checkForHeaderValues(std::string header_line) {
     // Header values from file
     std::size_t header_size = 6;
     std::vector<std::string> header_values(header_size, "");
-    splitString(header_line, header_values);
+    splitString(header_line, header_values, 5);
 
     std::vector<std::vector<std::string>> expected_values = {{"x"}, {"y"}, {"z"}, {"tm"}, {"tl", "ts"}, {"r", "cr"}};
 

--- a/src/CAparsefiles.cpp
+++ b/src/CAparsefiles.cpp
@@ -124,12 +124,12 @@ double getInputDouble(std::string val_input, int factor = 0) {
 // Given a string ("line"), parse at "separator" (commas used by default)
 // Modifies "parsed_line" to hold the comma separated values
 // expected_num_commas may be larger than the size of parsed_line, if only a portion of the line is being parsed
-void splitString(std::string line, std::vector<std::string> &parsed_line, int expected_num_commas,
+void splitString(std::string line, std::vector<std::string> &parsed_line, int expected_num_values,
                  char separator = ',') {
     std::size_t line_size = parsed_line.size();
     // Make sure the right number of commas are present
     int num_commas = std::count(line.begin(), line.end(), separator);
-    if (expected_num_commas > num_commas) {
+    if (expected_num_values > num_commas) {
         std::string error = "Error: Expected " + std::to_string(line_size - 1) + " commas while reading file; but " +
                             std::to_string(num_commas) + " were found";
         throw std::runtime_error(error);

--- a/src/CAparsefiles.cpp
+++ b/src/CAparsefiles.cpp
@@ -127,14 +127,12 @@ double getInputDouble(std::string val_input, int factor = 0) {
 void splitString(std::string line, std::vector<std::string> &parsed_line, int expected_num_commas,
                  char separator = ',') {
     std::size_t line_size = parsed_line.size();
-    // If reading a comma-separated line, make sure the right number of commas are present
-    if (separator == ',') {
-        int num_commas = std::count(line.begin(), line.end(), separator);
-        if (expected_num_commas > num_commas) {
-            std::string error = "Error: Expected " + std::to_string(line_size - 1) +
-                                " commas while reading file; but " + std::to_string(num_commas) + " were found";
-            throw std::runtime_error(error);
-        }
+    // Make sure the right number of commas are present
+    int num_commas = std::count(line.begin(), line.end(), separator);
+    if (expected_num_commas > num_commas) {
+        std::string error = "Error: Expected " + std::to_string(line_size - 1) + " commas while reading file; but " +
+                            std::to_string(num_commas) + " were found";
+        throw std::runtime_error(error);
     }
     for (std::size_t n = 0; n < line_size - 1; n++) {
         std::size_t pos = line.find(separator);

--- a/src/CAparsefiles.cpp
+++ b/src/CAparsefiles.cpp
@@ -122,24 +122,25 @@ double getInputDouble(std::string val_input, int factor = 0) {
 }
 
 // Given a string ("line"), parse at "separator" (commas used by default)
-// Modifies "parsed_line" to hold the comma separated values
-// expected_num_commas may be larger than the size of parsed_line, if only a portion of the line is being parsed
+// Modifies "parsed_line" to hold the separated values
+// expected_num_values may be larger than parsed_line_size, if only a portion of the line is being parsed
 void splitString(std::string line, std::vector<std::string> &parsed_line, int expected_num_values,
                  char separator = ',') {
-    std::size_t line_size = parsed_line.size();
-    // Make sure the right number of commas are present
-    int num_commas = std::count(line.begin(), line.end(), separator);
-    if (expected_num_values > num_commas) {
-        std::string error = "Error: Expected " + std::to_string(line_size - 1) + " commas while reading file; but " +
-                            std::to_string(num_commas) + " were found";
+    // Make sure the right number of values are present on the line - one more than the number of separators
+    int actual_num_values = std::count(line.begin(), line.end(), separator) + 1;
+    if (expected_num_values != actual_num_values) {
+        std::string error = "Error: Expected " + std::to_string(expected_num_values) +
+                            " values while reading file; but " + std::to_string(actual_num_values) + " were found";
         throw std::runtime_error(error);
     }
-    for (std::size_t n = 0; n < line_size - 1; n++) {
+    // Separate the line into its components, now that the number of values has been checked
+    std::size_t parsed_line_size = parsed_line.size();
+    for (std::size_t n = 0; n < parsed_line_size - 1; n++) {
         std::size_t pos = line.find(separator);
         parsed_line[n] = removeWhitespace(line.substr(0, pos));
         line = line.substr(pos + 1, std::string::npos);
     }
-    parsed_line[line_size - 1] = removeWhitespace(line);
+    parsed_line[parsed_line_size - 1] = removeWhitespace(line);
 }
 
 // Check to make sure that all expected column names appear in the header for this temperature file
@@ -148,7 +149,7 @@ void checkForHeaderValues(std::string header_line) {
     // Header values from file
     std::size_t header_size = 6;
     std::vector<std::string> header_values(header_size, "");
-    splitString(header_line, header_values, 5);
+    splitString(header_line, header_values, 6);
 
     std::vector<std::vector<std::string>> expected_values = {{"x"}, {"y"}, {"z"}, {"tm"}, {"tl", "ts"}, {"r", "cr"}};
 

--- a/src/CAparsefiles.hpp
+++ b/src/CAparsefiles.hpp
@@ -19,7 +19,8 @@ bool getInputBool(std::string val_input);
 int getInputInt(std::string val_input);
 float getInputFloat(std::string val_input, int factor = 0);
 double getInputDouble(std::string val_input, int factor = 0);
-void splitString(std::string line, std::vector<std::string> &parsed_line, std::string separator = ",");
+void splitString(std::string line, std::vector<std::string> &parsed_line, std::string separator = ",",
+                 int expected_num_commas = -1);
 void checkForHeaderValues(std::string header_line);
 void getTemperatureDataPoint(std::string s, std::vector<double> &XYZTemperaturePoint);
 void parseTemperatureInput_Old(std::vector<std::string> DeprecatedInputs, std::vector<std::string> DeprecatedInputsRead,

--- a/src/CAparsefiles.hpp
+++ b/src/CAparsefiles.hpp
@@ -35,6 +35,5 @@ void checkFileNotEmpty(std::string testfilename);
 void parseMaterialFile(std::string MaterialFile, double &AConst, double &BConst, double &CConst, double &DConst,
                        double &FreezingRange);
 std::string parseCoordinatePair(std::string line, int val);
-void parseCommaSeparatedArgs(std::string AnalysisFile, std::string ReadLine, std::vector<std::string> &ParsedLine);
 
 #endif

--- a/src/CAparsefiles.hpp
+++ b/src/CAparsefiles.hpp
@@ -19,8 +19,8 @@ bool getInputBool(std::string val_input);
 int getInputInt(std::string val_input);
 float getInputFloat(std::string val_input, int factor = 0);
 double getInputDouble(std::string val_input, int factor = 0);
-void splitString(std::string line, std::vector<std::string> &parsed_line, std::string separator = ",",
-                 int expected_num_commas = -1);
+void splitString(std::string line, std::vector<std::string> &parsed_line, int expected_num_commas,
+                 char separator = ',');
 void checkForHeaderValues(std::string header_line);
 void getTemperatureDataPoint(std::string s, std::vector<double> &XYZTemperaturePoint);
 void parseTemperatureInput_Old(std::vector<std::string> DeprecatedInputs, std::vector<std::string> DeprecatedInputsRead,

--- a/src/CAparsefiles.hpp
+++ b/src/CAparsefiles.hpp
@@ -19,7 +19,7 @@ bool getInputBool(std::string val_input);
 int getInputInt(std::string val_input);
 float getInputFloat(std::string val_input, int factor = 0);
 double getInputDouble(std::string val_input, int factor = 0);
-void splitString(std::string line, std::vector<std::string> &parsed_line, int expected_num_commas,
+void splitString(std::string line, std::vector<std::string> &parsed_line, int expected_num_values,
                  char separator = ',');
 void checkForHeaderValues(std::string header_line);
 void getTemperatureDataPoint(std::string s, std::vector<double> &XYZTemperaturePoint);


### PR DESCRIPTION
Replaced usage of the (slow) parseCommaSeparatedArgs function by expanding the functionality of the splitString function (fast).

Fixup of #81 