### PR TITLE
Do not print debug data if remelting is used

### DIFF
--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -466,6 +466,12 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
     GrainOrientationFile = checkFileInstalled(GrainOrientationFile_Read, id);
     checkFileNotEmpty(GrainOrientationFile);
 
+    // No printing of debug data if remelting is used - not currently supported
+    if ((RemeltingYN) && (PrintDebug > 0)) {
+        std::cout << "Printing of views following initialization with use of remelting is not currently supported"
+                  << std::endl;
+        PrintDebug = 0;
+    }
     if (id == 0) {
         std::cout << "Decomposition Strategy is " << DecompositionStrategy << std::endl;
         std::cout << "Material simulated is " << MaterialName


### PR DESCRIPTION
The current debug printing options only print useful data if remelting is not used - since they rely on the full multilayer temperature field being fully filled with data during initialization. With remelting, the temperature field is initialized one layer at a time, leading to printing of uninitialized values when printing debug data