### PR TITLE
Move powder overflow check to after nx, ny, nz are known

### DIFF
--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -342,16 +342,7 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
             std::cout << "The time step is " << deltat * pow(10, 6) << " microseconds" << std::endl;
         }
     }
-    // If this problem type includes a powder layer of some grain density, ensure that integer overflow won't occur when
-    // assigning powder layer GrainIDs
-    if (((SimulationType == "R") || (SimulationType == "S")) && (!(BaseplateThroughPowder))) {
-        long int NumCellsPowderLayers =
-            (long int)(nx) * (long int)(ny) * (long int)(LayerHeight) * (long int)(NumberOfLayers - 1);
-        long int NumAssignedCellsPowderLayers = std::lround((double)(NumCellsPowderLayers)*PowderDensity);
-        if (NumAssignedCellsPowderLayers > INT_MAX)
-            throw std::runtime_error("Error: A smaller value for powder density is required to avoid potential integer "
-                                     "overflow when assigning powder layer GrainID");
-    }
+
     // Optional inputs - should files post-initialization be printed for debugging?
     bool PrintDebugA = false;
     bool PrintDebugB = false;
@@ -479,6 +470,22 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
         if (RemeltingYN)
             std::cout << "This simulation includes logic for cells melting and multiple solidification events"
                       << std::endl;
+    }
+}
+
+void checkPowderOverflow(int nx, int ny, int LayerHeight, int NumberOfLayers, bool BaseplateThroughPowder,
+                         double PowderDensity) {
+
+    // Check to make sure powder grain density is compatible with the number of powder sites
+    // If this problem type includes a powder layer of some grain density, ensure that integer overflow won't occur when
+    // assigning powder layer GrainIDs
+    if (!(BaseplateThroughPowder)) {
+        long int NumCellsPowderLayers =
+            (long int)(nx) * (long int)(ny) * (long int)(LayerHeight) * (long int)(NumberOfLayers - 1);
+        long int NumAssignedCellsPowderLayers = std::lround((double)(NumCellsPowderLayers)*PowderDensity);
+        if (NumAssignedCellsPowderLayers > INT_MAX)
+            throw std::runtime_error("Error: A smaller value for powder density is required to avoid potential integer "
+                                     "overflow when assigning powder layer GrainID");
     }
 }
 

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -24,6 +24,8 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
                        bool &PrintFullOutput, int &NSpotsX, int &NSpotsY, int &SpotOffset, int &SpotRadius,
                        bool &PrintTimeSeries, int &TimeSeriesInc, bool &PrintIdleTimeSeriesFrames,
                        bool &PrintDefaultRVE, double &RNGSeed, bool &BaseplateThroughPowder, double &PowderDensity);
+void checkPowderOverflow(int nx, int ny, int LayerHeight, int NumberOfLayers, bool BaseplateThroughPowder,
+                         double PowderDensity);
 void NeighborListInit(NList &NeighborX, NList &NeighborY, NList &NeighborZ);
 void FindXYZBounds(std::string SimulationType, int id, double &deltax, int &nx, int &ny, int &nz,
                    std::vector<std::string> &temp_paths, float &XMin, float &XMax, float &YMin, float &YMax,

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -82,6 +82,10 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     FindXYZBounds(SimulationType, id, deltax, nx, ny, nz, temp_paths, XMin, XMax, YMin, YMax, ZMin, ZMax, LayerHeight,
                   NumberOfLayers, TempFilesInSeries, ZMinLayer, ZMaxLayer, SpotRadius);
 
+    // Ensure that input powder layer init options are compatible with this domain size, if needed for this problem type
+    if ((SimulationType == "R") || (SimulationType == "S"))
+        checkPowderOverflow(nx, ny, LayerHeight, NumberOfLayers, BaseplateThroughPowder, PowderDensity);
+
     // Decompose the domain into subdomains on each MPI rank: Each subdomain contains "MyXSlices" cells in X, and
     // "MyYSlices" in Y. Each subdomain is offset from the full domain origin by "MyXOffset" cells in X, and "MyYOffset"
     // cells in Y


### PR DESCRIPTION
nx, ny, and nz must be known before checking to see if the size of the powder layers exceeds the max possible int for GrainID - previously, this was not true for simulations using Problem type R and default powder layer initialization