### PR TITLE
Added timer for steering vector creation

### DIFF
--- a/src/CAprint.cpp
+++ b/src/CAprint.cpp
@@ -618,8 +618,8 @@ void PrintExaCALog(int id, int np, std::string InputFile, std::string Simulation
                    double FractSurfaceSitesActive, std::string PathToOutput, int NSpotsX, int NSpotsY, int SpotOffset,
                    int SpotRadius, std::string BaseFileName, double InitTime, double RunTime, double OutTime, int cycle,
                    double InitMaxTime, double InitMinTime, double NuclMaxTime, double NuclMinTime,
-                   double CaptureMaxTime, double CaptureMinTime, double GhostMaxTime, double GhostMinTime,
-                   double OutMaxTime, double OutMinTime) {
+                   double CreateSVMinTime, double CreateSVMaxTime, double CaptureMaxTime, double CaptureMinTime,
+                   double GhostMaxTime, double GhostMinTime, double OutMaxTime, double OutMinTime) {
 
     int *XSlices = new int[np];
     int *YSlices = new int[np];
@@ -691,6 +691,8 @@ void PrintExaCALog(int id, int np, std::string InputFile, std::string Simulation
                  << std::endl;
         ExaCALog << "Max/min rank time in CA nucleation   = " << NuclMaxTime << " / " << NuclMinTime << " s"
                  << std::endl;
+        ExaCALog << "Max/min rank time in CA steering vector creation = " << CreateSVMaxTime << " / " << CreateSVMinTime
+                 << " s" << std::endl;
         ExaCALog << "Max/min rank time in CA cell capture = " << CaptureMaxTime << " / " << CaptureMinTime << " s"
                  << std::endl;
         ExaCALog << "Max/min rank time in CA ghosting     = " << GhostMaxTime << " / " << GhostMinTime << " s"
@@ -711,6 +713,8 @@ void PrintExaCALog(int id, int np, std::string InputFile, std::string Simulation
                   << std::endl;
         std::cout << "Max/min rank time in CA nucleation   = " << NuclMaxTime << " / " << NuclMinTime << " s"
                   << std::endl;
+        std::cout << "Max/min rank time in CA steering vector creation = " << CreateSVMaxTime << " / "
+                  << CreateSVMinTime << " s" << std::endl;
         std::cout << "Max/min rank time in CA cell capture = " << CaptureMaxTime << " / " << CaptureMinTime << " s"
                   << std::endl;
         std::cout << "Max/min rank time in CA ghosting     = " << GhostMaxTime << " / " << GhostMinTime << " s"

--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -39,8 +39,8 @@ void PrintExaCALog(int id, int np, std::string InputFile, std::string Simulation
                    double FractSurfaceSitesActive, std::string PathToOutput, int NSpotsX, int NSpotsY, int SpotOffset,
                    int SpotRadius, std::string BaseFileName, double InitTime, double RunTime, double OutTime, int cycle,
                    double InitMaxTime, double InitMinTime, double NuclMaxTime, double NuclMinTime,
-                   double CaptureMaxTime, double CaptureMinTime, double GhostMaxTime, double GhostMinTime,
-                   double OutMaxTime, double OutMinTime);
+                   double CreateSVMinTime, double CreateSVMaxTime, double CaptureMaxTime, double CaptureMinTime,
+                   double GhostMaxTime, double GhostMinTime, double OutMaxTime, double OutMinTime);
 void PrintCAFields(int nx, int ny, int nz, ViewI3D_H GrainID_WholeDomain, ViewI3D_H LayerID_WholeDomain,
                    ViewI3D_H CritTimeStep_WholeDomain, ViewI3D_H CellType_WholeDomain,
                    ViewF3D_H UndercoolingChange_WholeDomain, ViewF3D_H UndercoolingCurrent_WholeDomain,


### PR DESCRIPTION
The time spent in creation of the steering vector is now reported as a quantity separate from the time spent performing cell capture; previously, the time spent in cell capture was the sum of the steering vector creation + cell capture time