### PR TITLE
Consolidation of layer bound check functions to simplify code

### DIFF
--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -39,12 +39,10 @@ void ReadTemperatureData(int id, double &deltax, double HT_deltax, int &HTtoCAra
                          float YMin, std::vector<std::string> &temp_paths, int NumberOfLayers, int TempFilesInSeries,
                          unsigned int &NumberOfTemperatureDataPoints, std::vector<double> &RawData, int *FirstValue,
                          int *LastValue, bool LayerwiseTempRead, int layernumber);
-int calcZBound_Low_Remelt(std::string SimulationType, int LayerHeight, int layernumber, float *ZMinLayer, float ZMin,
-                          double deltax);
-int calcZBound_High_Remelt(std::string SimulationType, int SpotRadius, int LayerHeight, int layernumber, float ZMin,
-                           double deltax, int nz, float *ZMaxLayer);
-int calcZBound_Low_NoRemelt(int id, int MyXSlices, int MyYSlices, int LocalDomainSize, int layernumber, ViewI LayerID);
-int calcZBound_High_NoRemelt(int id, int MyXSlices, int MyYSlices, int LocalDomainSize, int layernumber, ViewI LayerID);
+int calcZBound_Low(std::string SimulationType, int LayerHeight, int layernumber, float *ZMinLayer, float ZMin,
+                   double deltax);
+int calcZBound_High(std::string SimulationType, int SpotRadius, int LayerHeight, int layernumber, float ZMin,
+                    double deltax, int nz, float *ZMaxLayer);
 int calcnzActive(int ZBound_Low, int ZBound_High, int id, int layernumber);
 int calcLocalActiveDomainSize(int nx, int MyYSlices, int nzActive);
 void TempInit_DirSolidification(double G, double R, int id, int &nx, int &MyYSlices, double deltax, double deltat,

--- a/unit_test/tstInit.cpp
+++ b/unit_test/tstInit.cpp
@@ -269,7 +269,7 @@ void testReadWrite(bool PrintReadBinary) {
 //---------------------------------------------------------------------------//
 // activedomainsizecalc
 //---------------------------------------------------------------------------//
-void testcalcZBound_Low_Remelt() {
+void testcalcZBound_Low() {
 
     int LayerHeight = 10;
     int NumberOfLayers = 10;
@@ -281,16 +281,16 @@ void testcalcZBound_Low_Remelt() {
         // both problem types by the same)
         ZMinLayer[layernumber] = ZMin + layernumber * LayerHeight * deltax;
         // Call function for each layernumber, and for simulation types "S" and "R"
-        int ZBound_Low_S = calcZBound_Low_Remelt("S", LayerHeight, layernumber, ZMinLayer, ZMin, deltax);
+        int ZBound_Low_S = calcZBound_Low("S", LayerHeight, layernumber, ZMinLayer, ZMin, deltax);
         EXPECT_EQ(ZBound_Low_S, LayerHeight * layernumber);
-        int ZBound_Low_R = calcZBound_Low_Remelt("R", LayerHeight, layernumber, ZMinLayer, ZMin, deltax);
+        int ZBound_Low_R = calcZBound_Low("R", LayerHeight, layernumber, ZMinLayer, ZMin, deltax);
         EXPECT_EQ(ZBound_Low_R, LayerHeight * layernumber);
     }
 }
 
-void testcalcZBound_High_Remelt() {
+void testcalcZBound_High() {
 
-    // A separate function is now used for ZBound_High calculation without remelting
+    // A separate function is now used for ZBound_High calculation
     int SpotRadius = 100;
     int LayerHeight = 10;
     float ZMin = 0.5 * pow(10, -6);
@@ -303,15 +303,12 @@ void testcalcZBound_High_Remelt() {
         // ZMax value of ZMin + SpotRadius (lets solution for both problem types be the same)
         ZMaxLayer[layernumber] = ZMin + SpotRadius * deltax + layernumber * LayerHeight * deltax;
         // Call function for each layernumber, and for simulation types "S" and "R"
-        int ZBound_Max_S =
-            calcZBound_High_Remelt("S", SpotRadius, LayerHeight, layernumber, ZMin, deltax, nz, ZMaxLayer);
+        int ZBound_Max_S = calcZBound_High("S", SpotRadius, LayerHeight, layernumber, ZMin, deltax, nz, ZMaxLayer);
         EXPECT_EQ(ZBound_Max_S, SpotRadius + LayerHeight * layernumber);
-        int ZBound_Max_R =
-            calcZBound_High_Remelt("R", SpotRadius, LayerHeight, layernumber, ZMin, deltax, nz, ZMaxLayer);
+        int ZBound_Max_R = calcZBound_High("R", SpotRadius, LayerHeight, layernumber, ZMin, deltax, nz, ZMaxLayer);
         EXPECT_EQ(ZBound_Max_R, SpotRadius + LayerHeight * layernumber);
         // For simulation type C, should be independent of layernumber
-        int ZBound_Max_C =
-            calcZBound_High_Remelt("C", SpotRadius, LayerHeight, layernumber, ZMin, deltax, nz, ZMaxLayer);
+        int ZBound_Max_C = calcZBound_High("C", SpotRadius, LayerHeight, layernumber, ZMin, deltax, nz, ZMaxLayer);
         EXPECT_EQ(ZBound_Max_C, nz - 1);
     }
 }
@@ -500,8 +497,8 @@ TEST(TEST_CATEGORY, fileread_test) {
     testReadWrite(false);
 }
 TEST(TEST_CATEGORY, activedomainsizecalc) {
-    testcalcZBound_Low_Remelt();
-    testcalcZBound_High_Remelt();
+    testcalcZBound_Low();
+    testcalcZBound_High();
     testcalcnzActive();
     testcalcLocalActiveDomainSize();
 }

--- a/unit_test/tstKokkosInit.hpp
+++ b/unit_test/tstKokkosInit.hpp
@@ -79,45 +79,6 @@ void testOrientationInit_Angles() {
     }
 }
 
-// Tests calcZBound_Low_NoRemelt and calcZBound_High_NoRemelt
-void testcalcZBounds_NoRemelt() {
-
-    // Domain setup
-    int nx = 5;
-    int ny = 4;
-    int nz = 12;
-    int DomainSize = nx * ny * nz;
-    ViewI_H LayerID_Host(Kokkos::ViewAllocateWithoutInitializing("LayerID_Host"), DomainSize);
-
-    int layernumber = 0;
-    // Fill LayerID with -1s (not associated with a layer), assign a few cells the value "layernumber", assign a few
-    // other cells the value "layernumber + 1"
-    Kokkos::deep_copy(LayerID_Host, -1);
-    for (int k = 0; k < nz; k++) {
-        for (int i = 0; i < nx; i++) {
-            for (int j = 0; j < ny; j++) {
-                int Coordinate1D = k * nx * ny + i * ny + j;
-                if ((i == 2) && (j == 2) && (k > 4)) {
-                    if (k < 8)
-                        LayerID_Host(Coordinate1D) = layernumber;
-                    else
-                        LayerID_Host(Coordinate1D) = layernumber + 1;
-                }
-            }
-        }
-    }
-
-    // Copy view to device
-    ViewI LayerID = Kokkos::create_mirror_view_and_copy(device_memory_space(), LayerID_Host);
-
-    // Calculate ZBound_Low and ZBound_High
-    int ZBound_Low = calcZBound_Low_NoRemelt(0, nx, ny, DomainSize, layernumber, LayerID);
-    int ZBound_High = calcZBound_High_NoRemelt(0, nx, ny, DomainSize, layernumber, LayerID);
-
-    // Check against expected values
-    EXPECT_EQ(ZBound_Low, 5);
-    EXPECT_EQ(ZBound_High, 7);
-}
 //---------------------------------------------------------------------------//
 // RUN TESTS
 //---------------------------------------------------------------------------//
@@ -125,5 +86,4 @@ TEST(TEST_CATEGORY, orientation_init_tests) {
     testOrientationInit_Vectors();
     testOrientationInit_Angles();
 }
-TEST(TEST_CATEGORY, activedomainsizecalc) { testcalcZBounds_NoRemelt(); }
 } // end namespace Test


### PR DESCRIPTION
Removal of calcZBound_Low_NoRemelt and calcZBound_Low_NoRemelt functions - code without remelting now uses the same bounds calculation functions as the remelting code. This will lead to iteration over more cells than needed for certain situations in simulations without remelting, but the effect on performance appears to be minor to negligible (<3% of runtime) and the effect on the result is minor (iterating over the extra cells per layer slightly biases the simulation towards growth of existing grains over nucleation/growth of new ones)