### PR TITLE
Warn about future deprecation of domain decomposition option

### DIFF
--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -237,6 +237,11 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
     // Convert information read from the file into values usable by ExaCA
     // Required inputs for all problems
     DecompositionStrategy = getInputInt(RequiredInputsRead_General[0]);
+    // Warn that decomposition strategy will be deprecated in the future
+    if ((id == 0) && (DecompositionStrategy != 1))
+        std::cout << "Warning: the domain decomposition option will be deprecated in a future release and 1D "
+                     "decompositions will be used in all cases"
+                  << std::endl;
     MaterialName = RequiredInputsRead_General[1];
     deltax = getInputDouble(RequiredInputsRead_General[2], -6);
     NMax = getInputDouble(RequiredInputsRead_General[3], 12);


### PR DESCRIPTION
In a future release, the user-specified domain decomposition strategy from the input file will be ignored, and the code will only use a 1D domain decomposition (which is faster than the 2D options in nearly all cases when simulating on GPU backends)