### PR TITLE
Removed unused Melted variable and field

### DIFF
--- a/analysis/src/GAprint.cpp
+++ b/analysis/src/GAprint.cpp
@@ -16,7 +16,7 @@
 
 //*****************************************************************************/
 void PrintMisorientationData(bool *AnalysisTypes, std::string BaseFileName, int XMin, int XMax, int YMin, int YMax,
-                             int ZMin, int ZMax, ViewI3D_H Melted, ViewF_H GrainUnitVector, ViewI3D_H GrainID,
+                             int ZMin, int ZMax, ViewI3D_H LayerID, ViewF_H GrainUnitVector, ViewI3D_H GrainID,
                              int NumberOfOrientations) {
 
     // Frequency of misorientations in the selected region
@@ -47,8 +47,8 @@ void PrintMisorientationData(bool *AnalysisTypes, std::string BaseFileName, int 
     for (int k = ZMin; k <= ZMax; k++) {
         for (int i = XMin; i <= XMax; i++) {
             for (int j = YMin; j <= YMax; j++) {
-                // Only take data from cells in the representative area that underwent melting
-                if (Melted(k, i, j) == 1) {
+                // Only take data from cells in the representative area that underwent melting (LayerID >= 0)
+                if (LayerID(k, i, j) != -1) {
                     int MyOrientation = ((abs(GrainID(k, i, j)) - 1) % NumberOfOrientations);
                     float MyMisorientation = GrainMisorientation(MyOrientation);
                     if (AnalysisTypes[0])
@@ -308,7 +308,7 @@ void PrintGrainAreaData(bool *AnalysisTypes, std::string BaseFileName, double de
 
 //*****************************************************************************/
 void PrintPoleFigureData(bool *AnalysisTypes, std::string BaseFileName, int NumberOfOrientations, int XMin, int XMax,
-                         int YMin, int YMax, int ZMin, int ZMax, ViewI3D_H GrainID, ViewI3D_H Melted,
+                         int YMin, int YMax, int ZMin, int ZMax, ViewI3D_H GrainID, ViewI3D_H LayerID,
                          bool NewOrientationFormatYN, ViewF_H GrainEulerAngles) {
 
     if (AnalysisTypes[7]) {
@@ -319,7 +319,7 @@ void PrintPoleFigureData(bool *AnalysisTypes, std::string BaseFileName, int Numb
         for (int k = ZMin; k <= ZMax; k++) {
             for (int j = YMin; j <= YMax; j++) {
                 for (int i = XMin; i <= XMax; i++) {
-                    if (Melted(k, i, j)) {
+                    if (LayerID(k, i, j) != -1) {
                         int GOVal = (abs(GrainID(k, i, j)) - 1) % NumberOfOrientations;
                         GOHistogram(GOVal)++;
                     }

--- a/analysis/src/GAprint.hpp
+++ b/analysis/src/GAprint.hpp
@@ -28,14 +28,14 @@ void PrintCrossSectionOrientationData(int NumberOfCrossSections, std::string Bas
                                       bool NewOrientationFormatYN, double deltax, ViewF_H GrainUnitVectors,
                                       ViewF_H GrainEulerAngles);
 void PrintMisorientationData(bool *AnalysisTypes, std::string BaseFileName, int XMin, int XMax, int YMin, int YMax,
-                             int ZMin, int ZMax, ViewI3D_H Melted, ViewF_H GrainUnitVector, ViewI3D_H GrainID,
+                             int ZMin, int ZMax, ViewI3D_H LayerID, ViewF_H GrainUnitVector, ViewI3D_H GrainID,
                              int NumberOfOrientations);
 void PrintSizeData(bool *AnalysisTypes, std::string BaseFileName, int XMin, int XMax, int YMin, int YMax, int ZMin,
-                   int ZMax, int nx, int ny, int nz, ViewI3D_H Melted, ViewI3D_H GrainID_WholeDomain, double deltax);
+                   int ZMax, int nx, int ny, int nz, ViewI3D_H LayerID, ViewI3D_H GrainID_WholeDomain, double deltax);
 void PrintGrainAreaData(bool *AnalysisTypes, std::string BaseFileName, double deltax, int XMin, int XMax, int YMin,
                         int YMax, int ZMin, int ZMax, ViewI3D_H GrainID);
 void PrintPoleFigureData(bool *AnalysisTypes, std::string BaseFileName, int NumberOfOrientations, int XMin, int XMax,
-                         int YMin, int YMax, int ZMin, int ZMax, ViewI3D_H GrainID, ViewI3D_H Melted,
+                         int YMin, int YMax, int ZMin, int ZMax, ViewI3D_H GrainID, ViewI3D_H LayerID,
                          bool NewOrientationFormatYN, ViewF_H GrainEulerAngles);
 void WritePoleFigureDataToFile(std::string Filename, int NumberOfOrientations, ViewF_H GrainEulerAngles,
                                ViewI_H GOHistogram);

--- a/analysis/src/GAutils.hpp
+++ b/analysis/src/GAutils.hpp
@@ -26,14 +26,13 @@ void ReadField(std::ifstream &InputDataStream, int nx, int ny, int nz, ViewI3D_H
 void ParseFilenames(std::string AnalysisFile, std::string &LogFile, std::string &MicrostructureFile,
                     std::string &RotationFilename, std::string &OutputFileName, std::string &EulerAnglesFilename,
                     bool &NewOrientationFormatYN);
-void InitializeData(std::string MicrostructureFile, int nx, int ny, int nz, ViewI3D_H GrainID, ViewI3D_H LayerID,
-                    ViewI3D_H Melted);
+void InitializeData(std::string MicrostructureFile, int nx, int ny, int nz, ViewI3D_H GrainID, ViewI3D_H LayerID);
 void ParseAnalysisFile(std::string AnalysisFile, std::string RotationFilename, int &NumberOfOrientations,
                        bool *AnalysisTypes, std::vector<int> &XLow_RVE, std::vector<int> &XHigh_RVE,
                        std::vector<int> &YLow_RVE, std::vector<int> &YHigh_RVE, std::vector<int> &ZLow_RVE,
                        std::vector<int> &ZHigh_RVE, int &NumberOfRVEs, std::vector<int> &CrossSectionPlane,
                        std::vector<int> &CrossSectionLocation, int &NumberOfCrossSections, int &XMin, int &XMax,
-                       int &YMin, int &YMax, int &ZMin, int &ZMax, int nx, int ny, int nz, ViewI3D_H LayerID, ViewI3D_H,
+                       int &YMin, int &YMax, int &ZMin, int &ZMax, int nx, int ny, int nz, ViewI3D_H LayerID,
                        int NumberOfLayers, std::vector<bool> &PrintSectionPF, std::vector<bool> &PrintSectionIPF,
                        bool NewOrientationFormatYN);
 

--- a/analysis/src/runGA.cpp
+++ b/analysis/src/runGA.cpp
@@ -50,13 +50,12 @@ int main(int argc, char *argv[]) {
         int nx, ny, nz, NumberOfLayers;
         ParseLogFile(LogFile, nx, ny, nz, deltax, NumberOfLayers);
 
-        // Allocate memory blocks for GrainID, LayerID, and Melted data
+        // Allocate memory blocks for GrainID and LayerID data
         ViewI3D_H GrainID(Kokkos::ViewAllocateWithoutInitializing("GrainID"), nz, nx, ny);
         ViewI3D_H LayerID(Kokkos::ViewAllocateWithoutInitializing("LayerID"), nz, nx, ny);
-        ViewI3D_H Melted(Kokkos::ViewAllocateWithoutInitializing("Melted"), nz, nx, ny);
 
         // Fill arrays with data from paraview file
-        InitializeData(MicrostructureFile, nx, ny, nz, GrainID, LayerID, Melted);
+        InitializeData(MicrostructureFile, nx, ny, nz, GrainID, LayerID);
 
         // Read analysis file ("ExaCA/examples/Outputs.txt") to determine which analysis should be done
         // There are three parts to this analysis:
@@ -80,7 +79,7 @@ int main(int argc, char *argv[]) {
         ParseAnalysisFile(AnalysisFile, RotationFilename, NumberOfOrientations, AnalysisTypes, XLow_RVE, XHigh_RVE,
                           YLow_RVE, YHigh_RVE, ZLow_RVE, ZHigh_RVE, NumberOfRVEs, CrossSectionPlane,
                           CrossSectionLocation, NumberOfCrossSections, XMin, XMax, YMin, YMax, ZMin, ZMax, nx, ny, nz,
-                          LayerID, Melted, NumberOfLayers, PrintSectionPF, PrintSectionIPF, NewOrientationFormatYN);
+                          LayerID, NumberOfLayers, PrintSectionPF, PrintSectionIPF, NewOrientationFormatYN);
 
         // Allocate memory for grain unit vectors, grain euler angles (9*NumberOfOrientations and 3*NumberOfOrientations
         // in size, respectively)
@@ -107,12 +106,12 @@ int main(int argc, char *argv[]) {
         // Part 3: Representative volume grain statistics
         // Print data to std::out and if analysis option 0 is toggled, to the file
         // "[OutputFileName]_MisorientationFrequency.csv"
-        PrintMisorientationData(AnalysisTypes, OutputFileName, XMin, XMax, YMin, YMax, ZMin, ZMax, Melted,
+        PrintMisorientationData(AnalysisTypes, OutputFileName, XMin, XMax, YMin, YMax, ZMin, ZMax, LayerID,
                                 GrainUnitVector_Host, GrainID, NumberOfOrientations);
         // Print data to std::out and if analysis options 1, 2, or 5 are toggled, print data to files
         // "[OutputFileName]_VolumeFrequency.csv", "[OutputFileName]_AspectRatioFrequency.csv", and
         // [OutputFileName]_GrainHeightDistribution.csv", respectively
-        PrintSizeData(AnalysisTypes, OutputFileName, XMin, XMax, YMin, YMax, ZMin, ZMax, nx, ny, nz, Melted, GrainID,
+        PrintSizeData(AnalysisTypes, OutputFileName, XMin, XMax, YMin, YMax, ZMin, ZMax, nx, ny, nz, LayerID, GrainID,
                       deltax);
         // Print data to std::out and if analysis options 3, 4, or 6 are toggled, print data to files
         // "[OutputFileName]_GrainAreas.csv", "[OutputFileName]_WeightedGrainAreas.csv", and
@@ -121,7 +120,7 @@ int main(int argc, char *argv[]) {
         // If analysis option 7 is toggled, print orientation data to files "[OutputFileName]_pyEBSDOrientations.csv"
         // and "[OutputFileName]_MTEXOrientations.csv"
         PrintPoleFigureData(AnalysisTypes, OutputFileName, NumberOfOrientations, XMin, XMax, YMin, YMax, ZMin, ZMax,
-                            GrainID, Melted, NewOrientationFormatYN, GrainEulerAngles_Host);
+                            GrainID, LayerID, NewOrientationFormatYN, GrainEulerAngles_Host);
     }
     // Finalize kokkos and end program
     Kokkos::finalize();

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -50,7 +50,7 @@ int calcnzActive(int ZBound_Low, int ZBound_High, int id, int layernumber);
 int calcLocalActiveDomainSize(int MyXSlices, int MyYSlices, int nzActive);
 void TempInit_DirSolidification(double G, double R, int id, int &MyXSlices, int &MyYSlices, double deltax,
                                 double deltat, int nz, int LocalDomainSize, ViewI &CritTimeStep,
-                                ViewF &UndercoolingChange, bool *Melted, ViewI &LayerID);
+                                ViewF &UndercoolingChange, ViewI &LayerID);
 int calcMaxSolidificationEventsSpot(int MyXSlices, int MyYSlices, int NumberOfSpots, int NSpotsX, int SpotRadius,
                                     int SpotOffset, int MyXOffset, int MyYOffset);
 void OrientationInit(int id, int &NGrainOrientations, ViewF &ReadOrientationData, std::string GrainOrientationFile,
@@ -58,15 +58,15 @@ void OrientationInit(int id, int &NGrainOrientations, ViewF &ReadOrientationData
 void TempInit_SpotRemelt(int layernumber, double G, double R, std::string, int id, int &MyXSlices, int &MyYSlices,
                          int &MyXOffset, int &MyYOffset, double deltax, double deltat, int ZBound_Low, int nz,
                          int LocalActiveDomainSize, int LocalDomainSize, ViewI &CritTimeStep, ViewF &UndercoolingChange,
-                         ViewF &UndercoolingCurrent, bool *Melted, int LayerHeight, double FreezingRange,
-                         ViewI &LayerID, int NSpotsX, int NSpotsY, int SpotRadius, int SpotOffset,
-                         ViewF3D &LayerTimeTempHistory, ViewI &NumberOfSolidificationEvents, ViewI &MeltTimeStep,
-                         ViewI &MaxSolidificationEvents, ViewI &SolidificationEventCounter);
+                         ViewF &UndercoolingCurrent, int LayerHeight, double FreezingRange, ViewI &LayerID, int NSpotsX,
+                         int NSpotsY, int SpotRadius, int SpotOffset, ViewF3D &LayerTimeTempHistory,
+                         ViewI &NumberOfSolidificationEvents, ViewI &MeltTimeStep, ViewI &MaxSolidificationEvents,
+                         ViewI &SolidificationEventCounter);
 void TempInit_SpotNoRemelt(double G, double R, std::string SimulationType, int id, int &MyXSlices, int &MyYSlices,
                            int &MyXOffset, int &MyYOffset, double deltax, double deltat, int nz, int LocalDomainSize,
-                           ViewI &CritTimeStep, ViewF &UndercoolingChange, bool *Melted, int LayerHeight,
-                           int NumberOfLayers, double FreezingRange, ViewI &LayerID, int NSpotsX, int NSpotsY,
-                           int SpotRadius, int SpotOffset);
+                           ViewI &CritTimeStep, ViewF &UndercoolingChange, int LayerHeight, int NumberOfLayers,
+                           double FreezingRange, ViewI &LayerID, int NSpotsX, int NSpotsY, int SpotRadius,
+                           int SpotOffset);
 int getTempCoordX(int i, float XMin, double deltax, const std::vector<double> &RawData);
 int getTempCoordY(int i, float YMin, double deltax, const std::vector<double> &RawData);
 int getTempCoordZ(int i, double deltax, const std::vector<double> &RawData, int LayerHeight, int LayerCounter,
@@ -76,10 +76,10 @@ double getTempCoordTL(int i, const std::vector<double> &RawData);
 double getTempCoordCR(int i, const std::vector<double> &RawData);
 void TempInit_ReadDataNoRemelt(int id, int &MyXSlices, int &MyYSlices, int &MyXOffset, int &MyYOffset, double deltax,
                                int HTtoCAratio, double deltat, int nz, int LocalDomainSize, ViewI &CritTimeStep,
-                               ViewF &UndercoolingChange, float XMin, float YMin, float ZMin, bool *Melted,
-                               float *ZMinLayer, float *ZMaxLayer, int LayerHeight, int NumberOfLayers,
-                               int *FinishTimeStep, double FreezingRange, ViewI &LayerID, int *FirstValue,
-                               int *LastValue, std::vector<double> RawData);
+                               ViewF &UndercoolingChange, float XMin, float YMin, float ZMin, float *ZMinLayer,
+                               float *ZMaxLayer, int LayerHeight, int NumberOfLayers, int *FinishTimeStep,
+                               double FreezingRange, ViewI &LayerID, int *FirstValue, int *LastValue,
+                               std::vector<double> RawData);
 void calcMaxSolidificationEventsR(int id, int layernumber, int TempFilesInSeries, ViewI_H MaxSolidificationEvents_Host,
                                   int StartRange, int EndRange, std::vector<double> RawData, float XMin, float YMin,
                                   double deltax, float *ZMinLayer, int LayerHeight, int MyXSlices, int MyYSlices,
@@ -89,9 +89,9 @@ void TempInit_ReadDataRemelt(int layernumber, int id, int MyXSlices, int MyYSlic
                              double FreezingRange, ViewF3D &LayerTimeTempHistory, ViewI &NumberOfSolidificationEvents,
                              ViewI &MaxSolidificationEvents, ViewI &MeltTimeStep, ViewI &CritTimeStep,
                              ViewF &UndercoolingChange, ViewF &UndercoolingCurrent, float XMin, float YMin,
-                             bool *Melted, float *ZMinLayer, int LayerHeight, int nzActive, int ZBound_Low,
-                             int *FinishTimeStep, ViewI &LayerID, int *FirstValue, int *LastValue,
-                             std::vector<double> RawData, ViewI &SolidificationEventCounter, int TempFilesInSeries);
+                             float *ZMinLayer, int LayerHeight, int nzActive, int ZBound_Low, int *FinishTimeStep,
+                             ViewI &LayerID, int *FirstValue, int *LastValue, std::vector<double> RawData,
+                             ViewI &SolidificationEventCounter, int TempFilesInSeries);
 void SubstrateInit_ConstrainedGrowth(int id, double FractSurfaceSitesActive, int MyXSlices, int MyYSlices, int nx,
                                      int ny, int MyXOffset, int MyYOffset, NList NeighborX, NList NeighborY,
                                      NList NeighborZ, ViewF GrainUnitVector, int NGrainOrientations, ViewI CellType,

--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -18,23 +18,18 @@ void CollectIntField(ViewI3D_H IntVar_WholeDomain, ViewI_H IntVar, int nx, int n
 void CollectFloatField(ViewF3D_H FloatVar_WholeDomain, ViewF_H FloatVar, int nx, int ny, int nz, int MyXSlices,
                        int MyYSlices, int np, ViewI_H RecvXOffset, ViewI_H RecvYOffset, ViewI_H RecvXSlices,
                        ViewI_H RecvYSlices, ViewI_H RBufSize);
-void CollectBoolField(ViewI3D_H IntVar_WholeDomain, bool *BoolVar, int nx, int ny, int nz, int MyXSlices, int MyYSlices,
-                      int np, ViewI_H RecvXOffset, ViewI_H RecvYOffset, ViewI_H RecvXSlices, ViewI_H RecvYSlices,
-                      ViewI_H RBufSize);
 void SendIntField(ViewI_H VarToSend, int nz, int MyXSlices, int MyYSlices, int SendBufSize, int SendBufStartX,
                   int SendBufEndX, int SendBufStartY, int SendBufEndY);
 void SendFloatField(ViewF_H VarToSend, int nz, int MyXSlices, int MyYSlices, int SendBufSize, int SendBufStartX,
                     int SendBufEndX, int SendBufStartY, int SendBufEndY);
-void SendBoolField(bool *VarToSend, int nz, int MyXSlices, int MyYSlices, int SendBufSize, int SendBufStartX,
-                   int SendBufEndX, int SendBufStartY, int SendBufEndY);
 void PrintExaCAData(int id, int layernumber, int np, int nx, int ny, int nz, int MyXSlices, int MyYSlices,
                     int MyXOffset, int MyYOffset, int ProcessorsInXDirection, int ProcessorsInYDirection, ViewI GrainID,
                     ViewI CritTimeStep, ViewF GrainUnitVector, ViewI LayerID, ViewI CellType, ViewF UndercoolingChange,
                     ViewF UndercoolingCurrent, std::string BaseFileName, int DecompositionStrategy,
-                    int NGrainOrientations, bool *Melted, std::string PathToOutput, int PrintDebug,
-                    bool PrintMisorientation, bool PrintFinalUndercooling, bool PrintFullOutput, bool PrintTimeSeries,
-                    bool PrintDefaultRVE, int IntermediateFileCounter, int ZBound_Low, int nzActive, double deltax,
-                    float XMin, float YMin, float ZMin, int NumberOfLayers, int RVESize = 0);
+                    int NGrainOrientations, std::string PathToOutput, int PrintDebug, bool PrintMisorientation,
+                    bool PrintFinalUndercooling, bool PrintFullOutput, bool PrintTimeSeries, bool PrintDefaultRVE,
+                    int IntermediateFileCounter, int ZBound_Low, int nzActive, double deltax, float XMin, float YMin,
+                    float ZMin, int NumberOfLayers, int RVESize = 0);
 void PrintExaCALog(int id, int np, std::string InputFile, std::string SimulationType, int DecompositionStrategy,
                    int MyXSlices, int MyYSlices, int MyXOffset, int MyYOffset, double AConst, double BConst,
                    double CConst, double DConst, double FreezingRange, double deltax, double NMax, double dTN,
@@ -49,13 +44,13 @@ void PrintExaCALog(int id, int np, std::string InputFile, std::string Simulation
 void PrintCAFields(int nx, int ny, int nz, ViewI3D_H GrainID_WholeDomain, ViewI3D_H LayerID_WholeDomain,
                    ViewI3D_H CritTimeStep_WholeDomain, ViewI3D_H CellType_WholeDomain,
                    ViewF3D_H UndercoolingChange_WholeDomain, ViewF3D_H UndercoolingCurrent_WholeDomain,
-                   ViewI3D_H Melted_WholeDomain, std::string PathToOutput, std::string BaseFileName, int PrintDebug,
-                   bool PrintFullOutput, double deltax, float XMin, float YMin, float ZMin);
+                   std::string PathToOutput, std::string BaseFileName, int PrintDebug, bool PrintFullOutput,
+                   double deltax, float XMin, float YMin, float ZMin);
 void PrintGrainMisorientations(std::string BaseFileName, std::string PathToOutput, int nx, int ny, int nz,
-                               ViewI3D_H Melted_WholeDomain, ViewI3D_H GrainID_WholeDomain, ViewF_H GrainUnitVector,
+                               ViewI3D_H LayerID_WholeDomain, ViewI3D_H GrainID_WholeDomain, ViewF_H GrainUnitVector,
                                int NGrainOrientations, double deltax, float XMin, float YMin, float ZMin);
 void PrintFinalUndercooling(std::string BaseFileName, std::string PathToOutput, int nx, int ny, int nz,
-                            ViewI3D_H Melted_WholeDomain, ViewF3D_H UndercoolingCurrent_WholeDomain, double deltax,
+                            ViewF3D_H UndercoolingCurrent_WholeDomain, ViewI3D_H LayerID_WholeDomain, double deltax,
                             float XMin, float YMin, float ZMin);
 void PrintExaConstitDefaultRVE(std::string BaseFileName, std::string PathToOutput, int nx, int ny, int nz,
                                ViewI3D_H LayerID_WholeDomain, ViewI3D_H GrainID_WholeDomain, double deltax,

--- a/src/CAupdate.cpp
+++ b/src/CAupdate.cpp
@@ -609,10 +609,10 @@ void JumpTimeStep(int &cycle, unsigned long int RemainingCellsOfInterest, ViewI 
                   ViewI CellType, ViewI LayerID, int id, int layernumber, int np, int nx, int ny, int nz, int MyXOffset,
                   int MyYOffset, int ProcessorsInXDirection, int ProcessorsInYDirection, ViewI GrainID,
                   ViewI CritTimeStep, ViewF GrainUnitVector, ViewF UndercoolingChange, ViewF UndercoolingCurrent,
-                  std::string OutputFile, int DecompositionStrategy, int NGrainOrientations, bool *Melted,
-                  std::string PathToOutput, int &IntermediateFileCounter, int nzActive, double deltax, float XMin,
-                  float YMin, float ZMin, int NumberOfLayers, int &XSwitch, std::string TemperatureDataType,
-                  bool PrintIdleMovieFrames, int MovieFrameInc, int FinishTimeStep = 0) {
+                  std::string OutputFile, int DecompositionStrategy, int NGrainOrientations, std::string PathToOutput,
+                  int &IntermediateFileCounter, int nzActive, double deltax, float XMin, float YMin, float ZMin,
+                  int NumberOfLayers, int &XSwitch, std::string TemperatureDataType, bool PrintIdleMovieFrames,
+                  int MovieFrameInc, int FinishTimeStep = 0) {
 
     MPI_Bcast(&RemainingCellsOfInterest, 1, MPI_UNSIGNED_LONG, 0, MPI_COMM_WORLD);
     if (RemainingCellsOfInterest == 0) {
@@ -652,9 +652,9 @@ void JumpTimeStep(int &cycle, unsigned long int RemainingCellsOfInterest, ViewI 
                         PrintExaCAData(id, layernumber, np, nx, ny, nz, MyXSlices, MyYSlices, MyXOffset, MyYOffset,
                                        ProcessorsInXDirection, ProcessorsInYDirection, GrainID, CritTimeStep,
                                        GrainUnitVector, LayerID, CellType, UndercoolingChange, UndercoolingCurrent,
-                                       OutputFile, DecompositionStrategy, NGrainOrientations, Melted, PathToOutput, 0,
-                                       false, false, false, true, false, IntermediateFileCounter, ZBound_Low, nzActive,
-                                       deltax, XMin, YMin, ZMin, NumberOfLayers);
+                                       OutputFile, DecompositionStrategy, NGrainOrientations, PathToOutput, 0, false,
+                                       false, false, true, false, IntermediateFileCounter, ZBound_Low, nzActive, deltax,
+                                       XMin, YMin, ZMin, NumberOfLayers);
                         IntermediateFileCounter++;
                     }
                 }
@@ -678,10 +678,10 @@ void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyXSlices, int M
                                 int ProcessorsInXDirection, int ProcessorsInYDirection,
                                 int SuccessfulNucEvents_ThisRank, int &XSwitch, ViewI CellType, ViewI CritTimeStep,
                                 ViewI GrainID, std::string TemperatureDataType, int *FinishTimeStep, int layernumber,
-                                int, int ZBound_Low, int NGrainOrientations, bool *Melted, ViewI LayerID,
-                                ViewF GrainUnitVector, ViewF UndercoolingChange, ViewF UndercoolingCurrent,
-                                std::string PathToOutput, std::string OutputFile, bool PrintIdleMovieFrames,
-                                int MovieFrameInc, int &IntermediateFileCounter, int NumberOfLayers) {
+                                int, int ZBound_Low, int NGrainOrientations, ViewI LayerID, ViewF GrainUnitVector,
+                                ViewF UndercoolingChange, ViewF UndercoolingCurrent, std::string PathToOutput,
+                                std::string OutputFile, bool PrintIdleMovieFrames, int MovieFrameInc,
+                                int &IntermediateFileCounter, int NumberOfLayers) {
 
     sample::ValueType CellTypeStorage;
     Kokkos::parallel_reduce(
@@ -741,24 +741,21 @@ void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyXSlices, int M
                      ZBound_Low, false, CellType, LayerID, id, layernumber, np, nx, ny, nz, MyXOffset, MyYOffset,
                      ProcessorsInXDirection, ProcessorsInYDirection, GrainID, CritTimeStep, GrainUnitVector,
                      UndercoolingChange, UndercoolingCurrent, OutputFile, DecompositionStrategy, NGrainOrientations,
-                     Melted, PathToOutput, IntermediateFileCounter, nzActive, deltax, XMin, YMin, ZMin, NumberOfLayers,
-                     XSwitch, TemperatureDataType, PrintIdleMovieFrames, MovieFrameInc, FinishTimeStep[layernumber]);
+                     PathToOutput, IntermediateFileCounter, nzActive, deltax, XMin, YMin, ZMin, NumberOfLayers, XSwitch,
+                     TemperatureDataType, PrintIdleMovieFrames, MovieFrameInc, FinishTimeStep[layernumber]);
 }
 
 //*****************************************************************************/
 // Prints intermediate code output to stdout (intermediate output collected and printed is different than without
 // remelting) and checks to see if solidification is complete in the case where cells can solidify multiple times
-void IntermediateOutputAndCheck_Remelt(int id, int np, int &cycle, int MyXSlices, int MyYSlices, int MyXOffset,
-                                       int MyYOffset, int LocalActiveDomainSize, int nx, int ny, int nz, int nzActive,
-                                       double deltax, float XMin, float YMin, float ZMin, int DecompositionStrategy,
-                                       int ProcessorsInXDirection, int ProcessorsInYDirection,
-                                       int SuccessfulNucEvents_ThisRank, int &XSwitch, ViewI CellType,
-                                       ViewI CritTimeStep, ViewI GrainID, std::string TemperatureDataType,
-                                       int layernumber, int, int ZBound_Low, int NGrainOrientations, bool *Melted,
-                                       ViewI LayerID, ViewF GrainUnitVector, ViewF UndercoolingChange,
-                                       ViewF UndercoolingCurrent, std::string PathToOutput, std::string OutputFile,
-                                       bool PrintIdleMovieFrames, int MovieFrameInc, int &IntermediateFileCounter,
-                                       int NumberOfLayers, ViewI MeltTimeStep) {
+void IntermediateOutputAndCheck_Remelt(
+    int id, int np, int &cycle, int MyXSlices, int MyYSlices, int MyXOffset, int MyYOffset, int LocalActiveDomainSize,
+    int nx, int ny, int nz, int nzActive, double deltax, float XMin, float YMin, float ZMin, int DecompositionStrategy,
+    int ProcessorsInXDirection, int ProcessorsInYDirection, int SuccessfulNucEvents_ThisRank, int &XSwitch,
+    ViewI CellType, ViewI CritTimeStep, ViewI GrainID, std::string TemperatureDataType, int layernumber, int,
+    int ZBound_Low, int NGrainOrientations, ViewI LayerID, ViewF GrainUnitVector, ViewF UndercoolingChange,
+    ViewF UndercoolingCurrent, std::string PathToOutput, std::string OutputFile, bool PrintIdleMovieFrames,
+    int MovieFrameInc, int &IntermediateFileCounter, int NumberOfLayers, ViewI MeltTimeStep) {
 
     sample::ValueType CellTypeStorage;
     Kokkos::parallel_reduce(
@@ -812,6 +809,6 @@ void IntermediateOutputAndCheck_Remelt(int id, int np, int &cycle, int MyXSlices
                      true, CellType, LayerID, id, layernumber, np, nx, ny, nz, MyXOffset, MyYOffset,
                      ProcessorsInXDirection, ProcessorsInYDirection, GrainID, CritTimeStep, GrainUnitVector,
                      UndercoolingChange, UndercoolingCurrent, OutputFile, DecompositionStrategy, NGrainOrientations,
-                     Melted, PathToOutput, IntermediateFileCounter, nzActive, deltax, XMin, YMin, ZMin, NumberOfLayers,
-                     XSwitch, TemperatureDataType, PrintIdleMovieFrames, MovieFrameInc);
+                     PathToOutput, IntermediateFileCounter, nzActive, deltax, XMin, YMin, ZMin, NumberOfLayers, XSwitch,
+                     TemperatureDataType, PrintIdleMovieFrames, MovieFrameInc);
 }

--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -120,27 +120,27 @@ void JumpTimeStep(int &cycle, unsigned long int RemainingCellsOfInterest, ViewI 
                   ViewI CellType, ViewI LayerID, int id, int layernumber, int np, int nx, int ny, int nz, int MyXOffset,
                   int MyYOffset, int ProcessorsInXDirection, int ProcessorsInYDirection, ViewI GrainID,
                   ViewI CritTimeStep, ViewF GrainUnitVector, ViewF UndercoolingChange, ViewF UndercoolingCurrent,
-                  std::string OutputFile, int DecompositionStrategy, int NGrainOrientations, bool *Melted,
-                  std::string PathToOutput, int &IntermediateFileCounter, int nzActive, double deltax, float XMin,
-                  float YMin, float ZMin, int NumberOfLayers, int &XSwitch, std::string TemperatureDataType,
-                  bool PrintIdleMovieFrames, int MovieFrameInc, int FinishTimeStep);
+                  std::string OutputFile, int DecompositionStrategy, int NGrainOrientations, std::string PathToOutput,
+                  int &IntermediateFileCounter, int nzActive, double deltax, float XMin, float YMin, float ZMin,
+                  int NumberOfLayers, int &XSwitch, std::string TemperatureDataType, bool PrintIdleMovieFrames,
+                  int MovieFrameInc, int FinishTimeStep);
 void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyXSlices, int MyYSlices, int MyXOffset, int MyYOffset,
                                 int LocalDomainSize, int LocalActiveDomainSize, int nx, int ny, int nz, int nzActive,
                                 double deltax, float XMin, float YMin, float ZMin, int DecompositionStrategy,
                                 int ProcessorsInXDirection, int ProcessorsInYDirection,
                                 int SuccessfulNucEvents_ThisRank, int &XSwitch, ViewI CellType, ViewI CritTimeStep,
                                 ViewI GrainID, std::string TemperatureDataType, int *FinishTimeStep, int layernumber,
-                                int, int ZBound_Low, int NGrainOrientations, bool *Melted, ViewI LayerID,
-                                ViewF GrainUnitVector, ViewF UndercoolingChange, ViewF UndercoolingCurrent,
-                                std::string PathToOutput, std::string OutputFile, bool PrintIdleMovieFrames,
-                                int MovieFrameInc, int &IntermediateFileCounter, int NumberOfLayers);
+                                int, int ZBound_Low, int NGrainOrientations, ViewI LayerID, ViewF GrainUnitVector,
+                                ViewF UndercoolingChange, ViewF UndercoolingCurrent, std::string PathToOutput,
+                                std::string OutputFile, bool PrintIdleMovieFrames, int MovieFrameInc,
+                                int &IntermediateFileCounter, int NumberOfLayers);
 void IntermediateOutputAndCheck_Remelt(
     int id, int np, int &cycle, int MyXSlices, int MyYSlices, int MyXOffset, int MyYOffset, int LocalActiveDomainSize,
     int nx, int ny, int nz, int nzActive, double deltax, float XMin, float YMin, float ZMin, int DecompositionStrategy,
     int ProcessorsInXDirection, int ProcessorsInYDirection, int SuccessfulNucEvents_ThisRank, int &XSwitch,
     ViewI CellType, ViewI CritTimeStep, ViewI GrainID, std::string TemperatureDataType, int layernumber, int,
-    int ZBound_Low, int NGrainOrientations, bool *Melted, ViewI LayerID, ViewF GrainUnitVector,
-    ViewF UndercoolingChange, ViewF UndercoolingCurrent, std::string PathToOutput, std::string OutputFile,
-    bool PrintIdleMovieFrames, int MovieFrameInc, int &IntermediateFileCounter, int NumberOfLayers, ViewI MeltTimeStep);
+    int ZBound_Low, int NGrainOrientations, ViewI LayerID, ViewF GrainUnitVector, ViewF UndercoolingChange,
+    ViewF UndercoolingCurrent, std::string PathToOutput, std::string OutputFile, bool PrintIdleMovieFrames,
+    int MovieFrameInc, int &IntermediateFileCounter, int NumberOfLayers, ViewI MeltTimeStep);
 
 #endif

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -112,7 +112,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     ViewI LayerID(Kokkos::ViewAllocateWithoutInitializing("LayerID"), LocalDomainSize);
     ViewF UndercoolingChange(Kokkos::ViewAllocateWithoutInitializing("UndercoolingChange"), LocalDomainSize);
     ViewF UndercoolingCurrent("UndercoolingCurrent", LocalDomainSize);
-    bool *Melted = new bool[LocalDomainSize];
+
     // With remelting, temperature fields are also characterized by these variables:
     // Maximum number of times a cell in a given layer undergoes solidification
     ViewI MaxSolidificationEvents(Kokkos::ViewAllocateWithoutInitializing("NumberOfRemeltEvents"), NumberOfLayers);
@@ -139,32 +139,32 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
             TempInit_ReadDataRemelt(0, id, MyXSlices, MyYSlices, nz, LocalActiveDomainSize, LocalDomainSize, MyXOffset,
                                     MyYOffset, deltax, deltat, FreezingRange, LayerTimeTempHistory,
                                     NumberOfSolidificationEvents, MaxSolidificationEvents, MeltTimeStep, CritTimeStep,
-                                    UndercoolingChange, UndercoolingCurrent, XMin, YMin, Melted, ZMinLayer, LayerHeight,
+                                    UndercoolingChange, UndercoolingCurrent, XMin, YMin, ZMinLayer, LayerHeight,
                                     nzActive, ZBound_Low, FinishTimeStep, LayerID, FirstValue, LastValue, RawData,
                                     SolidificationEventCounter, TempFilesInSeries);
         else
             TempInit_ReadDataNoRemelt(id, MyXSlices, MyYSlices, MyXOffset, MyYOffset, deltax, HTtoCAratio, deltat, nz,
-                                      LocalDomainSize, CritTimeStep, UndercoolingChange, XMin, YMin, ZMin, Melted,
-                                      ZMinLayer, ZMaxLayer, LayerHeight, NumberOfLayers, FinishTimeStep, FreezingRange,
-                                      LayerID, FirstValue, LastValue, RawData);
+                                      LocalDomainSize, CritTimeStep, UndercoolingChange, XMin, YMin, ZMin, ZMinLayer,
+                                      ZMaxLayer, LayerHeight, NumberOfLayers, FinishTimeStep, FreezingRange, LayerID,
+                                      FirstValue, LastValue, RawData);
     }
     else if (SimulationType == "S") {
         // spot melt array test problem - with or without remelting
         if (RemeltingYN)
-            TempInit_SpotRemelt(
-                0, G, R, SimulationType, id, MyXSlices, MyYSlices, MyXOffset, MyYOffset, deltax, deltat, ZBound_Low, nz,
-                LocalActiveDomainSize, LocalDomainSize, CritTimeStep, UndercoolingChange, UndercoolingCurrent, Melted,
-                LayerHeight, FreezingRange, LayerID, NSpotsX, NSpotsY, SpotRadius, SpotOffset, LayerTimeTempHistory,
-                NumberOfSolidificationEvents, MeltTimeStep, MaxSolidificationEvents, SolidificationEventCounter);
+            TempInit_SpotRemelt(0, G, R, SimulationType, id, MyXSlices, MyYSlices, MyXOffset, MyYOffset, deltax, deltat,
+                                ZBound_Low, nz, LocalActiveDomainSize, LocalDomainSize, CritTimeStep,
+                                UndercoolingChange, UndercoolingCurrent, LayerHeight, FreezingRange, LayerID, NSpotsX,
+                                NSpotsY, SpotRadius, SpotOffset, LayerTimeTempHistory, NumberOfSolidificationEvents,
+                                MeltTimeStep, MaxSolidificationEvents, SolidificationEventCounter);
         else
             TempInit_SpotNoRemelt(G, R, SimulationType, id, MyXSlices, MyYSlices, MyXOffset, MyYOffset, deltax, deltat,
-                                  nz, LocalDomainSize, CritTimeStep, UndercoolingChange, Melted, LayerHeight,
-                                  NumberOfLayers, FreezingRange, LayerID, NSpotsX, NSpotsY, SpotRadius, SpotOffset);
+                                  nz, LocalDomainSize, CritTimeStep, UndercoolingChange, LayerHeight, NumberOfLayers,
+                                  FreezingRange, LayerID, NSpotsX, NSpotsY, SpotRadius, SpotOffset);
     }
     else if (SimulationType == "C") {
         // directional/constrained solidification test problem
         TempInit_DirSolidification(G, R, id, MyXSlices, MyYSlices, deltax, deltat, nz, LocalDomainSize, CritTimeStep,
-                                   UndercoolingChange, Melted, LayerID);
+                                   UndercoolingChange, LayerID);
     }
     // Delete temporary data structure for temperature data read if remelting is not performed (otherwise keep it to
     // avoid having to reread temperature files)
@@ -319,8 +319,8 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
         PrintExaCAData(id, -1, np, nx, ny, nz, MyXSlices, MyYSlices, MyXOffset, MyYOffset, ProcessorsInXDirection,
                        ProcessorsInYDirection, GrainID, CritTimeStep, GrainUnitVector, LayerID, CellType,
                        UndercoolingChange, UndercoolingCurrent, OutputFile, DecompositionStrategy, NGrainOrientations,
-                       Melted, PathToOutput, PrintDebug, false, false, false, false, false, 0, ZBound_Low, nzActive,
-                       deltax, XMin, YMin, ZMin, NumberOfLayers);
+                       PathToOutput, PrintDebug, false, false, false, false, false, 0, ZBound_Low, nzActive, deltax,
+                       XMin, YMin, ZMin, NumberOfLayers);
         MPI_Barrier(MPI_COMM_WORLD);
         if (id == 0)
             std::cout << "Initialization data file(s) printed" << std::endl;
@@ -344,8 +344,8 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                 PrintExaCAData(id, layernumber, np, nx, ny, nz, MyXSlices, MyYSlices, MyXOffset, MyYOffset,
                                ProcessorsInXDirection, ProcessorsInYDirection, GrainID, CritTimeStep, GrainUnitVector,
                                LayerID, CellType, UndercoolingChange, UndercoolingCurrent, OutputFile,
-                               DecompositionStrategy, NGrainOrientations, Melted, PathToOutput, 0, false, false, false,
-                               true, false, IntermediateFileCounter, ZBound_Low, nzActive, deltax, XMin, YMin, ZMin,
+                               DecompositionStrategy, NGrainOrientations, PathToOutput, 0, false, false, false, true,
+                               false, IntermediateFileCounter, ZBound_Low, nzActive, deltax, XMin, YMin, ZMin,
                                NumberOfLayers);
                 IntermediateFileCounter++;
             }
@@ -418,7 +418,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                         id, np, cycle, MyXSlices, MyYSlices, MyXOffset, MyYOffset, LocalActiveDomainSize, nx, ny, nz,
                         nzActive, deltax, XMin, YMin, ZMin, DecompositionStrategy, ProcessorsInXDirection,
                         ProcessorsInYDirection, SuccessfulNucEvents_ThisRank, XSwitch, CellType, CritTimeStep, GrainID,
-                        SimulationType, layernumber, NumberOfLayers, ZBound_Low, NGrainOrientations, Melted, LayerID,
+                        SimulationType, layernumber, NumberOfLayers, ZBound_Low, NGrainOrientations, LayerID,
                         GrainUnitVector, UndercoolingChange, UndercoolingCurrent, PathToOutput, OutputFile,
                         PrintIdleTimeSeriesFrames, TimeSeriesInc, IntermediateFileCounter, NumberOfLayers,
                         MeltTimeStep);
@@ -428,7 +428,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                         LocalActiveDomainSize, nx, ny, nz, nzActive, deltax, XMin, YMin, ZMin, DecompositionStrategy,
                         ProcessorsInXDirection, ProcessorsInYDirection, SuccessfulNucEvents_ThisRank, XSwitch, CellType,
                         CritTimeStep, GrainID, SimulationType, FinishTimeStep, layernumber, NumberOfLayers, ZBound_Low,
-                        NGrainOrientations, Melted, LayerID, GrainUnitVector, UndercoolingChange, UndercoolingCurrent,
+                        NGrainOrientations, LayerID, GrainUnitVector, UndercoolingChange, UndercoolingCurrent,
                         PathToOutput, OutputFile, PrintIdleTimeSeriesFrames, TimeSeriesInc, IntermediateFileCounter,
                         NumberOfLayers);
             }
@@ -456,7 +456,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                 if (SimulationType == "S")
                     TempInit_SpotRemelt(layernumber + 1, G, R, SimulationType, id, MyXSlices, MyYSlices, MyXOffset,
                                         MyYOffset, deltax, deltat, ZBound_Low, nz, LocalActiveDomainSize,
-                                        LocalDomainSize, CritTimeStep, UndercoolingChange, UndercoolingCurrent, Melted,
+                                        LocalDomainSize, CritTimeStep, UndercoolingChange, UndercoolingCurrent,
                                         LayerHeight, FreezingRange, LayerID, NSpotsX, NSpotsY, SpotRadius, SpotOffset,
                                         LayerTimeTempHistory, NumberOfSolidificationEvents, MeltTimeStep,
                                         MaxSolidificationEvents, SolidificationEventCounter);
@@ -465,8 +465,8 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                                             LocalDomainSize, MyXOffset, MyYOffset, deltax, deltat, FreezingRange,
                                             LayerTimeTempHistory, NumberOfSolidificationEvents, MaxSolidificationEvents,
                                             MeltTimeStep, CritTimeStep, UndercoolingChange, UndercoolingCurrent, XMin,
-                                            YMin, Melted, ZMinLayer, LayerHeight, nzActive, ZBound_Low, FinishTimeStep,
-                                            LayerID, FirstValue, LastValue, RawData, SolidificationEventCounter,
+                                            YMin, ZMinLayer, LayerHeight, nzActive, ZBound_Low, FinishTimeStep, LayerID,
+                                            FirstValue, LastValue, RawData, SolidificationEventCounter,
                                             TempFilesInSeries);
                 // Update buffer size
                 BufSizeZ = nzActive;
@@ -572,7 +572,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
         PrintExaCAData(id, NumberOfLayers - 1, np, nx, ny, nz, MyXSlices, MyYSlices, MyXOffset, MyYOffset,
                        ProcessorsInXDirection, ProcessorsInYDirection, GrainID, CritTimeStep, GrainUnitVector, LayerID,
                        CellType, UndercoolingChange, UndercoolingCurrent, OutputFile, DecompositionStrategy,
-                       NGrainOrientations, Melted, PathToOutput, 0, PrintMisorientation, PrintFinalUndercoolingVals,
+                       NGrainOrientations, PathToOutput, 0, PrintMisorientation, PrintFinalUndercoolingVals,
                        PrintFullOutput, false, PrintDefaultRVE, 0, ZBound_Low, nzActive, deltax, XMin, YMin, ZMin,
                        NumberOfLayers, RVESize);
     }


### PR DESCRIPTION
Boolean array "Melted" wasn't used for anything, as whether or not a cell was part of the melt pool footprint was already indicated by LayerID (-1 if no, >= 0 if yes, with the exact value depending on the layer number)