### PR TITLE
Writing and reading of ExaCA output data as binary

### DIFF
--- a/analysis/src/GAutils.hpp
+++ b/analysis/src/GAutils.hpp
@@ -23,7 +23,9 @@ int FindTopOrBottom(int ***LayerID, int XLow, int XHigh, int YLow, int YHigh, in
 // These are used in reading/parsing ExaCA microstructure data
 void ParseLogFile(std::string LogFile, int &nx, int &ny, int &nz, double &deltax, int &NumberOfLayers,
                   bool UseXYZBounds, std::vector<double> &XYZBounds);
-void ReadField(std::ifstream &InputDataStream, int nx, int ny, int nz, ViewI3D_H FieldOfInterest);
+void ReadASCIIField(std::ifstream &InputDataStream, int nx, int ny, int nz, ViewI3D_H FieldOfInterest);
+void ReadBinaryField(std::ifstream &InputDataStream, int nx, int ny, int nz, ViewI3D_H FieldOfInterest,
+                     std::string FieldName);
 void ParseFilenames(std::string AnalysisFile, std::string &LogFile, std::string &MicrostructureFile,
                     std::string &RotationFilename, std::string &OutputFileName, std::string &EulerAnglesFilename,
                     bool &NewOrientationFormatYN, std::string &RGBFilename);

--- a/examples/README.md
+++ b/examples/README.md
@@ -92,7 +92,7 @@ Some additional inputs are optional while others are required
 | Number of spots in y                   | Y            | Number of spots in the y direction
 | Offset between spot centers            | Y            | Offset of spot centers along the x and y axes, in microns
 | Radii of spots                         | Y            | Spot radii, in microns
-| Number of layers                       | Y            | Number of times this pattern is repeated, offset in the +Z (build) direction
+| Number of layers                       | Y            | Number of times this pattern is repeated, offset in the +Z (build) direction. Max value is 32767
 | Offset between layers                  | Y            | If Number of layers > 1, the number of CA cells should separate adjacent layers
 | Substrate grain spacing                | See note (a) | Mean spacing between grain centers in the baseplate/substrate (in microns)
 | Substrate filename                     | See note (a) | Path to and filename for substrate data
@@ -142,3 +142,4 @@ These values govern the printing intermediate data, for debugging or visualizati
 | Increment to separate frames | If Print intermediate frames = Y, the number of microseconds defining the ExaCA output intermediate data increment
 | Intermediate output even if system is unchanged from previous state | (Y or N) If Print intermediate frames = Y, whether or not ExaCA should print intermediate output regardless of whether the simulation has changed from the last frame (if Print intermediate frames = N, Print intermediate frames strict should also be = N)
 | Random seed for grains and nuclei generation | Value of type double used as the seed to generate baseplate, powder, and nuclei details (default value is 0.0 if not provided)
+| Print vtk data as binary | Whether or not ExaCA vtk output data should be printed as big endian binary data, or as ASCII characters (default value is false if not provided)

--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -34,7 +34,8 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
                        bool &PrintMisorientation, bool &PrintFinalUndercoolingVals, bool &PrintFullOutput, int &NSpotsX,
                        int &NSpotsY, int &SpotOffset, int &SpotRadius, bool &PrintTimeSeries, int &TimeSeriesInc,
                        bool &PrintIdleTimeSeriesFrames, bool &PrintDefaultRVE, double &RNGSeed,
-                       bool &BaseplateThroughPowder, double &PowderDensity, int &RVESize, bool &LayerwiseTempRead) {
+                       bool &BaseplateThroughPowder, double &PowderDensity, int &RVESize, bool &LayerwiseTempRead,
+                       bool &PrintBinary) {
 
     // Required inputs that should be present in the input file, regardless of problem type
     std::vector<std::string> RequiredInputs_General = {
@@ -59,6 +60,7 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
         "output even if system is unchanged",           // Optional input 4
         "file of final undercooling values",            // Optional input 5
         "Random seed for grains and nuclei generation", // Optional input 6
+        "Print vtk data as binary",                     // Optional input 7
     };
     std::vector<std::string> DeprecatedInputs_General = {
         "Decomposition strategy", // Deprecated input 0
@@ -403,6 +405,11 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
         RNGSeed = 0.0;
     else
         RNGSeed = getInputDouble(OptionalInputsRead_General[6]);
+    // Should the vtk output files be printed as binary data? (By default, they are printed as ASCII data)
+    if (OptionalInputsRead_General[7].empty())
+        PrintBinary = false;
+    else
+        PrintBinary = getInputBool(OptionalInputsRead_General[7]);
     // For simulations with substrate grain structures, should an input grain spacing or a substrate file be used?
     if ((SimulationType == "S") || (SimulationType == "R")) {
         // Exactly one of the two inputs "sub grain size" and "sub filename" should be present

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -23,7 +23,8 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
                        bool &PrintMisorientation, bool &PrintFinalUndercoolingVals, bool &PrintFullOutput, int &NSpotsX,
                        int &NSpotsY, int &SpotOffset, int &SpotRadius, bool &PrintTimeSeries, int &TimeSeriesInc,
                        bool &PrintIdleTimeSeriesFrames, bool &PrintDefaultRVE, double &RNGSeed,
-                       bool &BaseplateThroughPowder, double &PowderDensity, int &RVESize, bool &LayerwiseTempRead);
+                       bool &BaseplateThroughPowder, double &PowderDensity, int &RVESize, bool &LayerwiseTempRead,
+                       bool &PrintBinary);
 void checkPowderOverflow(int nx, int ny, int LayerHeight, int NumberOfLayers, bool BaseplateThroughPowder,
                          double PowderDensity);
 void NeighborListInit(NList &NeighborX, NList &NeighborY, NList &NeighborZ);

--- a/src/CAparsefiles.hpp
+++ b/src/CAparsefiles.hpp
@@ -8,6 +8,9 @@
 
 #include "CAtypes.hpp"
 
+#include <fstream>
+#include <iostream>
+#include <sstream>
 #include <string>
 
 void skipLines(std::ifstream &stream, std::string seperator);
@@ -36,5 +39,33 @@ void checkFileNotEmpty(std::string testfilename);
 void parseMaterialFile(std::string MaterialFile, double &AConst, double &BConst, double &CConst, double &DConst,
                        double &FreezingRange);
 std::string parseCoordinatePair(std::string line, int val);
+// Swaps bits for a variable of type SwapType
+template <typename SwapType>
+void SwapEndian(SwapType &var) {
+    // Cast var into a char array (bit values)
+    char *varArray = reinterpret_cast<char *>(&var);
+    // Size of char array
+    int varSize = sizeof(var);
+    // Swap the "ith" bit with the bit "i" from the end of the array
+    for (long i = 0; i < static_cast<long>(varSize / 2); i++)
+        std::swap(varArray[varSize - 1 - i], varArray[i]);
+}
+// Reads binary data of the type ReadType, optionally swapping the endian format
+template <typename ReadType>
+ReadType ReadBinaryData(std::ifstream &instream, bool SwapEndianYN = false) {
+    unsigned char temp[sizeof(ReadType)];
+    instream.read(reinterpret_cast<char *>(temp), sizeof(ReadType));
+    if (SwapEndianYN)
+        SwapEndian(temp);
+    ReadType readValue = reinterpret_cast<ReadType &>(temp);
+    return readValue;
+}
+// Parse space-separated ASCII data loaded into the string stream
+template <typename ReadType>
+ReadType ParseASCIIData(std::istringstream &ss) {
+    ReadType readValue;
+    ss >> readValue;
+    return readValue;
+}
 
 #endif

--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -7,13 +7,20 @@
 #define EXACA_PRINT_HPP
 
 #include "CAinterfacialresponse.hpp"
+#include "CAparsefiles.hpp"
 #include "CAtypes.hpp"
 
 #include <Kokkos_Core.hpp>
 
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
 
+void WriteHeader(std::ofstream &ParaviewOutputStream, std::string FName, bool PrintBinary, int nx, int ny, int nz,
+                 double deltax, double XMin, double YMin, double ZMin);
 void CollectIntField(ViewI3D_H IntVar_WholeDomain, ViewI_H IntVar, int nx, int ny, int nz, int MyYSlices, int np,
                      ViewI_H RecvYOffset, ViewI_H RecvYSlices, ViewI_H RBufSize);
 void CollectFloatField(ViewF3D_H FloatVar_WholeDomain, ViewF_H FloatVar, int nx, int ny, int nz, int MyYSlices, int np,
@@ -28,7 +35,7 @@ void PrintExaCAData(int id, int layernumber, int np, int nx, int ny, int nz, int
                     int NGrainOrientations, std::string PathToOutput, int PrintDebug, bool PrintMisorientation,
                     bool PrintFinalUndercooling, bool PrintFullOutput, bool PrintTimeSeries, bool PrintDefaultRVE,
                     int IntermediateFileCounter, int ZBound_Low, int nzActive, double deltax, float XMin, float YMin,
-                    float ZMin, int NumberOfLayers, int RVESize = 0);
+                    float ZMin, int NumberOfLayers, bool PrintBinary, int RVESize = 0);
 void PrintExaCALog(int id, int np, std::string InputFile, std::string SimulationType, int MyYSlices, int MyYOffset,
                    InterfacialResponseFunction irf, double deltax, double NMax, double dTN, double dTsigma,
                    std::vector<std::string> temp_paths, int TempFilesInSeries, double HT_deltax, bool RemeltingYN,
@@ -44,19 +51,33 @@ void PrintCAFields(int nx, int ny, int nz, ViewI3D_H GrainID_WholeDomain, ViewI3
                    ViewI3D_H CritTimeStep_WholeDomain, ViewI3D_H CellType_WholeDomain,
                    ViewF3D_H UndercoolingChange_WholeDomain, ViewF3D_H UndercoolingCurrent_WholeDomain,
                    std::string PathToOutput, std::string BaseFileName, int PrintDebug, bool PrintFullOutput,
-                   double deltax, float XMin, float YMin, float ZMin);
+                   double deltax, float XMin, float YMin, float ZMin, bool PrintBinary);
 void PrintGrainMisorientations(std::string BaseFileName, std::string PathToOutput, int nx, int ny, int nz,
                                ViewI3D_H LayerID_WholeDomain, ViewI3D_H GrainID_WholeDomain, ViewF_H GrainUnitVector,
-                               int NGrainOrientations, double deltax, float XMin, float YMin, float ZMin);
+                               int NGrainOrientations, double deltax, float XMin, float YMin, float ZMin,
+                               bool PrintBinary);
 void PrintFinalUndercooling(std::string BaseFileName, std::string PathToOutput, int nx, int ny, int nz,
                             ViewF3D_H UndercoolingCurrent_WholeDomain, ViewI3D_H LayerID_WholeDomain, double deltax,
-                            float XMin, float YMin, float ZMin);
+                            float XMin, float YMin, float ZMin, bool PrintBinary);
 void PrintExaConstitDefaultRVE(std::string BaseFileName, std::string PathToOutput, int nx, int ny, int nz,
                                ViewI3D_H LayerID_WholeDomain, ViewI3D_H GrainID_WholeDomain, double deltax,
                                int NumberOfLayers, int RVESize);
 void PrintIntermediateExaCAState(int IntermediateFileCounter, int layernumber, std::string BaseFileName,
                                  std::string PathToOutput, int ZBound_Low, int nzActive, int nx, int ny,
                                  ViewI3D_H GrainID_WholeDomain, ViewI3D_H CellType_WholeDomain, ViewF_H GrainUnitVector,
-                                 int NGrainOrientations, double deltax, float XMin, float YMin, float ZMin);
+                                 int NGrainOrientations, double deltax, float XMin, float YMin, float ZMin,
+                                 bool PrintBinary);
+// Write data of type PrintType as ascii or binary, with option to convert between big and small endian binary
+template <typename PrintType>
+void WriteData(std::ofstream &outstream, PrintType PrintValue, bool PrintBinary, bool SwapEndianYN = false) {
+    if (PrintBinary) {
+        if (SwapEndianYN)
+            SwapEndian(PrintValue);
+        int varSize = sizeof(PrintType);
+        outstream.write((char *)&PrintValue, varSize);
+    }
+    else
+        outstream << PrintValue << " ";
+}
 
 #endif

--- a/src/CAupdate.cpp
+++ b/src/CAupdate.cpp
@@ -527,7 +527,7 @@ void JumpTimeStep(int &cycle, unsigned long int RemainingCellsOfInterest, unsign
                   ViewF UndercoolingCurrent, std::string OutputFile, int NGrainOrientations, std::string PathToOutput,
                   int &IntermediateFileCounter, int nzActive, double deltax, float XMin, float YMin, float ZMin,
                   int NumberOfLayers, int &XSwitch, std::string TemperatureDataType, bool PrintIdleMovieFrames,
-                  int MovieFrameInc, int FinishTimeStep = 0) {
+                  int MovieFrameInc, bool PrintBinary, int FinishTimeStep = 0) {
 
     MPI_Bcast(&RemainingCellsOfInterest, 1, MPI_UNSIGNED_LONG, 0, MPI_COMM_WORLD);
     if (RemainingCellsOfInterest == 0) {
@@ -575,7 +575,7 @@ void JumpTimeStep(int &cycle, unsigned long int RemainingCellsOfInterest, unsign
                                        GrainUnitVector, LayerID, CellType, UndercoolingChange, UndercoolingCurrent,
                                        OutputFile, NGrainOrientations, PathToOutput, 0, false, false, false, true,
                                        false, IntermediateFileCounter, ZBound_Low, nzActive, deltax, XMin, YMin, ZMin,
-                                       NumberOfLayers);
+                                       NumberOfLayers, PrintBinary);
                         IntermediateFileCounter++;
                     }
                 }
@@ -601,7 +601,7 @@ void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyYSlices, int M
                                 ViewI LayerID, ViewF GrainUnitVector, ViewF UndercoolingChange,
                                 ViewF UndercoolingCurrent, std::string PathToOutput, std::string OutputFile,
                                 bool PrintIdleMovieFrames, int MovieFrameInc, int &IntermediateFileCounter,
-                                int NumberOfLayers) {
+                                int NumberOfLayers, bool PrintBinary) {
 
     unsigned long int LocalSuperheatedCells;
     unsigned long int LocalUndercooledCells;
@@ -662,22 +662,20 @@ void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyYSlices, int M
                      MyYSlices, ZBound_Low, false, CellType, LayerID, id, layernumber, np, nx, ny, nz, MyYOffset,
                      GrainID, CritTimeStep, GrainUnitVector, UndercoolingChange, UndercoolingCurrent, OutputFile,
                      NGrainOrientations, PathToOutput, IntermediateFileCounter, nzActive, deltax, XMin, YMin, ZMin,
-                     NumberOfLayers, XSwitch, TemperatureDataType, PrintIdleMovieFrames, MovieFrameInc,
+                     NumberOfLayers, XSwitch, TemperatureDataType, PrintIdleMovieFrames, MovieFrameInc, PrintBinary,
                      FinishTimeStep[layernumber]);
 }
 
 //*****************************************************************************/
 // Prints intermediate code output to stdout (intermediate output collected and printed is different than without
 // remelting) and checks to see if solidification is complete in the case where cells can solidify multiple times
-void IntermediateOutputAndCheck_Remelt(int id, int np, int &cycle, int MyYSlices, int MyYOffset,
-                                       int LocalActiveDomainSize, int nx, int ny, int nz, int nzActive, double deltax,
-                                       float XMin, float YMin, float ZMin, int SuccessfulNucEvents_ThisRank,
-                                       int &XSwitch, ViewI CellType, ViewI CritTimeStep, ViewI GrainID,
-                                       std::string TemperatureDataType, int layernumber, int, int ZBound_Low,
-                                       int NGrainOrientations, ViewI LayerID, ViewF GrainUnitVector,
-                                       ViewF UndercoolingChange, ViewF UndercoolingCurrent, std::string PathToOutput,
-                                       std::string OutputFile, bool PrintIdleMovieFrames, int MovieFrameInc,
-                                       int &IntermediateFileCounter, int NumberOfLayers, ViewI MeltTimeStep) {
+void IntermediateOutputAndCheck_Remelt(
+    int id, int np, int &cycle, int MyYSlices, int MyYOffset, int LocalActiveDomainSize, int nx, int ny, int nz,
+    int nzActive, double deltax, float XMin, float YMin, float ZMin, int SuccessfulNucEvents_ThisRank, int &XSwitch,
+    ViewI CellType, ViewI CritTimeStep, ViewI GrainID, std::string TemperatureDataType, int layernumber, int,
+    int ZBound_Low, int NGrainOrientations, ViewI LayerID, ViewF GrainUnitVector, ViewF UndercoolingChange,
+    ViewF UndercoolingCurrent, std::string PathToOutput, std::string OutputFile, bool PrintIdleMovieFrames,
+    int MovieFrameInc, int &IntermediateFileCounter, int NumberOfLayers, ViewI MeltTimeStep, bool PrintBinary) {
 
     unsigned long int LocalSuperheatedCells;
     unsigned long int LocalUndercooledCells;
@@ -732,5 +730,5 @@ void IntermediateOutputAndCheck_Remelt(int id, int np, int &cycle, int MyYSlices
                      ZBound_Low, true, CellType, LayerID, id, layernumber, np, nx, ny, nz, MyYOffset, GrainID,
                      CritTimeStep, GrainUnitVector, UndercoolingChange, UndercoolingCurrent, OutputFile,
                      NGrainOrientations, PathToOutput, IntermediateFileCounter, nzActive, deltax, XMin, YMin, ZMin,
-                     NumberOfLayers, XSwitch, TemperatureDataType, PrintIdleMovieFrames, MovieFrameInc);
+                     NumberOfLayers, XSwitch, TemperatureDataType, PrintIdleMovieFrames, MovieFrameInc, PrintBinary);
 }

--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -107,7 +107,7 @@ void JumpTimeStep(int &cycle, unsigned long int RemainingCellsOfInterest, ViewI 
                   int DecompositionStrategy, int NGrainOrientations, std::string PathToOutput,
                   int &IntermediateFileCounter, int nzActive, double deltax, float XMin, float YMin, float ZMin,
                   int NumberOfLayers, int &XSwitch, std::string TemperatureDataType, bool PrintIdleMovieFrames,
-                  int MovieFrameInc, int FinishTimeStep);
+                  int MovieFrameInc, bool PrintBinary, int FinishTimeStep);
 void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyYSlices, int MyYOffset, int LocalDomainSize,
                                 int LocalActiveDomainSize, int nx, int ny, int nz, int nzActive, double deltax,
                                 float XMin, float YMin, float ZMin, int SuccessfulNucEvents_ThisRank, int &XSwitch,
@@ -116,15 +116,13 @@ void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyYSlices, int M
                                 ViewI LayerID, ViewF GrainUnitVector, ViewF UndercoolingChange,
                                 ViewF UndercoolingCurrent, std::string PathToOutput, std::string OutputFile,
                                 bool PrintIdleMovieFrames, int MovieFrameInc, int &IntermediateFileCounter,
-                                int NumberOfLayers);
-void IntermediateOutputAndCheck_Remelt(int id, int np, int &cycle, int MyYSlices, int MyYOffset,
-                                       int LocalActiveDomainSize, int nx, int ny, int nz, int nzActive, double deltax,
-                                       float XMin, float YMin, float ZMin, int SuccessfulNucEvents_ThisRank,
-                                       int &XSwitch, ViewI CellType, ViewI CritTimeStep, ViewI GrainID,
-                                       std::string TemperatureDataType, int layernumber, int, int ZBound_Low,
-                                       int NGrainOrientations, ViewI LayerID, ViewF GrainUnitVector,
-                                       ViewF UndercoolingChange, ViewF UndercoolingCurrent, std::string PathToOutput,
-                                       std::string OutputFile, bool PrintIdleMovieFrames, int MovieFrameInc,
-                                       int &IntermediateFileCounter, int NumberOfLayers, ViewI MeltTimeStep);
+                                int NumberOfLayers, bool PrintBinary);
+void IntermediateOutputAndCheck_Remelt(
+    int id, int np, int &cycle, int MyYSlices, int MyYOffset, int LocalActiveDomainSize, int nx, int ny, int nz,
+    int nzActive, double deltax, float XMin, float YMin, float ZMin, int SuccessfulNucEvents_ThisRank, int &XSwitch,
+    ViewI CellType, ViewI CritTimeStep, ViewI GrainID, std::string TemperatureDataType, int layernumber, int,
+    int ZBound_Low, int NGrainOrientations, ViewI LayerID, ViewF GrainUnitVector, ViewF UndercoolingChange,
+    ViewF UndercoolingCurrent, std::string PathToOutput, std::string OutputFile, bool PrintIdleMovieFrames,
+    int MovieFrameInc, int &IntermediateFileCounter, int NumberOfLayers, ViewI MeltTimeStep, bool PrintBinary);
 
 #endif

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -26,7 +26,8 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     unsigned int NumberOfTemperatureDataPoints;
     int PrintDebug, TimeSeriesInc;
     bool PrintMisorientation, PrintFinalUndercoolingVals, PrintFullOutput, RemeltingYN, UseSubstrateFile,
-        PrintTimeSeries, PrintIdleTimeSeriesFrames, PrintDefaultRVE, BaseplateThroughPowder, LayerwiseTempRead;
+        PrintTimeSeries, PrintIdleTimeSeriesFrames, PrintDefaultRVE, BaseplateThroughPowder, LayerwiseTempRead,
+        PrintBinary;
     float SubstrateGrainSpacing;
     double HT_deltax, deltax, deltat, FractSurfaceSitesActive, G, R, NMax, dTN, dTsigma, RNGSeed, PowderDensity;
     std::string SubstrateFileName, MaterialFileName, SimulationType, OutputFile, GrainOrientationFile, PathToOutput;
@@ -39,7 +40,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                       FractSurfaceSitesActive, PathToOutput, PrintDebug, PrintMisorientation,
                       PrintFinalUndercoolingVals, PrintFullOutput, NSpotsX, NSpotsY, SpotOffset, SpotRadius,
                       PrintTimeSeries, TimeSeriesInc, PrintIdleTimeSeriesFrames, PrintDefaultRVE, RNGSeed,
-                      BaseplateThroughPowder, PowderDensity, RVESize, LayerwiseTempRead);
+                      BaseplateThroughPowder, PowderDensity, RVESize, LayerwiseTempRead, PrintBinary);
     // Read material data.
     InterfacialResponseFunction irf(MaterialFileName, deltat, deltax);
 
@@ -283,7 +284,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
         PrintExaCAData(id, -1, np, nx, ny, nz, MyYSlices, MyYOffset, GrainID, CritTimeStep, GrainUnitVector, LayerID,
                        CellType, UndercoolingChange, UndercoolingCurrent, OutputFile, NGrainOrientations, PathToOutput,
                        PrintDebug, false, false, false, false, false, 0, ZBound_Low, nzActive, deltax, XMin, YMin, ZMin,
-                       NumberOfLayers);
+                       NumberOfLayers, PrintBinary);
         MPI_Barrier(MPI_COMM_WORLD);
         if (id == 0)
             std::cout << "Initialization data file(s) printed" << std::endl;
@@ -307,7 +308,8 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                 PrintExaCAData(id, layernumber, np, nx, ny, nz, MyYSlices, MyYOffset, GrainID, CritTimeStep,
                                GrainUnitVector, LayerID, CellType, UndercoolingChange, UndercoolingCurrent, OutputFile,
                                NGrainOrientations, PathToOutput, 0, false, false, false, true, false,
-                               IntermediateFileCounter, ZBound_Low, nzActive, deltax, XMin, YMin, ZMin, NumberOfLayers);
+                               IntermediateFileCounter, ZBound_Low, nzActive, deltax, XMin, YMin, ZMin, NumberOfLayers,
+                               PrintBinary);
                 IntermediateFileCounter++;
             }
             cycle++;
@@ -364,8 +366,8 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                         YMin, ZMin, SuccessfulNucEvents_ThisRank, XSwitch, CellType, CritTimeStep, GrainID,
                         SimulationType, layernumber, NumberOfLayers, ZBound_Low, NGrainOrientations, LayerID,
                         GrainUnitVector, UndercoolingChange, UndercoolingCurrent, PathToOutput, OutputFile,
-                        PrintIdleTimeSeriesFrames, TimeSeriesInc, IntermediateFileCounter, NumberOfLayers,
-                        MeltTimeStep);
+                        PrintIdleTimeSeriesFrames, TimeSeriesInc, IntermediateFileCounter, NumberOfLayers, MeltTimeStep,
+                        PrintBinary);
                 else
                     IntermediateOutputAndCheck(id, np, cycle, MyYSlices, MyYOffset, LocalDomainSize,
                                                LocalActiveDomainSize, nx, ny, nz, nzActive, deltax, XMin, YMin, ZMin,
@@ -373,7 +375,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                                                SimulationType, FinishTimeStep, layernumber, NumberOfLayers, ZBound_Low,
                                                NGrainOrientations, LayerID, GrainUnitVector, UndercoolingChange,
                                                UndercoolingCurrent, PathToOutput, OutputFile, PrintIdleTimeSeriesFrames,
-                                               TimeSeriesInc, IntermediateFileCounter, NumberOfLayers);
+                                               TimeSeriesInc, IntermediateFileCounter, NumberOfLayers, PrintBinary);
             }
 
         } while (XSwitch == 0);
@@ -509,7 +511,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                        GrainUnitVector, LayerID, CellType, UndercoolingChange, UndercoolingCurrent, OutputFile,
                        NGrainOrientations, PathToOutput, 0, PrintMisorientation, PrintFinalUndercoolingVals,
                        PrintFullOutput, false, PrintDefaultRVE, 0, ZBound_Low, nzActive, deltax, XMin, YMin, ZMin,
-                       NumberOfLayers, RVESize);
+                       NumberOfLayers, PrintBinary, RVESize);
     }
     else {
         if (id == 0)


### PR DESCRIPTION
Added the option to print ExaCA vtk data as binary data (instead of ASCII, which is currently used by default) to reduce the output file sizes. To support this, new functions were added to read and write binary data, and convert between little and big endian format, and a new unit test was written to test the binary input/output.

LayerID and GrainMisorientation data is now printed as "short int" data instead of "int" to reduce file size, this won't matter for GrainMisorientation which will never reach the lower/upper limits of this data type, and would only matter for LayerID in the unlikely case that more than 32,767 layers of microstructure were simulated