### PR TITLE
Renamed example file and output for consistency

### DIFF
--- a/examples/Inp_SpotMelt_RM.txt
+++ b/examples/Inp_SpotMelt_RM.txt
@@ -8,7 +8,7 @@ Heterogeneous nucleation density: 10
 Mean nucleation undercooling: 5
 Standard deviation of nucleation undercooling: 0.5
 Path to output:./
-Output file base name:TestProblemSpot
+Output file base name:TestProblemSpot_RM
 File of grain orientations:GrainOrientationVectors.csv
 Thermal gradient: 500000
 Cooling rate: 300000

--- a/examples/Inp_TwoLineTwoLayer_RM.txt
+++ b/examples/Inp_TwoLineTwoLayer_RM.txt
@@ -8,7 +8,7 @@ Heterogeneous nucleation density: 100
 Mean nucleation undercooling: 5
 Standard deviation of nucleation undercooling: 0.5
 Path to output:./
-Output file base name:TestProblemTwoLineTwoLayer
+Output file base name:TestProblemTwoLineTwoLayer_RM
 File of grain orientations:GrainOrientationVectors.csv
 Time step: 0.0825
 Substrate grain spacing: 25


### PR DESCRIPTION
Consistent naming of example files and output from example files with "_RM" when remelting is included:
Renamed example file that includes remelting: Inp_TwoLineTwoLayer.txt -> Inp_TwoLineTwoLayer_RM.txt, prints output to files starting with "TestProblemTwoLineTwoLayer_RM"
Inp_SpotMelt_RM.txt prints output to files starting with "TestProblemSpot_RM"