### PR TITLE
Separate ZBound_Low and ZBound_High functions for remelt/no remelt

### DIFF
--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -850,7 +850,7 @@ void ReadTemperatureData(int id, double &deltax, double HT_deltax, int &HTtoCAra
 int calcZBound_Low_Remelt(std::string SimulationType, int LayerHeight, int layernumber, float *ZMinLayer, float ZMin,
                           double deltax) {
 
-    int ZBound_Low;
+    int ZBound_Low = -1; // assign dummy initial value
     if (SimulationType == "S") {
         // lower bound of domain is an integer multiple of the layer spacing, since the temperature field is the
         // same for every layer
@@ -860,8 +860,8 @@ int calcZBound_Low_Remelt(std::string SimulationType, int LayerHeight, int layer
         // lower bound of domain is based on the data read from the file(s)
         ZBound_Low = round((ZMinLayer[layernumber] - ZMin) / deltax);
     }
-    else
-        throw std::runtime_error("Error: simulations with remelting must be simulation type SM or RM");
+    if (ZBound_Low == -1)
+        throw std::runtime_error("Error: ZBound_Low went uninitialized, problem type must be C, S, or R");
     return ZBound_Low;
 }
 // If not using remelting, determine the smallest Z coordinate containing cells of the present layer ID

--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -847,38 +847,51 @@ void ReadTemperatureData(int id, double &deltax, double HT_deltax, int &HTtoCAra
 //*****************************************************************************/
 // Get the Z coordinate of the lower bound of iteration
 // If using remelting, this is called before initializing temperature data views for each layer
-// If not using remelting, this is only called before initializing temperature data view for the first layer, since the
-// existing DomainShiftAndResize subroutine already exists for other layers. These functions should be unified in a
-// future update
-int calcZBound_Low(bool RemeltingYN, std::string SimulationType, int LayerHeight, int layernumber, float *ZMinLayer,
-                   float ZMin, double deltax) {
+int calcZBound_Low_Remelt(std::string SimulationType, int LayerHeight, int layernumber, float *ZMinLayer, float ZMin,
+                          double deltax) {
 
-    int ZBound_Low = 0; // set to zero if no remelting (was previously done in individual TempInit_[ProblemType]
-                        // subroutines - implicitly assumes bottom of layer 0 is the bottom of the overall domain - this
-                        // should be fixed in the future for edge cases where this isn't true)
-    if (RemeltingYN) {
-        if (SimulationType == "S") {
-            // lower bound of domain is an integer multiple of the layer spacing, since the temperature field is the
-            // same for every layer
-            ZBound_Low = LayerHeight * layernumber;
-        }
-        else if (SimulationType == "R") {
-            // lower bound of domain is based on the data read from the file(s)
-            ZBound_Low = round((ZMinLayer[layernumber] - ZMin) / deltax);
-        }
-        else
-            throw std::runtime_error("Error: simulations with remelting must be simulation type SM or RM");
+    int ZBound_Low;
+    if (SimulationType == "S") {
+        // lower bound of domain is an integer multiple of the layer spacing, since the temperature field is the
+        // same for every layer
+        ZBound_Low = LayerHeight * layernumber;
     }
+    else if (SimulationType == "R") {
+        // lower bound of domain is based on the data read from the file(s)
+        ZBound_Low = round((ZMinLayer[layernumber] - ZMin) / deltax);
+    }
+    else
+        throw std::runtime_error("Error: simulations with remelting must be simulation type SM or RM");
+    return ZBound_Low;
+}
+// If not using remelting, determine the smallest Z coordinate containing cells of the present layer ID
+// Previously done in the subroutine DomainShiftAndResize_NoRemelt
+int calcZBound_Low_NoRemelt(int id, int MyXSlices, int MyYSlices, int LocalDomainSize, int layernumber, ViewI LayerID) {
+
+    // The new "bottom" of the active domain is located at the lowest Z coordinate containing LayerID values
+    // corresponding to the specified layernumber
+    int NewMin, ZBound_Low;
+    Kokkos::parallel_reduce(
+        "MinReduce", LocalDomainSize,
+        KOKKOS_LAMBDA(const int &D3D1ConvPosition, int &lmin) {
+            if (LayerID(D3D1ConvPosition) == layernumber) {
+                // Check Z position of this active cell
+                int RankZ = D3D1ConvPosition / (MyXSlices * MyYSlices);
+                if (RankZ < lmin)
+                    lmin = RankZ;
+            }
+        },
+        Kokkos::Min<int>(NewMin));
+    MPI_Allreduce(&NewMin, &ZBound_Low, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+    if (id == 0)
+        std::cout << "New domain bottom at Z = " << ZBound_Low << std::endl;
     return ZBound_Low;
 }
 //*****************************************************************************/
 // Get the Z coordinate of the upper bound of iteration
 // If using remelting, this is called before initializing temperature data views for each layer
-// If not using remelting, this is only called before initializing temperature data view for the first layer, since the
-// existing DomainShiftAndResize subroutine already exists for other layers. These functions should be unified in a
-// future update
-int calcZBound_High(std::string SimulationType, int SpotRadius, int LayerHeight, int layernumber, float ZMin,
-                    double deltax, int nz, float *ZMaxLayer) {
+int calcZBound_High_Remelt(std::string SimulationType, int SpotRadius, int LayerHeight, int layernumber, float ZMin,
+                           double deltax, int nz, float *ZMaxLayer) {
 
     int ZBound_High = -1; // assign dummy initial value
     if (SimulationType == "C") {
@@ -897,6 +910,31 @@ int calcZBound_High(std::string SimulationType, int SpotRadius, int LayerHeight,
     }
     if (ZBound_High == -1)
         throw std::runtime_error("Error: ZBound_High went uninitialized, problem type must be C, S, or R");
+    return ZBound_High;
+}
+// If not using remelting, this is only called before initializing temperature data view for the first layer, since the
+// existing DomainShiftAndResize subroutine already exists for other layers. These functions should be unified in a
+// future update
+int calcZBound_High_NoRemelt(int id, int MyXSlices, int MyYSlices, int LocalDomainSize, int layernumber,
+                             ViewI LayerID) {
+
+    // The new "top" of the active domain is located at the highest Z coordinate with cells associated with the
+    // specified layernumber
+    int NewMax, ZBound_High;
+    Kokkos::parallel_reduce(
+        "MaxReduce", LocalDomainSize,
+        KOKKOS_LAMBDA(const int &D3D1ConvPosition, int &lmax) {
+            if (LayerID(D3D1ConvPosition) == layernumber) {
+                // Check Z position of this active cell
+                int RankZ = D3D1ConvPosition / (MyXSlices * MyYSlices);
+                if (RankZ > lmax)
+                    lmax = RankZ;
+            }
+        },
+        Kokkos::Max<int>(NewMax));
+    MPI_Allreduce(&NewMax, &ZBound_High, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+    if (id == 0)
+        std::cout << "New domain top at Z = " << ZBound_High << std::endl;
     return ZBound_High;
 }
 //*****************************************************************************/
@@ -2434,66 +2472,6 @@ void NucleiInit(int layernumber, double RNGSeed, int MyXSlices, int MyYSlices, i
     MPI_Barrier(MPI_COMM_WORLD);
     if (id == 0)
         std::cout << "Nucleation data structures for layer " << layernumber << " initialized" << std::endl;
-}
-
-//*****************************************************************************/
-void DomainShiftAndResize_NoRemelt(int id, int MyXSlices, int MyYSlices, int &ZShift, int &ZBound_Low, int &ZBound_High,
-                                   int &nzActive, int LocalDomainSize, int &LocalActiveDomainSize, int &BufSizeZ,
-                                   int LayerHeight, ViewI CellType, int layernumber, ViewI LayerID) {
-
-    int ZBound_LowOld = ZBound_Low;
-
-    // The top "top" of the active domain is a shift of "LayerHeight" from the previous domain top
-    ZBound_High += LayerHeight;
-
-    // The new "bottom" of the active domain is located at the Z coordinate of the lowest active cells remaining in the
-    // domain
-    int NewMin;
-    Kokkos::parallel_reduce(
-        "MinReduce", LocalDomainSize,
-        KOKKOS_LAMBDA(const int &D3D1ConvPosition, int &lmin) {
-            if (CellType(D3D1ConvPosition) == Active) {
-                // Check Z position of this active cell
-                int RankZ = D3D1ConvPosition / (MyXSlices * MyYSlices);
-                if (RankZ < lmin)
-                    lmin = RankZ;
-            }
-        },
-        Kokkos::Min<int>(NewMin));
-    MPI_Allreduce(&NewMin, &ZBound_Low, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
-
-    // Shift in +Z direction for the bottom of the active region
-    ZShift = ZBound_Low - ZBound_LowOld;
-
-    if (id == 0)
-        std::cout << "New domain bottom at Z = " << ZBound_Low << ", a shift of " << ZShift << " cells" << std::endl;
-
-    // The new "top" of the active domain is located at the highest location with cells solidifying during the next
-    // layer
-    int NewMax;
-    Kokkos::parallel_reduce(
-        "MaxReduce", LocalDomainSize,
-        KOKKOS_LAMBDA(const int &D3D1ConvPosition, int &lmax) {
-            if (LayerID(D3D1ConvPosition) == layernumber + 1) {
-                // Check Z position of this active cell
-                int RankZ = D3D1ConvPosition / (MyXSlices * MyYSlices);
-                if (RankZ > lmax)
-                    lmax = RankZ;
-            }
-        },
-        Kokkos::Max<int>(NewMax));
-    MPI_Allreduce(&NewMax, &ZBound_High, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
-    if (id == 0)
-        std::cout << "New domain top at Z = " << ZBound_High << std::endl;
-    // Change in active region data structures' sizes
-    nzActive = ZBound_High - ZBound_Low + 1;
-    LocalActiveDomainSize = MyXSlices * MyYSlices * nzActive;
-
-    // Change in height of buffers
-    BufSizeZ = nzActive;
-
-    if (id == 0)
-        std::cout << "New active domain height is " << nzActive << std::endl;
 }
 
 //*****************************************************************************/

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -42,10 +42,12 @@ void ReadTemperatureData(int id, double &deltax, double HT_deltax, int &HTtoCAra
                          int MyXOffset, int MyYOffset, float XMin, float YMin, std::vector<std::string> &temp_paths,
                          int NumberOfLayers, int TempFilesInSeries, unsigned int &NumberOfTemperatureDataPoints,
                          std::vector<double> &RawData, int *FirstValue, int *LastValue);
-int calcZBound_Low(bool RemeltingYN, std::string SimulationType, int LayerHeight, int layernumber, float *ZMinLayer,
-                   float ZMin, double deltax);
-int calcZBound_High(std::string SimulationType, int SpotRadius, int LayerHeight, int layernumber, float ZMin,
-                    double deltax, int nz, float *ZMaxLayer);
+int calcZBound_Low_Remelt(std::string SimulationType, int LayerHeight, int layernumber, float *ZMinLayer, float ZMin,
+                          double deltax);
+int calcZBound_High_Remelt(std::string SimulationType, int SpotRadius, int LayerHeight, int layernumber, float ZMin,
+                           double deltax, int nz, float *ZMaxLayer);
+int calcZBound_Low_NoRemelt(int id, int MyXSlices, int MyYSlices, int LocalDomainSize, int layernumber, ViewI LayerID);
+int calcZBound_High_NoRemelt(int id, int MyXSlices, int MyYSlices, int LocalDomainSize, int layernumber, ViewI LayerID);
 int calcnzActive(int ZBound_Low, int ZBound_High, int id, int layernumber);
 int calcLocalActiveDomainSize(int MyXSlices, int MyYSlices, int nzActive);
 void TempInit_DirSolidification(double G, double R, int id, int &MyXSlices, int &MyYSlices, double deltax,
@@ -146,9 +148,6 @@ void placeNucleiData_Remelt(int NucleiMultiplier, int Nuclei_ThisLayerSingle, Vi
                             std::vector<double> NucleiUndercooling_WholeDomain_V,
                             std::vector<int> &NucleiGrainID_MyRank_V, std::vector<int> &NucleiLocation_MyRank_V,
                             std::vector<int> &NucleationTimes_MyRank_V, int &PossibleNuclei_ThisRankThisLayer);
-void DomainShiftAndResize_NoRemelt(int id, int MyXSlices, int MyYSlices, int &ZShift, int &ZBound_Low, int &ZBound_High,
-                                   int &nzActive, int LocalDomainSize, int &LocalActiveDomainSize, int &BufSizeZ,
-                                   int LayerHeight, ViewI CellType, int layernumber, ViewI LayerID);
 void ZeroResetViews(int LocalActiveDomainSize, int BufSizeX, int BufSizeY, int BufSizeZ, ViewF &DiagonalLength,
                     ViewF &CritDiagonalLength, ViewF &DOCenter, int DecompositionStrategy, Buffer2D &BufferWestSend,
                     Buffer2D &BufferEastSend, Buffer2D &BufferNorthSend, Buffer2D &BufferSouthSend,

--- a/unit_test/tstInit.cpp
+++ b/unit_test/tstInit.cpp
@@ -196,7 +196,6 @@ void testInputReadFromFile() {
 //---------------------------------------------------------------------------//
 void testcalcZBound_Low_Remelt() {
 
-    // A separate function is now used for ZBound_Low calculation without remelting
     int LayerHeight = 10;
     int NumberOfLayers = 10;
     double deltax = 1 * pow(10, -6);

--- a/unit_test/tstInit.cpp
+++ b/unit_test/tstInit.cpp
@@ -194,35 +194,29 @@ void testInputReadFromFile() {
 //---------------------------------------------------------------------------//
 // activedomainsizecalc
 //---------------------------------------------------------------------------//
-void testcalcZBound_Low(bool RemeltingYN) {
+void testcalcZBound_Low_Remelt() {
 
-    if (!(RemeltingYN)) {
-        float *ZMinLayer = new float[1];
-        int ZBound_Low_C = calcZBound_Low(RemeltingYN, "C", 0, 0, ZMinLayer, 0, 0);
-        // Should have just set the lower bound to zero, other inputs don't matter
-        EXPECT_EQ(ZBound_Low_C, 0);
-    }
-    else {
-        int LayerHeight = 10;
-        int NumberOfLayers = 10;
-        double deltax = 1 * pow(10, -6);
-        float ZMin = -0.5 * pow(10, -6);
-        float *ZMinLayer = new float[NumberOfLayers];
-        for (int layernumber = 0; layernumber < NumberOfLayers; layernumber++) {
-            // Set ZMinLayer for each layer to be offset by LayerHeight cells from the previous one (lets solution for
-            // both problem types by the same)
-            ZMinLayer[layernumber] = ZMin + layernumber * LayerHeight * deltax;
-            // Call function for each layernumber, and for simulation types "S" and "R"
-            int ZBound_Low_S = calcZBound_Low(RemeltingYN, "S", LayerHeight, layernumber, ZMinLayer, ZMin, deltax);
-            EXPECT_EQ(ZBound_Low_S, LayerHeight * layernumber);
-            int ZBound_Low_R = calcZBound_Low(RemeltingYN, "R", LayerHeight, layernumber, ZMinLayer, ZMin, deltax);
-            EXPECT_EQ(ZBound_Low_R, LayerHeight * layernumber);
-        }
+    // A separate function is now used for ZBound_Low calculation without remelting
+    int LayerHeight = 10;
+    int NumberOfLayers = 10;
+    double deltax = 1 * pow(10, -6);
+    float ZMin = -0.5 * pow(10, -6);
+    float *ZMinLayer = new float[NumberOfLayers];
+    for (int layernumber = 0; layernumber < NumberOfLayers; layernumber++) {
+        // Set ZMinLayer for each layer to be offset by LayerHeight cells from the previous one (lets solution for
+        // both problem types by the same)
+        ZMinLayer[layernumber] = ZMin + layernumber * LayerHeight * deltax;
+        // Call function for each layernumber, and for simulation types "S" and "R"
+        int ZBound_Low_S = calcZBound_Low_Remelt("S", LayerHeight, layernumber, ZMinLayer, ZMin, deltax);
+        EXPECT_EQ(ZBound_Low_S, LayerHeight * layernumber);
+        int ZBound_Low_R = calcZBound_Low_Remelt("R", LayerHeight, layernumber, ZMinLayer, ZMin, deltax);
+        EXPECT_EQ(ZBound_Low_R, LayerHeight * layernumber);
     }
 }
 
-void testcalcZBound_High() {
+void testcalcZBound_High_Remelt() {
 
+    // A separate function is now used for ZBound_High calculation without remelting
     int SpotRadius = 100;
     int LayerHeight = 10;
     float ZMin = 0.5 * pow(10, -6);
@@ -235,12 +229,15 @@ void testcalcZBound_High() {
         // ZMax value of ZMin + SpotRadius (lets solution for both problem types be the same)
         ZMaxLayer[layernumber] = ZMin + SpotRadius * deltax + layernumber * LayerHeight * deltax;
         // Call function for each layernumber, and for simulation types "S" and "R"
-        int ZBound_Max_S = calcZBound_High("S", SpotRadius, LayerHeight, layernumber, ZMin, deltax, nz, ZMaxLayer);
+        int ZBound_Max_S =
+            calcZBound_High_Remelt("S", SpotRadius, LayerHeight, layernumber, ZMin, deltax, nz, ZMaxLayer);
         EXPECT_EQ(ZBound_Max_S, SpotRadius + LayerHeight * layernumber);
-        int ZBound_Max_R = calcZBound_High("R", SpotRadius, LayerHeight, layernumber, ZMin, deltax, nz, ZMaxLayer);
+        int ZBound_Max_R =
+            calcZBound_High_Remelt("R", SpotRadius, LayerHeight, layernumber, ZMin, deltax, nz, ZMaxLayer);
         EXPECT_EQ(ZBound_Max_R, SpotRadius + LayerHeight * layernumber);
         // For simulation type C, should be independent of layernumber
-        int ZBound_Max_C = calcZBound_High("C", SpotRadius, LayerHeight, layernumber, ZMin, deltax, nz, ZMaxLayer);
+        int ZBound_Max_C =
+            calcZBound_High_Remelt("C", SpotRadius, LayerHeight, layernumber, ZMin, deltax, nz, ZMaxLayer);
         EXPECT_EQ(ZBound_Max_C, nz - 1);
     }
 }
@@ -417,10 +414,8 @@ void testgetTempCoords() {
 //---------------------------------------------------------------------------//
 TEST(TEST_CATEGORY, fileread_test) { testInputReadFromFile(); }
 TEST(TEST_CATEGORY, activedomainsizecalc) {
-    // calcZBound_Low tested with and without remelting
-    testcalcZBound_Low(true);
-    testcalcZBound_Low(false);
-    testcalcZBound_High();
+    testcalcZBound_Low_Remelt();
+    testcalcZBound_High_Remelt();
     testcalcnzActive();
     testcalcLocalActiveDomainSize();
 }

--- a/unit_test/tstKokkosInit.hpp
+++ b/unit_test/tstKokkosInit.hpp
@@ -74,6 +74,45 @@ void testOrientationInit_Angles() {
     }
 }
 
+// Tests calcZBound_Low_NoRemelt and calcZBound_High_NoRemelt
+void testcalcZBounds_NoRemelt() {
+
+    // Domain setup
+    int nx = 5;
+    int ny = 4;
+    int nz = 12;
+    int DomainSize = nx * ny * nz;
+    ViewI_H LayerID_Host(Kokkos::ViewAllocateWithoutInitializing("LayerID_Host"), DomainSize);
+
+    int layernumber = 0;
+    // Fill LayerID with -1s (not associated with a layer), assign a few cells the value "layernumber", assign a few
+    // other cells the value "layernumber + 1"
+    Kokkos::deep_copy(LayerID_Host, -1);
+    for (int k = 0; k < nz; k++) {
+        for (int i = 0; i < nx; i++) {
+            for (int j = 0; j < ny; j++) {
+                int Coordinate1D = k * nx * ny + i * ny + j;
+                if ((i == 2) && (j == 2) && (k > 4)) {
+                    if (k < 8)
+                        LayerID_Host(Coordinate1D) = layernumber;
+                    else
+                        LayerID_Host(Coordinate1D) = layernumber + 1;
+                }
+            }
+        }
+    }
+
+    // Copy view to device
+    ViewI LayerID = Kokkos::create_mirror_view_and_copy(device_memory_space(), LayerID_Host);
+
+    // Calculate ZBound_Low and ZBound_High
+    int ZBound_Low = calcZBound_Low_NoRemelt(0, nx, ny, DomainSize, layernumber, LayerID);
+    int ZBound_High = calcZBound_High_NoRemelt(0, nx, ny, DomainSize, layernumber, LayerID);
+
+    // Check against expected values
+    EXPECT_EQ(ZBound_Low, 5);
+    EXPECT_EQ(ZBound_High, 7);
+}
 //---------------------------------------------------------------------------//
 // RUN TESTS
 //---------------------------------------------------------------------------//
@@ -81,4 +120,5 @@ TEST(TEST_CATEGORY, orientation_init_tests) {
     testOrientationInit_Vectors();
     testOrientationInit_Angles();
 }
+TEST(TEST_CATEGORY, activedomainsizecalc) { testcalcZBounds_NoRemelt(); }
 } // end namespace Test


### PR DESCRIPTION
Removes subroutine DomainShiftAndResize_NoRemelt, replaces it with separate versions of the bounds calculations with and without remelting. LayerID, rather than CellType, is now used to determine a layer bounds for simulations without remelting - this yields the same result, but is done in preparation for CellType only being defined for a given layer, rather than for every cell in the multilayer domain