### PR TITLE
Allow printing of any RVE size without analysis script

### DIFF
--- a/examples/Inp_WorkflowExample.txt
+++ b/examples/Inp_WorkflowExample.txt
@@ -18,6 +18,8 @@ Print file of grain misorientation values: N
 Print file of all ExaCA data: Y
 Debug check (reduced): N
 Debug check (extensive): N
+Print default RVE output: Y
+Default RVE size, in CA cells: 100
 ***Intermediate output printing as a time series of vtk files (these can be read as a movie by Paraview)***
 Print intermediate output frames: N
 Increment to separate frames: 0

--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -34,7 +34,8 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
                        int &PrintDebug, bool &PrintMisorientation, bool &PrintFinalUndercoolingVals,
                        bool &PrintFullOutput, int &NSpotsX, int &NSpotsY, int &SpotOffset, int &SpotRadius,
                        bool &PrintTimeSeries, int &TimeSeriesInc, bool &PrintIdleTimeSeriesFrames,
-                       bool &PrintDefaultRVE, double &RNGSeed, bool &BaseplateThroughPowder, double &PowderDensity) {
+                       bool &PrintDefaultRVE, double &RNGSeed, bool &BaseplateThroughPowder, double &PowderDensity,
+                       int &RVESize) {
 
     // Required inputs that should be present in the input file, regardless of problem type
     std::vector<std::string> RequiredInputs_General = {
@@ -126,12 +127,13 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
         RequiredInputs_ProblemSpecific.resize(2);
         RequiredInputs_ProblemSpecific[0] = "Time step";
         RequiredInputs_ProblemSpecific[1] = "Path to and name of temperature field assembly instructions";
-        OptionalInputs_ProblemSpecific.resize(5);
+        OptionalInputs_ProblemSpecific.resize(6);
         OptionalInputs_ProblemSpecific[0] = "Substrate grain spacing";
         OptionalInputs_ProblemSpecific[1] = "Substrate filename";
         OptionalInputs_ProblemSpecific[2] = "default RVE output";
         OptionalInputs_ProblemSpecific[3] = "Extend baseplate through layers";
         OptionalInputs_ProblemSpecific[4] = "Density of powder surface sites active";
+        OptionalInputs_ProblemSpecific[5] = "Default RVE size, in CA cells";
         DeprecatedInputs_ProblemSpecific.resize(7);
         DeprecatedInputs_ProblemSpecific[0] = "Path to temperature file(s)";
         DeprecatedInputs_ProblemSpecific[1] = "Temperature filename";
@@ -439,6 +441,14 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
         PrintDefaultRVE = false;
         if (!(OptionalInputsRead_ProblemSpecific[2].empty()))
             PrintDefaultRVE = getInputBool(OptionalInputsRead_ProblemSpecific[2]);
+        // If printing RVE data, specify RVE size (in cells per side). Otherwise, RVE is 0.5 mm per side
+        if (!(OptionalInputsRead_ProblemSpecific[5].empty()))
+            RVESize = getInputInt(OptionalInputsRead_ProblemSpecific[5]);
+        else
+            RVESize = 0.0005 / deltax;
+        if ((id == 0) && (PrintDefaultRVE))
+            std::cout << "RVE data from a default location in the simulation will be printed, consisting of " << RVESize
+                      << " cells per side" << std::endl;
     }
     else {
         // RVE data print option is only for simulation type R

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -23,7 +23,8 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
                        int &PrintDebug, bool &PrintMisorientation, bool &PrintFinalUndercoolingVals,
                        bool &PrintFullOutput, int &NSpotsX, int &NSpotsY, int &SpotOffset, int &SpotRadius,
                        bool &PrintTimeSeries, int &TimeSeriesInc, bool &PrintIdleTimeSeriesFrames,
-                       bool &PrintDefaultRVE, double &RNGSeed, bool &BaseplateThroughPowder, double &PowderDensity);
+                       bool &PrintDefaultRVE, double &RNGSeed, bool &BaseplateThroughPowder, double &PowderDensity,
+                       int &RVESize);
 void checkPowderOverflow(int nx, int ny, int LayerHeight, int NumberOfLayers, bool BaseplateThroughPowder,
                          double PowderDensity);
 void NeighborListInit(NList &NeighborX, NList &NeighborY, NList &NeighborZ);

--- a/src/CAprint.cpp
+++ b/src/CAprint.cpp
@@ -177,7 +177,7 @@ void PrintExaCAData(int id, int layernumber, int np, int nx, int ny, int nz, int
                     int NGrainOrientations, bool *Melted, std::string PathToOutput, int PrintDebug,
                     bool PrintMisorientation, bool PrintFinalUndercoolingVals, bool PrintFullOutput,
                     bool PrintTimeSeries, bool PrintDefaultRVE, int IntermediateFileCounter, int ZBound_Low,
-                    int nzActive, double deltax, float XMin, float YMin, float ZMin, int NumberOfLayers) {
+                    int nzActive, double deltax, float XMin, float YMin, float ZMin, int NumberOfLayers, int RVESize) {
 
     if (id == 0) {
         // Message sizes and data offsets for data recieved from other ranks- message size different for different ranks
@@ -275,7 +275,7 @@ void PrintExaCAData(int id, int layernumber, int np, int nx, int ny, int nz, int
                                    UndercoolingCurrent_WholeDomain, deltax, XMin, YMin, ZMin);
         if (PrintDefaultRVE)
             PrintExaConstitDefaultRVE(BaseFileName, PathToOutput, nx, ny, nz, LayerID_WholeDomain, GrainID_WholeDomain,
-                                      deltax, NumberOfLayers);
+                                      deltax, NumberOfLayers, RVESize);
         if ((PrintFullOutput) || (PrintDebug > 0))
             PrintCAFields(nx, ny, nz, GrainID_WholeDomain, LayerID_WholeDomain, CritTimeStep_WholeDomain,
                           CellType_WholeDomain, UndercoolingChange_WholeDomain, UndercoolingCurrent_WholeDomain,
@@ -565,16 +565,13 @@ void PrintFinalUndercooling(std::string BaseFileName, std::string PathToOutput, 
 // microstructure, and centered in the simulation domain in X and Y Default RVE size is 0.5 by 0.5 by 0.5 mm
 void PrintExaConstitDefaultRVE(std::string BaseFileName, std::string PathToOutput, int nx, int ny, int nz,
                                ViewI3D_H LayerID_WholeDomain, ViewI3D_H GrainID_WholeDomain, double deltax,
-                               int NumberOfLayers) {
-
-    // Determine the size, in CA cells of the RVE
-    long int RVESize = std::lrint(0.0005 / deltax);
+                               int NumberOfLayers, int RVESize) {
 
     // Determine the lower and upper Y bounds of the RVE
-    long int RVE_XLow = std::floor(nx / 2) - std::floor(RVESize / 2);
-    long int RVE_XHigh = RVE_XLow + RVESize - 1;
-    long int RVE_YLow = std::floor(ny / 2) - std::floor(RVESize / 2);
-    long int RVE_YHigh = RVE_YLow + RVESize - 1;
+    int RVE_XLow = std::floor(nx / 2) - std::floor(RVESize / 2);
+    int RVE_XHigh = RVE_XLow + RVESize - 1;
+    int RVE_YLow = std::floor(ny / 2) - std::floor(RVESize / 2);
+    int RVE_YHigh = RVE_YLow + RVESize - 1;
 
     // Make sure the RVE fits in the simulation domain in X and Y
     if ((RVE_XLow < 0) || (RVE_XHigh > nx - 1) || (RVE_YLow < 0) || (RVE_YHigh > ny - 1)) {
@@ -592,7 +589,7 @@ void PrintExaConstitDefaultRVE(std::string BaseFileName, std::string PathToOutpu
 
     // Determine the upper Z bound of the RVE - largest Z for which all cells in the RVE do not contain LayerID values
     // of the last layer
-    long int RVE_ZHigh = nz - 1;
+    int RVE_ZHigh = nz - 1;
     for (int k = nz - 1; k >= 0; k--) {
         [&] {
             for (int i = RVE_XLow; i <= RVE_XHigh; i++) {
@@ -607,7 +604,7 @@ void PrintExaConstitDefaultRVE(std::string BaseFileName, std::string PathToOutpu
     }
 
     // Determine the lower Z bound of the RVE, and make sure the RVE fits in the simulation domain in X and Y
-    long int RVE_ZLow = RVE_ZHigh - RVESize + 1;
+    int RVE_ZLow = RVE_ZHigh - RVESize + 1;
     if (RVE_ZLow < 0) {
         std::cout << "WARNING: Simulation domain is too small to obtain default RVE data (should be at least "
                   << RVESize << " cells in the Z direction, more layers are required" << std::endl;

--- a/src/CAprint.cpp
+++ b/src/CAprint.cpp
@@ -561,8 +561,10 @@ void PrintFinalUndercooling(std::string BaseFileName, std::string PathToOutput, 
 }
 
 //*****************************************************************************/
-// Print the "default" representative volume element from this multilayer simulation, not including the final layer's
-// microstructure, and centered in the simulation domain in X and Y Default RVE size is 0.5 by 0.5 by 0.5 mm
+// Print a representative volume element (RVE) from this multilayer simulation from the "default" location in the
+// domain. The default location is as close to the center of the domain in X and Y as possible, and as close to the top
+// of the domain while not including the final layer's microstructure. If an RVE size was not specified in the input
+// file, the default size is 0.5 by 0.5 by 0.5 mm
 void PrintExaConstitDefaultRVE(std::string BaseFileName, std::string PathToOutput, int nx, int ny, int nz,
                                ViewI3D_H LayerID_WholeDomain, ViewI3D_H GrainID_WholeDomain, double deltax,
                                int NumberOfLayers, int RVESize) {

--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -12,8 +12,6 @@
 
 #include <string>
 
-void PrintGrainIDsForExaConstit(std::string FName, int nx, int ny, int nz, ViewI3D_H GrainID_WholeDomain,
-                                double deltax);
 void CollectIntField(ViewI3D_H IntVar_WholeDomain, ViewI_H IntVar, int nx, int ny, int nz, int MyXSlices, int MyYSlices,
                      int np, ViewI_H RecvXOffset, ViewI_H RecvYOffset, ViewI_H RecvXSlices, ViewI_H RecvYSlices,
                      ViewI_H RBufSize);
@@ -36,7 +34,7 @@ void PrintExaCAData(int id, int layernumber, int np, int nx, int ny, int nz, int
                     int NGrainOrientations, bool *Melted, std::string PathToOutput, int PrintDebug,
                     bool PrintMisorientation, bool PrintFinalUndercooling, bool PrintFullOutput, bool PrintTimeSeries,
                     bool PrintDefaultRVE, int IntermediateFileCounter, int ZBound_Low, int nzActive, double deltax,
-                    float XMin, float YMin, float ZMin, int NumberOfLayers);
+                    float XMin, float YMin, float ZMin, int NumberOfLayers, int RVESize = 0);
 void PrintExaCALog(int id, int np, std::string InputFile, std::string SimulationType, int DecompositionStrategy,
                    int MyXSlices, int MyYSlices, int MyXOffset, int MyYOffset, double AConst, double BConst,
                    double CConst, double DConst, double FreezingRange, double deltax, double NMax, double dTN,
@@ -61,7 +59,7 @@ void PrintFinalUndercooling(std::string BaseFileName, std::string PathToOutput, 
                             float XMin, float YMin, float ZMin);
 void PrintExaConstitDefaultRVE(std::string BaseFileName, std::string PathToOutput, int nx, int ny, int nz,
                                ViewI3D_H LayerID_WholeDomain, ViewI3D_H GrainID_WholeDomain, double deltax,
-                               int NumberOfLayers);
+                               int NumberOfLayers, int RVESize);
 void PrintIntermediateExaCAState(int IntermediateFileCounter, int layernumber, std::string BaseFileName,
                                  std::string PathToOutput, int ZBound_Low, int nzActive, int nx, int ny,
                                  ViewI3D_H GrainID_WholeDomain, ViewI3D_H CellType_WholeDomain, ViewF_H GrainUnitVector,

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -23,7 +23,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     double StartInitTime = MPI_Wtime();
 
     int nx, ny, nz, DecompositionStrategy, NumberOfLayers, LayerHeight, TempFilesInSeries;
-    int NSpotsX, NSpotsY, SpotOffset, SpotRadius, HTtoCAratio;
+    int NSpotsX, NSpotsY, SpotOffset, SpotRadius, HTtoCAratio, RVESize;
     unsigned int NumberOfTemperatureDataPoints = 0; // Initialized to 0 - updated if/when temperature files are read
     int PrintDebug, TimeSeriesInc;
     bool PrintMisorientation, PrintFinalUndercoolingVals, PrintFullOutput, RemeltingYN, UseSubstrateFile,
@@ -41,7 +41,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                       SubstrateGrainSpacing, UseSubstrateFile, G, R, nx, ny, nz, FractSurfaceSitesActive, PathToOutput,
                       PrintDebug, PrintMisorientation, PrintFinalUndercoolingVals, PrintFullOutput, NSpotsX, NSpotsY,
                       SpotOffset, SpotRadius, PrintTimeSeries, TimeSeriesInc, PrintIdleTimeSeriesFrames,
-                      PrintDefaultRVE, RNGSeed, BaseplateThroughPowder, PowderDensity);
+                      PrintDefaultRVE, RNGSeed, BaseplateThroughPowder, PowderDensity, RVESize);
 
     // Grid decomposition
     int ProcessorsInXDirection, ProcessorsInYDirection;
@@ -574,7 +574,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                        CellType, UndercoolingChange, UndercoolingCurrent, OutputFile, DecompositionStrategy,
                        NGrainOrientations, Melted, PathToOutput, 0, PrintMisorientation, PrintFinalUndercoolingVals,
                        PrintFullOutput, false, PrintDefaultRVE, 0, ZBound_Low, nzActive, deltax, XMin, YMin, ZMin,
-                       NumberOfLayers);
+                       NumberOfLayers, RVESize);
     }
     else {
         if (id == 0)

--- a/unit_test/tstInit.cpp
+++ b/unit_test/tstInit.cpp
@@ -197,7 +197,7 @@ void testInputReadFromFile() {
     // Read and parse each input file
     for (auto FileName : InputFilenames) {
         int DecompositionStrategy, TempFilesInSeries, NumberOfLayers, LayerHeight, nx, ny, nz, PrintDebug, NSpotsX,
-            NSpotsY, SpotOffset, SpotRadius, TimeSeriesInc;
+            NSpotsY, SpotOffset, SpotRadius, TimeSeriesInc, RVESize;
         float SubstrateGrainSpacing;
         double AConst, BConst, CConst, DConst, FreezingRange, deltax, NMax, dTN, dTsigma, HT_deltax, deltat, G, R,
             FractSurfaceSitesActive, RNGSeed, PowderDensity;
@@ -212,7 +212,7 @@ void testInputReadFromFile() {
             deltat, NumberOfLayers, LayerHeight, SubstrateFileName, SubstrateGrainSpacing, UseSubstrateFile, G, R, nx,
             ny, nz, FractSurfaceSitesActive, PathToOutput, PrintDebug, PrintMisorientation, PrintFinalUndercoolingVals,
             PrintFullOutput, NSpotsX, NSpotsY, SpotOffset, SpotRadius, PrintTimeSeries, TimeSeriesInc,
-            PrintIdleTimeSeriesFrames, PrintDefaultRVE, RNGSeed, BaseplateThroughPowder, PowderDensity);
+            PrintIdleTimeSeriesFrames, PrintDefaultRVE, RNGSeed, BaseplateThroughPowder, PowderDensity, RVESize);
 
         // Check the results
         // The existence of the specified orientation, substrate, and temperature filenames was already checked within

--- a/unit_test/tstPrint.hpp
+++ b/unit_test/tstPrint.hpp
@@ -32,6 +32,7 @@ void testPrintExaConstitDefaultRVE() {
     int nz = 10;
     int NumberOfLayers = 10;
     double deltax = 0.0001; // in meters
+    int RVESize = 0.0005 / deltax;
 
     // Create test data
     ViewI3D_H GrainID_WholeDomain(Kokkos::ViewAllocateWithoutInitializing("GrainID_WholeDomain"), nz, nx, ny);
@@ -47,7 +48,7 @@ void testPrintExaConstitDefaultRVE() {
 
     // Print RVE
     PrintExaConstitDefaultRVE(BaseFileName, PathToOutput, nx, ny, nz, LayerID_WholeDomain, GrainID_WholeDomain, deltax,
-                              NumberOfLayers);
+                              NumberOfLayers, RVESize);
 
     // Check printed RVE
     std::ifstream GrainplotE;


### PR DESCRIPTION
ExaCA previously only supported printing RVE data of a specific size without having to run the analysis script