### PR TITLE
Reorder printed RVE data - contiguous in X

### DIFF
--- a/analysis/src/GAprint.cpp
+++ b/analysis/src/GAprint.cpp
@@ -502,8 +502,8 @@ void PrintExaConstitRVEData(int NumberOfRVEs, std::string BaseFileName, int, int
         GrainplotE << "X coord, Y coord, Z coord, Grain ID" << std::endl;
         int NucleatedGrainCells = 0;
         for (int k = ZLow_RVE[n]; k <= ZHigh_RVE[n]; k++) {
-            for (int i = XLow_RVE[n]; i <= XHigh_RVE[n]; i++) {
-                for (int j = YLow_RVE[n]; j <= YHigh_RVE[n]; j++) {
+            for (int j = YLow_RVE[n]; j <= YHigh_RVE[n]; j++) {
+                for (int i = XLow_RVE[n]; i <= XHigh_RVE[n]; i++) {
                     GrainplotE << i << "," << j << "," << k << "," << GrainID(k, i, j) << std::endl;
                     if (GrainID(k, i, j) < 0)
                         NucleatedGrainCells++;

--- a/src/CAprint.cpp
+++ b/src/CAprint.cpp
@@ -538,8 +538,8 @@ void PrintExaConstitDefaultRVE(std::string BaseFileName, std::string PathToOutpu
     int RVE_ZHigh = nz - 1;
     for (int k = nz - 1; k >= 0; k--) {
         [&] {
-            for (int i = RVE_XLow; i <= RVE_XHigh; i++) {
-                for (int j = RVE_YLow; j <= RVE_YHigh; j++) {
+            for (int j = RVE_YLow; j <= RVE_YHigh; j++) {
+                for (int i = RVE_XLow; i <= RVE_XHigh; i++) {
                     if (LayerID_WholeDomain(k, i, j) == (NumberOfLayers - 1))
                         return; // check next lowest value for k
                 }
@@ -570,8 +570,8 @@ void PrintExaConstitDefaultRVE(std::string BaseFileName, std::string PathToOutpu
                << " by " << RVE_YHigh - RVE_YLow + 1 << " by " << RVE_ZHigh - RVE_ZLow + 1 << " cells" << std::endl;
     GrainplotE << "X coord, Y coord, Z coord, Grain ID" << std::endl;
     for (int k = RVE_ZLow; k <= RVE_ZHigh; k++) {
-        for (int i = RVE_XLow; i <= RVE_XHigh; i++) {
-            for (int j = RVE_YLow; j <= RVE_YHigh; j++) {
+        for (int j = RVE_YLow; j <= RVE_YHigh; j++) {
+            for (int i = RVE_XLow; i <= RVE_XHigh; i++) {
                 GrainplotE << i << "," << j << "," << k << "," << GrainID_WholeDomain(k, i, j) << std::endl;
             }
         }

--- a/unit_test/tstKokkosPrint.hpp
+++ b/unit_test/tstKokkosPrint.hpp
@@ -34,8 +34,8 @@ void testPrintExaConstitDefaultRVE() {
     ViewI3D_H GrainID_WholeDomain(Kokkos::ViewAllocateWithoutInitializing("GrainID_WholeDomain"), nz, nx, ny);
     ViewI3D_H LayerID_WholeDomain(Kokkos::ViewAllocateWithoutInitializing("LayerID_WholeDomain"), nz, nx, ny);
     for (int k = 0; k < nz; k++) {
-        for (int i = 0; i < nx; i++) {
-            for (int j = 0; j < ny; j++) {
+        for (int j = 0; j < ny; j++) {
+            for (int i = 0; i < nx; i++) {
                 LayerID_WholeDomain(k, i, j) = k;
                 GrainID_WholeDomain(k, i, j) = i + j;
             }
@@ -57,8 +57,8 @@ void testPrintExaConstitDefaultRVE() {
     std::getline(GrainplotE, line);
     EXPECT_TRUE(line == "X coord, Y coord, Z coord, Grain ID");
     for (int k = 4; k < 9; k++) {
-        for (int i = 3; i < 8; i++) {
-            for (int j = 3; j < 8; j++) {
+        for (int j = 3; j < 8; j++) {
+            for (int i = 3; i < 8; i++) {
                 std::string ExpectedLine =
                     std::to_string(i) + "," + std::to_string(j) + "," + std::to_string(k) + "," + std::to_string(i + j);
                 std::getline(GrainplotE, line);


### PR DESCRIPTION
Previously, RVE data was contiguous in the Y direction - having the data contiguous in the X direction is cleaner since the coordinates are listed as (x, y, z) and preferred for ExaConstit post-processing