### PR TITLE
Consistent use of double for temperature data

### DIFF
--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -531,9 +531,9 @@ void NeighborListInit(NList &NeighborX, NList &NeighborY, NList &NeighborZ) {
 // Obtain the physical XYZ bounds of the domain, using either domain size from the input file, or reading temperature
 // data files and parsing the coordinates
 void FindXYZBounds(std::string SimulationType, int id, double &deltax, int &nx, int &ny, int &nz,
-                   std::vector<std::string> &temp_paths, float &XMin, float &XMax, float &YMin, float &YMax,
-                   float &ZMin, float &ZMax, int &LayerHeight, int NumberOfLayers, int TempFilesInSeries,
-                   float *ZMinLayer, float *ZMaxLayer, int SpotRadius) {
+                   std::vector<std::string> &temp_paths, double &XMin, double &XMax, double &YMin, double &YMax,
+                   double &ZMin, double &ZMax, int &LayerHeight, int NumberOfLayers, int TempFilesInSeries,
+                   double *ZMinLayer, double *ZMaxLayer, int SpotRadius) {
 
     if (SimulationType == "R") {
         // Two passes through reading temperature data files- the first pass only reads the headers to
@@ -542,12 +542,12 @@ void FindXYZBounds(std::string SimulationType, int id, double &deltax, int &nx, 
         // remelting events in the simulation can also be calculated. The second pass reads the actual X/Y/Z/liquidus
         // time/cooling rate data and each rank stores the data relevant to itself in "RawData" - this is done in the
         // subroutine "ReadTemperatureData"
-        XMin = std::numeric_limits<float>::max();
-        YMin = std::numeric_limits<float>::max();
-        ZMin = std::numeric_limits<float>::max();
-        XMax = std::numeric_limits<float>::min();
-        YMax = std::numeric_limits<float>::min();
-        ZMax = std::numeric_limits<float>::min();
+        XMin = std::numeric_limits<double>::max();
+        YMin = std::numeric_limits<double>::max();
+        ZMin = std::numeric_limits<double>::max();
+        XMax = std::numeric_limits<double>::min();
+        YMax = std::numeric_limits<double>::min();
+        ZMax = std::numeric_limits<double>::min();
 
         // Read the first temperature file, first line to determine if the "new" OpenFOAM output format (with a 1 line
         // header) is used, or whether the "old" OpenFOAM header (which contains information like the X/Y/Z bounds of
@@ -579,12 +579,12 @@ void FindXYZBounds(std::string SimulationType, int id, double &deltax, int &nx, 
             getline(TemperatureFile, HeaderLine);
             checkForHeaderValues(HeaderLine);
 
-            double XMin_ThisLayer = 1000000.0;
-            double XMax_ThisLayer = -1000000.0;
-            double YMin_ThisLayer = 1000000.0;
-            double YMax_ThisLayer = -1000000.0;
-            double ZMin_ThisLayer = 1000000.0;
-            double ZMax_ThisLayer = -100000.0;
+            double XMin_ThisLayer = std::numeric_limits<double>::max();
+            double YMin_ThisLayer = std::numeric_limits<double>::max();
+            double ZMin_ThisLayer = std::numeric_limits<double>::max();
+            double XMax_ThisLayer = std::numeric_limits<double>::min();
+            double YMax_ThisLayer = std::numeric_limits<double>::min();
+            double ZMax_ThisLayer = std::numeric_limits<double>::min();
 
             // Units are assumed to be in meters, meters, seconds, seconds, and K/second
             std::vector<double> XCoordinates(1000000), YCoordinates(1000000), ZCoordinates(1000000);
@@ -721,7 +721,7 @@ void DomainDecomposition(int id, int np, int &MyYSlices, int &MyYOffset, int &Ne
 
 // Read in temperature data from files, stored in "RawData", with the appropriate MPI ranks storing the appropriate data
 void ReadTemperatureData(int id, double &deltax, double HT_deltax, int &HTtoCAratio, int MyYSlices, int MyYOffset,
-                         float YMin, std::vector<std::string> &temp_paths, int NumberOfLayers, int TempFilesInSeries,
+                         double YMin, std::vector<std::string> &temp_paths, int NumberOfLayers, int TempFilesInSeries,
                          unsigned int &NumberOfTemperatureDataPoints, std::vector<double> &RawData, int *FirstValue,
                          int *LastValue, bool LayerwiseTempRead, int layernumber) {
 
@@ -856,7 +856,7 @@ void ReadTemperatureData(int id, double &deltax, double HT_deltax, int &HTtoCAra
 
 //*****************************************************************************/
 // Get the Z coordinate of the lower bound of iteration
-int calcZBound_Low(std::string SimulationType, int LayerHeight, int layernumber, float *ZMinLayer, float ZMin,
+int calcZBound_Low(std::string SimulationType, int LayerHeight, int layernumber, double *ZMinLayer, double ZMin,
                    double deltax) {
 
     int ZBound_Low = -1; // assign dummy initial value
@@ -879,8 +879,8 @@ int calcZBound_Low(std::string SimulationType, int LayerHeight, int layernumber,
 }
 //*****************************************************************************/
 // Get the Z coordinate of the upper bound of iteration
-int calcZBound_High(std::string SimulationType, int SpotRadius, int LayerHeight, int layernumber, float ZMin,
-                    double deltax, int nz, float *ZMaxLayer) {
+int calcZBound_High(std::string SimulationType, int SpotRadius, int LayerHeight, int layernumber, double ZMin,
+                    double deltax, int nz, double *ZMaxLayer) {
 
     int ZBound_High = -1; // assign dummy initial value
     if (SimulationType == "C") {
@@ -1179,18 +1179,18 @@ void TempInit_SpotRemelt(int layernumber, double G, double R, std::string, int i
 }
 
 // Read data from storage, and calculate the normalized x value of the data point
-int getTempCoordX(int i, float XMin, double deltax, const std::vector<double> &RawData) {
+int getTempCoordX(int i, double XMin, double deltax, const std::vector<double> &RawData) {
     int XInt = round((RawData[i] - XMin) / deltax);
     return XInt;
 }
 // Read data from storage, and calculate the normalized y value of the data point
-int getTempCoordY(int i, float YMin, double deltax, const std::vector<double> &RawData) {
+int getTempCoordY(int i, double YMin, double deltax, const std::vector<double> &RawData) {
     int YInt = round((RawData[i + 1] - YMin) / deltax);
     return YInt;
 }
 // Read data from storage, and calculate the normalized z value of the data point
 int getTempCoordZ(int i, double deltax, const std::vector<double> &RawData, int LayerHeight, int LayerCounter,
-                  float *ZMinLayer) {
+                  double *ZMinLayer) {
     int ZInt = round((RawData[i + 2] + deltax * LayerHeight * LayerCounter - ZMinLayer[LayerCounter]) / deltax);
     return ZInt;
 }
@@ -1214,9 +1214,9 @@ double getTempCoordCR(int i, const std::vector<double> &RawData) {
 // file(s)
 void TempInit_ReadDataNoRemelt(int id, int &nx, int &MyYSlices, int &MyYOffset, double deltax, int HTtoCAratio,
                                double deltat, int, int LocalDomainSize, ViewI &CritTimeStep, ViewF &UndercoolingChange,
-                               float XMin, float YMin, float ZMin, float *ZMinLayer, float *ZMaxLayer, int LayerHeight,
-                               int NumberOfLayers, int *FinishTimeStep, double FreezingRange, ViewI &LayerID,
-                               int *FirstValue, int *LastValue, std::vector<double> RawData) {
+                               double XMin, double YMin, double ZMin, double *ZMinLayer, double *ZMaxLayer,
+                               int LayerHeight, int NumberOfLayers, int *FinishTimeStep, double FreezingRange,
+                               ViewI &LayerID, int *FirstValue, int *LastValue, std::vector<double> RawData) {
 
     // These views are initialized to zeros on the host, filled with data, and then copied to the device for layer
     // "layernumber"
@@ -1289,7 +1289,7 @@ void TempInit_ReadDataNoRemelt(int id, int &nx, int &MyYSlices, int &MyYOffset, 
                 }
                 double CoolingRate = getTempCoordCR(i, RawData);
                 CR[ZInt][XInt][YInt - LowerYBound] = CoolingRate;
-                float SolidusTime =
+                double SolidusTime =
                     CritTL[ZInt][XInt][YInt - LowerYBound] + FreezingRange / CR[ZInt][XInt][YInt - LowerYBound];
                 if (SolidusTime > LargestTime) {
                     // Store largest TSolidus value (based on liquidus/cooling rate/freezing range) over all cells
@@ -1429,8 +1429,8 @@ void TempInit_ReadDataNoRemelt(int id, int &nx, int &MyYSlices, int &MyYOffset, 
 // Calculate the number of times that a cell in layer "layernumber" undergoes melting/solidification, and store in
 // MaxSolidificationEvents_Host
 void calcMaxSolidificationEventsR(int id, int layernumber, int TempFilesInSeries, ViewI_H MaxSolidificationEvents_Host,
-                                  int StartRange, int EndRange, std::vector<double> RawData, float XMin, float YMin,
-                                  double deltax, float *ZMinLayer, int LayerHeight, int nx, int MyYSlices,
+                                  int StartRange, int EndRange, std::vector<double> RawData, double XMin, double YMin,
+                                  double deltax, double *ZMinLayer, int LayerHeight, int nx, int MyYSlices,
                                   int MyYOffset, int LocalActiveDomainSize) {
 
     if (layernumber > TempFilesInSeries) {
@@ -1479,8 +1479,8 @@ void TempInit_ReadDataRemelt(int layernumber, int id, int nx, int MyYSlices, int
                              int LocalDomainSize, int MyYOffset, double &deltax, double deltat, double FreezingRange,
                              ViewF3D &LayerTimeTempHistory, ViewI &NumberOfSolidificationEvents,
                              ViewI &MaxSolidificationEvents, ViewI &MeltTimeStep, ViewI &CritTimeStep,
-                             ViewF &UndercoolingChange, ViewF &UndercoolingCurrent, float XMin, float YMin,
-                             float *ZMinLayer, int LayerHeight, int nzActive, int ZBound_Low, int *FinishTimeStep,
+                             ViewF &UndercoolingChange, ViewF &UndercoolingCurrent, double XMin, double YMin,
+                             double *ZMinLayer, int LayerHeight, int nzActive, int ZBound_Low, int *FinishTimeStep,
                              ViewI &LayerID, int *FirstValue, int *LastValue, std::vector<double> RawData,
                              ViewI &SolidificationEventCounter, int TempFilesInSeries) {
 
@@ -1575,9 +1575,9 @@ void TempInit_ReadDataRemelt(int layernumber, int id, int nx, int MyYSlices, int
                 for (int j = (i + 1); j < NumberOfSolidificationEvents_Host(n); j++) {
                     if (LayerTimeTempHistory_Host(n, i, 0) > LayerTimeTempHistory_Host(n, j, 0)) {
                         // Swap these two points - melting event "j" happens before event "i"
-                        float OldMeltVal = LayerTimeTempHistory_Host(n, i, 0);
-                        float OldLiqVal = LayerTimeTempHistory_Host(n, i, 1);
-                        float OldCRVal = LayerTimeTempHistory_Host(n, i, 2);
+                        double OldMeltVal = LayerTimeTempHistory_Host(n, i, 0);
+                        double OldLiqVal = LayerTimeTempHistory_Host(n, i, 1);
+                        double OldCRVal = LayerTimeTempHistory_Host(n, i, 2);
                         LayerTimeTempHistory_Host(n, i, 0) = LayerTimeTempHistory_Host(n, j, 0);
                         LayerTimeTempHistory_Host(n, i, 1) = LayerTimeTempHistory_Host(n, j, 1);
                         LayerTimeTempHistory_Host(n, i, 2) = LayerTimeTempHistory_Host(n, j, 2);
@@ -1850,7 +1850,7 @@ void SubstrateInit_FromFile(std::string SubstrateFileName, int nz, int nx, int M
 }
 
 // Initializes Grain ID values where the baseplate is generated using an input grain spacing and a Voronoi Tessellation
-void BaseplateInit_FromGrainSpacing(float SubstrateGrainSpacing, int nx, int ny, float *ZMinLayer, float *ZMaxLayer,
+void BaseplateInit_FromGrainSpacing(float SubstrateGrainSpacing, int nx, int ny, double *ZMinLayer, double *ZMaxLayer,
                                     int MyYSlices, int MyYOffset, int id, double deltax, ViewI GrainID, double RNGSeed,
                                     int &NextLayer_FirstEpitaxialGrainID, int nz, double BaseplateThroughPowder) {
 
@@ -1941,7 +1941,7 @@ void BaseplateInit_FromGrainSpacing(float SubstrateGrainSpacing, int nx, int ny,
 
 // Each layer's top Z coordinates are seeded with CA-cell sized substrate grains (emulating bulk nucleation alongside
 // the edges of partially melted powder particles)
-void PowderInit(int layernumber, int nx, int ny, int LayerHeight, float *ZMaxLayer, float ZMin, double deltax,
+void PowderInit(int layernumber, int nx, int ny, int LayerHeight, double *ZMaxLayer, double ZMin, double deltax,
                 int MyYSlices, int MyYOffset, int id, ViewI GrainID, double RNGSeed,
                 int &NextLayer_FirstEpitaxialGrainID, double PowderDensity) {
 

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -29,20 +29,20 @@ void checkPowderOverflow(int nx, int ny, int LayerHeight, int NumberOfLayers, bo
                          double PowderDensity);
 void NeighborListInit(NList &NeighborX, NList &NeighborY, NList &NeighborZ);
 void FindXYZBounds(std::string SimulationType, int id, double &deltax, int &nx, int &ny, int &nz,
-                   std::vector<std::string> &temp_paths, float &XMin, float &XMax, float &YMin, float &YMax,
-                   float &ZMin, float &ZMax, int &LayerHeight, int NumberOfLayers, int TempFilesInSeries,
-                   float *ZMinLayer, float *ZMaxLayer, int SpotRadius);
+                   std::vector<std::string> &temp_paths, double &XMin, double &XMax, double &YMin, double &YMax,
+                   double &ZMin, double &ZMax, int &LayerHeight, int NumberOfLayers, int TempFilesInSeries,
+                   double *ZMinLayer, double *ZMaxLayer, int SpotRadius);
 void DomainDecomposition(int id, int np, int &MyYSlices, int &MyYOffset, int &NeighborRank_North,
                          int &NeighborRank_South, int &nx, int &ny, int &nz, long int &LocalDomainSize,
                          bool &AtNorthBoundary, bool &AtSouthBoundary);
 void ReadTemperatureData(int id, double &deltax, double HT_deltax, int &HTtoCAratio, int MyYSlices, int MyYOffset,
-                         float YMin, std::vector<std::string> &temp_paths, int NumberOfLayers, int TempFilesInSeries,
+                         double YMin, std::vector<std::string> &temp_paths, int NumberOfLayers, int TempFilesInSeries,
                          unsigned int &NumberOfTemperatureDataPoints, std::vector<double> &RawData, int *FirstValue,
                          int *LastValue, bool LayerwiseTempRead, int layernumber);
-int calcZBound_Low(std::string SimulationType, int LayerHeight, int layernumber, float *ZMinLayer, float ZMin,
+int calcZBound_Low(std::string SimulationType, int LayerHeight, int layernumber, double *ZMinLayer, double ZMin,
                    double deltax);
-int calcZBound_High(std::string SimulationType, int SpotRadius, int LayerHeight, int layernumber, float ZMin,
-                    double deltax, int nz, float *ZMaxLayer);
+int calcZBound_High(std::string SimulationType, int SpotRadius, int LayerHeight, int layernumber, double ZMin,
+                    double deltax, int nz, double *ZMaxLayer);
 int calcnzActive(int ZBound_Low, int ZBound_High, int id, int layernumber);
 int calcLocalActiveDomainSize(int nx, int MyYSlices, int nzActive);
 void TempInit_DirSolidification(double G, double R, int id, int &nx, int &MyYSlices, double deltax, double deltat,
@@ -64,29 +64,29 @@ void TempInit_SpotNoRemelt(double G, double R, std::string SimulationType, int i
                            ViewI &CritTimeStep, ViewF &UndercoolingChange, int LayerHeight, int NumberOfLayers,
                            double FreezingRange, ViewI &LayerID, int NSpotsX, int NSpotsY, int SpotRadius,
                            int SpotOffset);
-int getTempCoordX(int i, float XMin, double deltax, const std::vector<double> &RawData);
-int getTempCoordY(int i, float YMin, double deltax, const std::vector<double> &RawData);
+int getTempCoordX(int i, double XMin, double deltax, const std::vector<double> &RawData);
+int getTempCoordY(int i, double YMin, double deltax, const std::vector<double> &RawData);
 int getTempCoordZ(int i, double deltax, const std::vector<double> &RawData, int LayerHeight, int LayerCounter,
-                  float *ZMinLayer);
+                  double *ZMinLayer);
 double getTempCoordTM(int i, const std::vector<double> &RawData);
 double getTempCoordTL(int i, const std::vector<double> &RawData);
 double getTempCoordCR(int i, const std::vector<double> &RawData);
 void TempInit_ReadDataNoRemelt(int id, int &nx, int &MyYSlices, int &MyYOffset, double deltax, int HTtoCAratio,
                                double deltat, int nz, int LocalDomainSize, ViewI &CritTimeStep,
-                               ViewF &UndercoolingChange, float XMin, float YMin, float ZMin, float *ZMinLayer,
-                               float *ZMaxLayer, int LayerHeight, int NumberOfLayers, int *FinishTimeStep,
+                               ViewF &UndercoolingChange, double XMin, double YMin, double ZMin, double *ZMinLayer,
+                               double *ZMaxLayer, int LayerHeight, int NumberOfLayers, int *FinishTimeStep,
                                double FreezingRange, ViewI &LayerID, int *FirstValue, int *LastValue,
                                std::vector<double> RawData);
 void calcMaxSolidificationEventsR(int id, int layernumber, int TempFilesInSeries, ViewI_H MaxSolidificationEvents_Host,
-                                  int StartRange, int EndRange, std::vector<double> RawData, float XMin, float YMin,
-                                  double deltax, float *ZMinLayer, int LayerHeight, int nx, int MyYSlices,
+                                  int StartRange, int EndRange, std::vector<double> RawData, double XMin, double YMin,
+                                  double deltax, double *ZMinLayer, int LayerHeight, int nx, int MyYSlices,
                                   int MyYOffset, int LocalActiveDomainSize);
 void TempInit_ReadDataRemelt(int layernumber, int id, int nx, int MyYSlices, int nz, int LocalActiveDomainSize,
                              int LocalDomainSize, int MyYOffset, double &deltax, double deltat, double FreezingRange,
                              ViewF3D &LayerTimeTempHistory, ViewI &NumberOfSolidificationEvents,
                              ViewI &MaxSolidificationEvents, ViewI &MeltTimeStep, ViewI &CritTimeStep,
-                             ViewF &UndercoolingChange, ViewF &UndercoolingCurrent, float XMin, float YMin,
-                             float *ZMinLayer, int LayerHeight, int nzActive, int ZBound_Low, int *FinishTimeStep,
+                             ViewF &UndercoolingChange, ViewF &UndercoolingCurrent, double XMin, double YMin,
+                             double *ZMinLayer, int LayerHeight, int nzActive, int ZBound_Low, int *FinishTimeStep,
                              ViewI &LayerID, int *FirstValue, int *LastValue, std::vector<double> RawData,
                              ViewI &SolidificationEventCounter, int TempFilesInSeries);
 void SubstrateInit_ConstrainedGrowth(int id, double FractSurfaceSitesActive, int MyYSlices, int nx, int ny,
@@ -97,10 +97,10 @@ void SubstrateInit_ConstrainedGrowth(int id, double FractSurfaceSitesActive, int
                                      bool AtNorthBoundary, bool AtSouthBoundary);
 void SubstrateInit_FromFile(std::string SubstrateFileName, int nz, int nx, int MyYSlices, int MyYOffset, int pid,
                             ViewI &GrainID, int nzActive, bool BaseplateThroughPowder);
-void BaseplateInit_FromGrainSpacing(float SubstrateGrainSpacing, int nx, int ny, float *ZMinLayer, float *ZMaxLayer,
+void BaseplateInit_FromGrainSpacing(float SubstrateGrainSpacing, int nx, int ny, double *ZMinLayer, double *ZMaxLayer,
                                     int MyYSlices, int MyYOffset, int id, double deltax, ViewI GrainID, double RNGSeed,
                                     int &NextLayer_FirstEpitaxialGrainID, int nz, double BaseplateThroughPowder);
-void PowderInit(int layernumber, int nx, int ny, int LayerHeight, float *ZMaxLayer, float ZMin, double deltax,
+void PowderInit(int layernumber, int nx, int ny, int LayerHeight, double *ZMaxLayer, double ZMin, double deltax,
                 int MyYSlices, int MyYOffset, int id, ViewI GrainID, double RNGSeed,
                 int &NextLayer_FirstEpitaxialGrainID, double PowderDensity);
 void CellTypeInit_Remelt(int nx, int MyYSlices, int LocalActiveDomainSize, ViewI CellType, ViewI CritTimeStep, int id,

--- a/src/CAprint.cpp
+++ b/src/CAprint.cpp
@@ -188,8 +188,8 @@ void PrintExaCAData(int id, int layernumber, int np, int nx, int ny, int nz, int
                     ViewF UndercoolingChange, ViewF UndercoolingCurrent, std::string BaseFileName,
                     int NGrainOrientations, std::string PathToOutput, int PrintDebug, bool PrintMisorientation,
                     bool PrintFinalUndercoolingVals, bool PrintFullOutput, bool PrintTimeSeries, bool PrintDefaultRVE,
-                    int IntermediateFileCounter, int ZBound_Low, int nzActive, double deltax, float XMin, float YMin,
-                    float ZMin, int NumberOfLayers, bool PrintBinary, int RVESize) {
+                    int IntermediateFileCounter, int ZBound_Low, int nzActive, double deltax, double XMin, double YMin,
+                    double ZMin, int NumberOfLayers, bool PrintBinary, int RVESize) {
 
     if (id == 0) {
         // Message sizes and data offsets for data recieved from other ranks- message size different for different ranks
@@ -324,7 +324,7 @@ void PrintCAFields(int nx, int ny, int nz, ViewI3D_H GrainID_WholeDomain, ViewI3
                    ViewI3D_H CritTimeStep_WholeDomain, ViewI3D_H CellType_WholeDomain,
                    ViewF3D_H UndercoolingChange_WholeDomain, ViewF3D_H UndercoolingCurrent_WholeDomain,
                    std::string PathToOutput, std::string BaseFileName, int PrintDebug, bool PrintFullOutput,
-                   double deltax, float XMin, float YMin, float ZMin, bool PrintBinary) {
+                   double deltax, double XMin, double YMin, double ZMin, bool PrintBinary) {
 
     std::string FName;
     if (PrintFullOutput) {
@@ -425,7 +425,7 @@ void PrintCAFields(int nx, int ny, int nz, ViewI3D_H GrainID_WholeDomain, ViewI3
 // Print grain misorientation, 0-62 for epitaxial grains and 100-162 for nucleated grains, to a paraview file
 void PrintGrainMisorientations(std::string BaseFileName, std::string PathToOutput, int nx, int ny, int nz,
                                ViewI3D_H LayerID_WholeDomain, ViewI3D_H GrainID_WholeDomain, ViewF_H GrainUnitVector,
-                               int NGrainOrientations, double deltax, float XMin, float YMin, float ZMin,
+                               int NGrainOrientations, double deltax, double XMin, double YMin, double ZMin,
                                bool PrintBinary) {
 
     std::string FName = PathToOutput + BaseFileName + "_Misorientations.vtk";
@@ -472,7 +472,7 @@ void PrintGrainMisorientations(std::string BaseFileName, std::string PathToOutpu
 // solidification, to a paraview file
 void PrintFinalUndercooling(std::string BaseFileName, std::string PathToOutput, int nx, int ny, int nz,
                             ViewF3D_H UndercoolingCurrent_WholeDomain, ViewI3D_H LayerID_WholeDomain, double deltax,
-                            float XMin, float YMin, float ZMin, bool PrintBinary) {
+                            double XMin, double YMin, double ZMin, bool PrintBinary) {
 
     std::string FName = PathToOutput + BaseFileName + "_FinalUndercooling.vtk";
     std::cout << "Printing Paraview file of final undercooling values" << std::endl;
@@ -702,7 +702,7 @@ void PrintExaCALog(int id, int np, std::string InputFile, std::string Simulation
 void PrintIntermediateExaCAState(int IntermediateFileCounter, int layernumber, std::string BaseFileName,
                                  std::string PathToOutput, int ZBound_Low, int nzActive, int nx, int ny,
                                  ViewI3D_H GrainID_WholeDomain, ViewI3D_H CellType_WholeDomain, ViewF_H GrainUnitVector,
-                                 int NGrainOrientations, double deltax, float XMin, float YMin, float ZMin,
+                                 int NGrainOrientations, double deltax, double XMin, double YMin, double ZMin,
                                  bool PrintBinary) {
 
     std::string FName = PathToOutput + BaseFileName + "_layer" + std::to_string(layernumber) + "_" +

--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -34,8 +34,8 @@ void PrintExaCAData(int id, int layernumber, int np, int nx, int ny, int nz, int
                     ViewF UndercoolingChange, ViewF UndercoolingCurrent, std::string BaseFileName,
                     int NGrainOrientations, std::string PathToOutput, int PrintDebug, bool PrintMisorientation,
                     bool PrintFinalUndercooling, bool PrintFullOutput, bool PrintTimeSeries, bool PrintDefaultRVE,
-                    int IntermediateFileCounter, int ZBound_Low, int nzActive, double deltax, float XMin, float YMin,
-                    float ZMin, int NumberOfLayers, bool PrintBinary, int RVESize = 0);
+                    int IntermediateFileCounter, int ZBound_Low, int nzActive, double deltax, double XMin, double YMin,
+                    double ZMin, int NumberOfLayers, bool PrintBinary, int RVESize = 0);
 void PrintExaCALog(int id, int np, std::string InputFile, std::string SimulationType, int MyYSlices, int MyYOffset,
                    InterfacialResponseFunction irf, double deltax, double NMax, double dTN, double dTsigma,
                    std::vector<std::string> temp_paths, int TempFilesInSeries, double HT_deltax, bool RemeltingYN,
@@ -51,21 +51,21 @@ void PrintCAFields(int nx, int ny, int nz, ViewI3D_H GrainID_WholeDomain, ViewI3
                    ViewI3D_H CritTimeStep_WholeDomain, ViewI3D_H CellType_WholeDomain,
                    ViewF3D_H UndercoolingChange_WholeDomain, ViewF3D_H UndercoolingCurrent_WholeDomain,
                    std::string PathToOutput, std::string BaseFileName, int PrintDebug, bool PrintFullOutput,
-                   double deltax, float XMin, float YMin, float ZMin, bool PrintBinary);
+                   double deltax, double XMin, double YMin, double ZMin, bool PrintBinary);
 void PrintGrainMisorientations(std::string BaseFileName, std::string PathToOutput, int nx, int ny, int nz,
                                ViewI3D_H LayerID_WholeDomain, ViewI3D_H GrainID_WholeDomain, ViewF_H GrainUnitVector,
-                               int NGrainOrientations, double deltax, float XMin, float YMin, float ZMin,
+                               int NGrainOrientations, double deltax, double XMin, double YMin, double ZMin,
                                bool PrintBinary);
 void PrintFinalUndercooling(std::string BaseFileName, std::string PathToOutput, int nx, int ny, int nz,
                             ViewF3D_H UndercoolingCurrent_WholeDomain, ViewI3D_H LayerID_WholeDomain, double deltax,
-                            float XMin, float YMin, float ZMin, bool PrintBinary);
+                            double XMin, double YMin, double ZMin, bool PrintBinary);
 void PrintExaConstitDefaultRVE(std::string BaseFileName, std::string PathToOutput, int nx, int ny, int nz,
                                ViewI3D_H LayerID_WholeDomain, ViewI3D_H GrainID_WholeDomain, double deltax,
                                int NumberOfLayers, int RVESize);
 void PrintIntermediateExaCAState(int IntermediateFileCounter, int layernumber, std::string BaseFileName,
                                  std::string PathToOutput, int ZBound_Low, int nzActive, int nx, int ny,
                                  ViewI3D_H GrainID_WholeDomain, ViewI3D_H CellType_WholeDomain, ViewF_H GrainUnitVector,
-                                 int NGrainOrientations, double deltax, float XMin, float YMin, float ZMin,
+                                 int NGrainOrientations, double deltax, double XMin, double YMin, double ZMin,
                                  bool PrintBinary);
 // Write data of type PrintType as ascii or binary, with option to convert between big and small endian binary
 template <typename PrintType>

--- a/src/CAupdate.cpp
+++ b/src/CAupdate.cpp
@@ -525,7 +525,7 @@ void JumpTimeStep(int &cycle, unsigned long int RemainingCellsOfInterest, unsign
                   ViewI CellType, ViewI LayerID, int id, int layernumber, int np, int nx, int ny, int nz, int MyYOffset,
                   ViewI GrainID, ViewI CritTimeStep, ViewF GrainUnitVector, ViewF UndercoolingChange,
                   ViewF UndercoolingCurrent, std::string OutputFile, int NGrainOrientations, std::string PathToOutput,
-                  int &IntermediateFileCounter, int nzActive, double deltax, float XMin, float YMin, float ZMin,
+                  int &IntermediateFileCounter, int nzActive, double deltax, double XMin, double YMin, double ZMin,
                   int NumberOfLayers, int &XSwitch, std::string TemperatureDataType, bool PrintIdleMovieFrames,
                   int MovieFrameInc, bool PrintBinary, int FinishTimeStep = 0) {
 
@@ -595,7 +595,7 @@ void JumpTimeStep(int &cycle, unsigned long int RemainingCellsOfInterest, unsign
 // Prints intermediate code output to stdout, checks to see if solidification is complete
 void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyYSlices, int MyYOffset, int LocalDomainSize,
                                 int LocalActiveDomainSize, int nx, int ny, int nz, int nzActive, double deltax,
-                                float XMin, float YMin, float ZMin, int SuccessfulNucEvents_ThisRank, int &XSwitch,
+                                double XMin, double YMin, double ZMin, int SuccessfulNucEvents_ThisRank, int &XSwitch,
                                 ViewI CellType, ViewI CritTimeStep, ViewI GrainID, std::string TemperatureDataType,
                                 int *FinishTimeStep, int layernumber, int, int ZBound_Low, int NGrainOrientations,
                                 ViewI LayerID, ViewF GrainUnitVector, ViewF UndercoolingChange,
@@ -671,7 +671,7 @@ void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyYSlices, int M
 // remelting) and checks to see if solidification is complete in the case where cells can solidify multiple times
 void IntermediateOutputAndCheck_Remelt(
     int id, int np, int &cycle, int MyYSlices, int MyYOffset, int LocalActiveDomainSize, int nx, int ny, int nz,
-    int nzActive, double deltax, float XMin, float YMin, float ZMin, int SuccessfulNucEvents_ThisRank, int &XSwitch,
+    int nzActive, double deltax, double XMin, double YMin, double ZMin, int SuccessfulNucEvents_ThisRank, int &XSwitch,
     ViewI CellType, ViewI CritTimeStep, ViewI GrainID, std::string TemperatureDataType, int layernumber, int,
     int ZBound_Low, int NGrainOrientations, ViewI LayerID, ViewF GrainUnitVector, ViewF UndercoolingChange,
     ViewF UndercoolingCurrent, std::string PathToOutput, std::string OutputFile, bool PrintIdleMovieFrames,

--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -105,12 +105,12 @@ void JumpTimeStep(int &cycle, unsigned long int RemainingCellsOfInterest, ViewI 
                   int nz, int MyYOffset, ViewI GrainID, ViewI CritTimeStep, ViewF GrainUnitVector,
                   ViewF UndercoolingChange, ViewF UndercoolingCurrent, std::string OutputFile,
                   int DecompositionStrategy, int NGrainOrientations, std::string PathToOutput,
-                  int &IntermediateFileCounter, int nzActive, double deltax, float XMin, float YMin, float ZMin,
+                  int &IntermediateFileCounter, int nzActive, double deltax, double XMin, double YMin, double ZMin,
                   int NumberOfLayers, int &XSwitch, std::string TemperatureDataType, bool PrintIdleMovieFrames,
                   int MovieFrameInc, bool PrintBinary, int FinishTimeStep);
 void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyYSlices, int MyYOffset, int LocalDomainSize,
                                 int LocalActiveDomainSize, int nx, int ny, int nz, int nzActive, double deltax,
-                                float XMin, float YMin, float ZMin, int SuccessfulNucEvents_ThisRank, int &XSwitch,
+                                double XMin, double YMin, double ZMin, int SuccessfulNucEvents_ThisRank, int &XSwitch,
                                 ViewI CellType, ViewI CritTimeStep, ViewI GrainID, std::string TemperatureDataType,
                                 int *FinishTimeStep, int layernumber, int, int ZBound_Low, int NGrainOrientations,
                                 ViewI LayerID, ViewF GrainUnitVector, ViewF UndercoolingChange,
@@ -119,7 +119,7 @@ void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyYSlices, int M
                                 int NumberOfLayers, bool PrintBinary);
 void IntermediateOutputAndCheck_Remelt(
     int id, int np, int &cycle, int MyYSlices, int MyYOffset, int LocalActiveDomainSize, int nx, int ny, int nz,
-    int nzActive, double deltax, float XMin, float YMin, float ZMin, int SuccessfulNucEvents_ThisRank, int &XSwitch,
+    int nzActive, double deltax, double XMin, double YMin, double ZMin, int SuccessfulNucEvents_ThisRank, int &XSwitch,
     ViewI CellType, ViewI CritTimeStep, ViewI GrainID, std::string TemperatureDataType, int layernumber, int,
     int ZBound_Low, int NGrainOrientations, ViewI LayerID, ViewF GrainUnitVector, ViewF UndercoolingChange,
     ViewF UndercoolingCurrent, std::string PathToOutput, std::string OutputFile, bool PrintIdleMovieFrames,

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -57,9 +57,9 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     // View initialization is performed on host views, but copied to the device views within subroutines
     // Neighbor lists for cells
     NList NeighborX, NeighborY, NeighborZ;
-    float XMin, YMin, ZMin, XMax, YMax, ZMax; // OpenFOAM simulation bounds (if using OpenFOAM data)
-    float *ZMinLayer = new float[NumberOfLayers];
-    float *ZMaxLayer = new float[NumberOfLayers];
+    double XMin, YMin, ZMin, XMax, YMax, ZMax; // OpenFOAM simulation bounds (if using OpenFOAM data)
+    double *ZMinLayer = new double[NumberOfLayers];
+    double *ZMaxLayer = new double[NumberOfLayers];
     int *FinishTimeStep = new int[NumberOfLayers];
 
     // Data structure for storing raw temperature data from file(s)

--- a/unit_test/tstInit.cpp
+++ b/unit_test/tstInit.cpp
@@ -274,8 +274,8 @@ void testcalcZBound_Low() {
     int LayerHeight = 10;
     int NumberOfLayers = 10;
     double deltax = 1 * pow(10, -6);
-    float ZMin = -0.5 * pow(10, -6);
-    float *ZMinLayer = new float[NumberOfLayers];
+    double ZMin = -0.5 * pow(10, -6);
+    double *ZMinLayer = new double[NumberOfLayers];
     for (int layernumber = 0; layernumber < NumberOfLayers; layernumber++) {
         // Set ZMinLayer for each layer to be offset by LayerHeight cells from the previous one (lets solution for
         // both problem types by the same)
@@ -293,11 +293,11 @@ void testcalcZBound_High() {
     // A separate function is now used for ZBound_High calculation
     int SpotRadius = 100;
     int LayerHeight = 10;
-    float ZMin = 0.5 * pow(10, -6);
+    double ZMin = 0.5 * pow(10, -6);
     double deltax = 1.0 * pow(10, -6);
     int nz = 101;
     int NumberOfLayers = 10;
-    float *ZMaxLayer = new float[NumberOfLayers];
+    double *ZMaxLayer = new double[NumberOfLayers];
     for (int layernumber = 0; layernumber < NumberOfLayers; layernumber++) {
         // Set ZMaxLayer for each layer to be offset by LayerHeight cells from the previous one, with layer 0 having a
         // ZMax value of ZMin + SpotRadius (lets solution for both problem types be the same)
@@ -376,7 +376,7 @@ void testReadTemperatureData(int NumberOfLayers, bool LayerwiseTempRead) {
     for (int id = 0; id < 4; id++) {
         int MyYSlices = 3;
         int MyYOffset = 3 * id; // each col is separated from the others by 3 cells
-        float YMin = 0.0;
+        double YMin = 0.0;
         int layernumber = 0;
         std::vector<std::string> temp_paths(2);
         temp_paths[0] = TestTempFileName1;
@@ -440,12 +440,12 @@ void testgetTempCoords() {
 
     // cell size and simulation lower bounds
     double deltax = 0.5;
-    float XMin = -5;
-    float YMin = 0.0;
+    double XMin = -5;
+    double YMin = 0.0;
 
     // test - each rank initializes data for layer id, of 4 total layers
     for (int layernumber = 0; layernumber < 4; layernumber++) {
-        float *ZMinLayer = new float[4];
+        double *ZMinLayer = new double[4];
         for (int n = 0; n < 4; n++) {
             ZMinLayer[n] = 2 * n;
         }

--- a/unit_test/tstKokkosInitMPI.hpp
+++ b/unit_test/tstKokkosInitMPI.hpp
@@ -116,8 +116,8 @@ void testBaseplateInit_FromGrainSpacing() {
     MPI_Comm_rank(MPI_COMM_WORLD, &id);
     // Create test data
     int nz = 4;
-    float ZMinLayer[1];
-    float ZMaxLayer[1];
+    double ZMinLayer[1];
+    double ZMaxLayer[1];
     ZMinLayer[0] = 0;
     ZMaxLayer[0] = 2 * pow(10, -6);
     int nx = 3;
@@ -171,10 +171,10 @@ void testPowderInit() {
     int nz = 6;
     int layernumber = 1;
     // Z = 4 and Z = 5 should be the region seeded with powder layer Grain IDs
-    float ZMaxLayer[2];
+    double ZMaxLayer[2];
     ZMaxLayer[1] = 5.0 * pow(10, -6);
     double deltax = 1.0 * pow(10, -6);
-    float ZMin = 0;
+    double ZMin = 0;
     int LayerHeight = 2;
     int nx = 1;
     // Each rank is assigned a different portion of the domain in Y


### PR DESCRIPTION
Code previously used `float` (or inconsistently used `float` and `double`) instead of `double` for intermediate quantities derived from the double precision temperature input data