### PR TITLE
Added ability to control powder layer site density

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -74,7 +74,7 @@ Some additional inputs are optional while others are required
 | Density of powder surface sites active | See note (b) | Density of sites in the powder layer to be assigned as the home of a unique grain, normalized by 1 x 10^12 m^-3 (default value is 1/(CA cell size ^3)
 
 (a) One of these inputs must be provided, but not both
-(b) This is optional, but if this is given, Extend baseplate through layers must be set to N
+(b) This is optional, but if this is given, "Extend baseplate through layers" must be set to N
 
 ### Problem type R
 Some additional inputs are optional while others are required

--- a/examples/README.md
+++ b/examples/README.md
@@ -74,7 +74,7 @@ Some additional inputs are optional while others are required
 | Density of powder surface sites active | See note (b) | Density of sites in the powder layer to be assigned as the home of a unique grain, normalized by 1 x 10^12 m^-3 (default value is 1/(CA cell size ^3)
 
 (a) One of these inputs must be provided, but not both
-(b) This is optional, but if this is given, Density of powder surface sites active must be set to N
+(b) This is optional, but if this is given, Extend baseplate through layers must be set to N
 
 ### Problem type R
 Some additional inputs are optional while others are required
@@ -90,7 +90,7 @@ Some additional inputs are optional while others are required
 | Density of powder surface sites active                      | See note (b) | Density of sites in the powder layer to be assigned as the home of a unique grain, normalized by 1 x 10^12 m^-3 (default value is 1/(CA cell size ^3)
 
 (a) One of these inputs must be provided, but not both
-(b) This is optional, but if this is given, Density of powder surface sites active must be set to N
+(b) This is optional, but if this is given, Extend baseplate through layers must be set to N
 
 The input "Extra set of wall cells", used in previous versions of ExaCA to create a set of wall cells "padding" the temperature data at the domain's X and Y boundaries, is deprecated and no longer has an effect.
 Additional information regarding the temperature field is provided inside the auxiliary file specified on the "Path to and name of temperature field assembly instructions" line. A temperature field construction file contains the following additional specifications:

--- a/examples/README.md
+++ b/examples/README.md
@@ -55,33 +55,42 @@ All inputs are required.
 | Fraction surface sites active| What fraction of cells at the bottom surface of the domain are the source of a grain?
 
 ### Problem type S
-All inputs are required - with the exception of sub grain size and sub filename: one of the two should be provided, but not both.
+Some additional inputs are optional while others are required
 
-|Input                       | Details |
-|----------------------------|---------|
-| Thermal gradient  | Thermal gradient in each hemispherical spot, in K/m
-| Cooling rate      | Cooling rate (uniform for each spot), in K/s
-| Time step ratio   | Used to set the time step: time step = cell size/(cooling rate/thermal gradient) x N)
-| Number of spots in x    | Number of spots in the x direction
-| Number of spots in y    | Number of spots in the y direction
-| Offset between spot centers | Offset of spot centers along the x and y axes, in microns
-| Radii of spots    | Spot radii, in microns
-| Number of layers  | Number of times this pattern is repeated, offset in the +Z (build) direction
-| Offset between layers | If Number of layers > 1, the number of CA cells should separate adjacent layers
-| Substrate grain spacing | Mean spacing between grain centers in the baseplate/substrate (in microns)
-| Substrate filename| Filename for substrate data (either this OR Sub grain size should be provided, but not both)
+|Input                                   | Required Y/N | Details |
+|----------------------------------------|--------------|---------|
+| Thermal gradient                       | Y            | Thermal gradient in each hemispherical spot, in K/m
+| Cooling rate                           | Y            | Cooling rate (uniform for each spot), in K/s
+| Time step ratio                        | Y            | Used to set the time step: time step = cell size/(cooling rate/thermal gradient) x N)
+| Number of spots in x                   | Y            | Number of spots in the x direction
+| Number of spots in y                   | Y            | Number of spots in the y direction
+| Offset between spot centers            | Y            | Offset of spot centers along the x and y axes, in microns
+| Radii of spots                         | Y            | Spot radii, in microns
+| Number of layers                       | Y            | Number of times this pattern is repeated, offset in the +Z (build) direction
+| Offset between layers                  | Y            | If Number of layers > 1, the number of CA cells should separate adjacent layers
+| Substrate grain spacing                | See note (a) | Mean spacing between grain centers in the baseplate/substrate (in microns)
+| Substrate filename                     | See note (a) | Path to and filename for substrate data
+| Extend baseplate through layers        | N            | Value should be Y or N: Whether to use the baseplate microstructure as the boundary condition for the entire height of the simulation (default value is N)
+| Density of powder surface sites active | See note (b) | Density of sites in the powder layer to be assigned as the home of a unique grain, normalized by 1 x 10^12 m^-3 (default value is 1/(CA cell size ^3)
 
+(a) One of these inputs must be provided, but not both
+(b) This is optional, but if this is given, Density of powder surface sites active must be set to N
 
 ### Problem type R
-Some additional inputs are optional while others are required. As was the case for Problem type S, sub grain size and sub filename are both optional inputs, but one of the two must be provided.
+Some additional inputs are optional while others are required
 
-|Input              | Required Y/N | Details |
-|-------------------| - |---------|
-| Substrate grain spacing | Y/N | Mean spacing between grain centers in the baseplate/substrate (in microns) (either this OR Sub filename should be given, but not both)
-| Substrate filename      | Y/N | Filename (including path) for substrate data (either this OR Sub grain size should be provided, but not both)
-| Time step         | Y | CA time step, in microseconds
-| Path to and name of temperature field assembly instructions | Y | Additional file containing information on the temperature data
-| default RVE output | N | Whether or not to print representative volume element (RVE) data for ExaConstit, for a 0.5 cubic mm region in the domain center in X and Y, and at the domain top in Z excluding the final layer's grain structure
+|Input                                                        | Required Y/N | Details |
+|-------------------------------------------------------------| -------------|---------|
+| Substrate grain spacing                                     | See note (a) | Mean spacing between grain centers in the baseplate/substrate (in microns)
+| Substrate filename                                          | See note (a) | Path to and filename for substrate data
+| Time step                                                   | Y            | CA time step, in microseconds
+| Path to and name of temperature field assembly instructions | Y            | Additional file containing information on the temperature data
+| default RVE output                                          | N            | Whether or not to print representative volume element (RVE) data for ExaConstit, for a 0.5 cubic mm region in the domain center in X and Y, and at the domain top in Z excluding the final layer's grain structure
+| Extend baseplate through layers                             | N            | Value should be Y or N: Whether to use the baseplate microstructure as the boundary condition for the entire height of the simulation (default value is N)
+| Density of powder surface sites active                      | See note (b) | Density of sites in the powder layer to be assigned as the home of a unique grain, normalized by 1 x 10^12 m^-3 (default value is 1/(CA cell size ^3)
+
+(a) One of these inputs must be provided, but not both
+(b) This is optional, but if this is given, Density of powder surface sites active must be set to N
 
 The input "Extra set of wall cells", used in previous versions of ExaCA to create a set of wall cells "padding" the temperature data at the domain's X and Y boundaries, is deprecated and no longer has an effect.
 Additional information regarding the temperature field is provided inside the auxiliary file specified on the "Path to and name of temperature field assembly instructions" line. A temperature field construction file contains the following additional specifications:

--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -268,8 +268,8 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
                 throw std::runtime_error("Error: Density of powder surface sites active must be larger than 0 and less "
                                          "than 1/(CA cell volume)");
             if (BaseplateThroughPowder)
-                throw std::runtime_error("Error: if the option to extend the baseplate through the powder layers it "
-                                         "toggled, a powder density cannot be given");
+                throw std::runtime_error("Error: if the option to extend the baseplate through through all powder "
+                                         "layers is turned on, a powder density cannot be given");
         }
         if (id == 0) {
             std::cout << "CA Simulation using temperature data from file(s)" << std::endl;

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -23,7 +23,7 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
                        int &PrintDebug, bool &PrintMisorientation, bool &PrintFinalUndercoolingVals,
                        bool &PrintFullOutput, int &NSpotsX, int &NSpotsY, int &SpotOffset, int &SpotRadius,
                        bool &PrintTimeSeries, int &TimeSeriesInc, bool &PrintIdleTimeSeriesFrames,
-                       bool &PrintDefaultRVE, double &RNGSeed);
+                       bool &PrintDefaultRVE, double &RNGSeed, bool &BaseplateThroughPowder, double &PowderDensity);
 void NeighborListInit(NList &NeighborX, NList &NeighborY, NList &NeighborZ);
 void FindXYZBounds(std::string SimulationType, int id, double &deltax, int &nx, int &ny, int &nz,
                    std::vector<std::string> &temp_paths, float &XMin, float &XMax, float &YMin, float &YMax,
@@ -100,13 +100,14 @@ void SubstrateInit_ConstrainedGrowth(int id, double FractSurfaceSitesActive, int
                                      int BufSizeY, bool AtNorthBoundary, bool AtSouthBoundary, bool AtEastBoundary,
                                      bool AtWestBoundary);
 void SubstrateInit_FromFile(std::string SubstrateFileName, int nz, int MyXSlices, int MyYSlices, int MyXOffset,
-                            int MyYOffset, int pid, ViewI &GrainID);
+                            int MyYOffset, int pid, ViewI &GrainID, int nzActive, bool BaseplateThroughPowder);
 void BaseplateInit_FromGrainSpacing(float SubstrateGrainSpacing, int nx, int ny, float *ZMinLayer, float *ZMaxLayer,
                                     int MyXSlices, int MyYSlices, int MyXOffset, int MyYOffset, int id, double deltax,
-                                    ViewI GrainID, double RNGSeed, int &NextLayer_FirstEpitaxialGrainID);
+                                    ViewI GrainID, double RNGSeed, int &NextLayer_FirstEpitaxialGrainID, int nz,
+                                    double BaseplateThroughPowder);
 void PowderInit(int layernumber, int nx, int ny, int LayerHeight, float *ZMaxLayer, float ZMin, double deltax,
                 int MyXSlices, int MyYSlices, int MyXOffset, int MyYOffset, int id, ViewI GrainID, double RNGSeed,
-                int &NextLayer_FirstEpitaxialGrainID);
+                int &NextLayer_FirstEpitaxialGrainID, double PowderDensity);
 void CellTypeInit_Remelt(int MyXSlices, int MyYSlices, int LocalActiveDomainSize, ViewI CellType, ViewI CritTimeStep,
                          int id, int ZBound_Low);
 void CellTypeInit_NoRemelt(int layernumber, int id, int np, int DecompositionStrategy, int MyXSlices, int MyYSlices,

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -27,10 +27,10 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     unsigned int NumberOfTemperatureDataPoints = 0; // Initialized to 0 - updated if/when temperature files are read
     int PrintDebug, TimeSeriesInc;
     bool PrintMisorientation, PrintFinalUndercoolingVals, PrintFullOutput, RemeltingYN, UseSubstrateFile,
-        PrintTimeSeries, PrintIdleTimeSeriesFrames, PrintDefaultRVE;
+        PrintTimeSeries, PrintIdleTimeSeriesFrames, PrintDefaultRVE, BaseplateThroughPowder;
     float SubstrateGrainSpacing;
     double HT_deltax, deltax, deltat, FractSurfaceSitesActive, G, R, AConst, BConst, CConst, DConst, FreezingRange,
-        NMax, dTN, dTsigma, RNGSeed;
+        NMax, dTN, dTsigma, RNGSeed, PowderDensity;
     std::string SubstrateFileName, SimulationType, OutputFile, GrainOrientationFile, PathToOutput;
     std::vector<std::string> temp_paths;
 
@@ -41,7 +41,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                       SubstrateGrainSpacing, UseSubstrateFile, G, R, nx, ny, nz, FractSurfaceSitesActive, PathToOutput,
                       PrintDebug, PrintMisorientation, PrintFinalUndercoolingVals, PrintFullOutput, NSpotsX, NSpotsY,
                       SpotOffset, SpotRadius, PrintTimeSeries, TimeSeriesInc, PrintIdleTimeSeriesFrames,
-                      PrintDefaultRVE, RNGSeed);
+                      PrintDefaultRVE, RNGSeed, BaseplateThroughPowder, PowderDensity);
 
     // Grid decomposition
     int ProcessorsInXDirection, ProcessorsInYDirection;
@@ -233,11 +233,12 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     }
     else {
         if (UseSubstrateFile)
-            SubstrateInit_FromFile(SubstrateFileName, nz, MyXSlices, MyYSlices, MyXOffset, MyYOffset, id, GrainID);
+            SubstrateInit_FromFile(SubstrateFileName, nz, MyXSlices, MyYSlices, MyXOffset, MyYOffset, id, GrainID,
+                                   nzActive, BaseplateThroughPowder);
         else
             BaseplateInit_FromGrainSpacing(SubstrateGrainSpacing, nx, ny, ZMinLayer, ZMaxLayer, MyXSlices, MyYSlices,
                                            MyXOffset, MyYOffset, id, deltax, GrainID, RNGSeed,
-                                           NextLayer_FirstEpitaxialGrainID);
+                                           NextLayer_FirstEpitaxialGrainID, nz, BaseplateThroughPowder);
         // Separate routine for active cell data structure init for problems other than constrained solidification
         if (RemeltingYN)
             CellTypeInit_Remelt(MyXSlices, MyYSlices, LocalActiveDomainSize, CellType, CritTimeStep, id, ZBound_Low);
@@ -490,9 +491,9 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
             // If the baseplate was initialized from a substrate grain spacing, initialize powder layer grain structure
             // for the next layer "layernumber + 1" Otherwise, the entire substrate (baseplate + powder) was read from a
             // file, and the powder layers have already been initialized
-            if (!(UseSubstrateFile))
+            if ((!(UseSubstrateFile)) && (!(BaseplateThroughPowder)))
                 PowderInit(layernumber + 1, nx, ny, LayerHeight, ZMaxLayer, ZMin, deltax, MyXSlices, MyYSlices,
-                           MyXOffset, MyYOffset, id, GrainID, RNGSeed, NextLayer_FirstEpitaxialGrainID);
+                           MyXOffset, MyYOffset, id, GrainID, RNGSeed, NextLayer_FirstEpitaxialGrainID, PowderDensity);
 
             // Initialize active cell data structures and nuclei locations for the next layer "layernumber + 1"
             if (RemeltingYN)

--- a/unit_test/tstInit.cpp
+++ b/unit_test/tstInit.cpp
@@ -147,6 +147,7 @@ void testInputReadFromFile() {
             TestDataFile << "Print default RVE output: Y" << std::endl;
             TestDataFile << "Print file of all ExaCA data: N" << std::endl;
             TestDataFile << "Time step: 1.5" << std::endl;
+            TestDataFile << "Density of powder surface sites active: 1000" << std::endl;
             if (n == 2) {
                 // Deprecated temperature input lines
                 TestDataFile << "Path to temperature file(s): ./" << std::endl;
@@ -199,19 +200,19 @@ void testInputReadFromFile() {
             NSpotsY, SpotOffset, SpotRadius, TimeSeriesInc;
         float SubstrateGrainSpacing;
         double AConst, BConst, CConst, DConst, FreezingRange, deltax, NMax, dTN, dTsigma, HT_deltax, deltat, G, R,
-            FractSurfaceSitesActive, RNGSeed;
+            FractSurfaceSitesActive, RNGSeed, PowderDensity;
         bool RemeltingYN, PrintMisorientation, PrintFinalUndercoolingVals, PrintFullOutput, PrintTimeSeries,
-            UseSubstrateFile, PrintIdleTimeSeriesFrames, PrintDefaultRVE = false;
+            UseSubstrateFile, PrintIdleTimeSeriesFrames, PrintDefaultRVE = false, BaseplateThroughPowder;
         std::string SimulationType, OutputFile, GrainOrientationFile, temppath, tempfile, SubstrateFileName,
             PathToOutput;
         std::vector<std::string> temp_paths;
-        InputReadFromFile(id, FileName, SimulationType, DecompositionStrategy, AConst, BConst, CConst, DConst,
-                          FreezingRange, deltax, NMax, dTN, dTsigma, OutputFile, GrainOrientationFile,
-                          TempFilesInSeries, temp_paths, HT_deltax, RemeltingYN, deltat, NumberOfLayers, LayerHeight,
-                          SubstrateFileName, SubstrateGrainSpacing, UseSubstrateFile, G, R, nx, ny, nz,
-                          FractSurfaceSitesActive, PathToOutput, PrintDebug, PrintMisorientation,
-                          PrintFinalUndercoolingVals, PrintFullOutput, NSpotsX, NSpotsY, SpotOffset, SpotRadius,
-                          PrintTimeSeries, TimeSeriesInc, PrintIdleTimeSeriesFrames, PrintDefaultRVE, RNGSeed);
+        InputReadFromFile(
+            id, FileName, SimulationType, DecompositionStrategy, AConst, BConst, CConst, DConst, FreezingRange, deltax,
+            NMax, dTN, dTsigma, OutputFile, GrainOrientationFile, TempFilesInSeries, temp_paths, HT_deltax, RemeltingYN,
+            deltat, NumberOfLayers, LayerHeight, SubstrateFileName, SubstrateGrainSpacing, UseSubstrateFile, G, R, nx,
+            ny, nz, FractSurfaceSitesActive, PathToOutput, PrintDebug, PrintMisorientation, PrintFinalUndercoolingVals,
+            PrintFullOutput, NSpotsX, NSpotsY, SpotOffset, SpotRadius, PrintTimeSeries, TimeSeriesInc,
+            PrintIdleTimeSeriesFrames, PrintDefaultRVE, RNGSeed, BaseplateThroughPowder, PowderDensity);
 
         // Check the results
         // The existence of the specified orientation, substrate, and temperature filenames was already checked within
@@ -260,6 +261,7 @@ void testInputReadFromFile() {
             EXPECT_EQ(NumberOfLayers, 2);
             EXPECT_EQ(LayerHeight, 20);
             EXPECT_FALSE(UseSubstrateFile);
+            EXPECT_FALSE(BaseplateThroughPowder);
             EXPECT_FLOAT_EQ(SubstrateGrainSpacing, 25.0);
             EXPECT_TRUE(OutputFile == "TestProblemSpot");
             EXPECT_FALSE(PrintFinalUndercoolingVals);
@@ -272,6 +274,8 @@ void testInputReadFromFile() {
             EXPECT_EQ(NumberOfLayers, 2);
             EXPECT_EQ(LayerHeight, 1);
             EXPECT_TRUE(UseSubstrateFile);
+            EXPECT_FALSE(BaseplateThroughPowder);
+            EXPECT_DOUBLE_EQ(PowderDensity, 0.001);
             if (FileName == "Inp_TemperatureTest_Old.txt")
                 EXPECT_DOUBLE_EQ(HT_deltax, 12.0 * pow(10, -6));
             else

--- a/unit_test/tstKokkosInit.hpp
+++ b/unit_test/tstKokkosInit.hpp
@@ -216,7 +216,7 @@ void testBaseplateInit_FromGrainSpacing() {
     ViewI GrainID("GrainID_Device", LocalDomainSize);
 
     BaseplateInit_FromGrainSpacing(SubstrateGrainSpacing, nx, ny, ZMinLayer, ZMaxLayer, MyXSlices, MyYSlices, MyXOffset,
-                                   MyYOffset, id, deltax, GrainID, RNGSeed, NextLayer_FirstEpitaxialGrainID);
+                                   MyYOffset, id, deltax, GrainID, RNGSeed, NextLayer_FirstEpitaxialGrainID, nz, false);
 
     // Copy results back to host to check
     ViewI_H GrainID_H = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), GrainID);
@@ -272,7 +272,7 @@ void testPowderInit() {
     double RNGSeed = 0.0;
 
     PowderInit(layernumber, nx, ny, LayerHeight, ZMaxLayer, ZMin, deltax, MyXSlices, MyYSlices, MyXOffset, MyYOffset,
-               id, GrainID, RNGSeed, NextLayer_FirstEpitaxialGrainID);
+               id, GrainID, RNGSeed, NextLayer_FirstEpitaxialGrainID, 1.0);
 
     // Copy results back to host to check
     ViewI_H GrainID_H = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), GrainID);


### PR DESCRIPTION
Added options for initialization of powder layer: 
* If not reading substrate data from a file, the user can optionally set a density of cells in the powder layer to be assigned GrainIDs (default is that all cells in the powder layer are assigned GrainIDs, for consistency with master)
* If reading substrate data from a file, the user alternatively choose to use portions of the read substrate grain structure as the grain structure in the powder layer