### PR TITLE
fixup: remove unused variables

### DIFF
--- a/analysis/src/GAprint.cpp
+++ b/analysis/src/GAprint.cpp
@@ -373,12 +373,11 @@ void AnalyzeCrossSection_Bimodal(std::ofstream &QoIs, std::string BaseFileName, 
         std::round(MinGrainSize_microns / (deltax * deltax * pow(10, 12))); // convert area to value in cells
     int SmallLargeCutoff =
         std::round(SmallLargeCutoff_microns / (deltax * deltax * pow(10, 12))); // convert area to value in cells
-    int NumTooSmallGrains = 0, NumSmallGrains = 0, NumLargeGrains = 0;
+    int NumSmallGrains = 0, NumLargeGrains = 0;
     int AreaTooSmallGrains = 0, AreaSmallGrains = 0, AreaLargeGrains = 0;
     for (int n = 0; n < NumberOfGrains; n++) {
         if (GrainAreas[n] < MinGrainSize) {
             AreaTooSmallGrains += GrainAreas[n];
-            NumTooSmallGrains++;
         }
         else {
             if (GrainAreas[n] < SmallLargeCutoff) {

--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -1147,7 +1147,6 @@ void TempInit_SpotRemelt(int layernumber, double G, double R, std::string, int i
                   << ", each of which takes approximately " << TimeBetweenSpots << " time steps to solidify"
                   << std::endl;
 
-    int Count = 0;
     for (int n = 0; n < NumberOfSpots; n++) {
         if (id == 0)
             std::cout << "Initializing spot " << n << " on layer " << layernumber << std::endl;
@@ -1176,7 +1175,6 @@ void TempInit_SpotRemelt(int layernumber, double G, double R, std::string, int i
                         LayerTimeTempHistory_Host(D3D1ConvPosition, NumberOfSolidificationEvents_Host(D3D1ConvPosition),
                                                   2) = R * deltat;
                         NumberOfSolidificationEvents_Host(D3D1ConvPosition)++;
-                        Count++;
                     }
                 }
             }


### PR DESCRIPTION
unused counters produce warnings on newer clang versions