### PR TITLE
Perform kokkos tests without MPI

### DIFF
--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -109,6 +109,6 @@ ExaCA_add_tests_nobackend(NAMES Init)
 
 ExaCA_add_tests_nobackend(MPI NAMES InitMPI)
 
-ExaCA_add_tests(NAMES KokkosUpdate KokkosPrint)
+ExaCA_add_tests(NAMES KokkosInit KokkosUpdate KokkosPrint)
 
 ExaCA_add_tests(MPI NAMES KokkosInitMPI)


### PR DESCRIPTION
Fixup of #90 - unit test was accidentally removed from the CMake file