### PR TITLE
Avoid out of bounds error during temperature interpolation

### DIFF
--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -517,9 +517,9 @@ void FindXYZBounds(std::string SimulationType, int id, double &deltax, int &nx, 
         XMin = std::numeric_limits<double>::max();
         YMin = std::numeric_limits<double>::max();
         ZMin = std::numeric_limits<double>::max();
-        XMax = std::numeric_limits<double>::min();
-        YMax = std::numeric_limits<double>::min();
-        ZMax = std::numeric_limits<double>::min();
+        XMax = std::numeric_limits<double>::lowest();
+        YMax = std::numeric_limits<double>::lowest();
+        ZMax = std::numeric_limits<double>::lowest();
 
         // Read the first temperature file, first line to determine if the "new" OpenFOAM output format (with a 1 line
         // header) is used, or whether the "old" OpenFOAM header (which contains information like the X/Y/Z bounds of
@@ -554,9 +554,9 @@ void FindXYZBounds(std::string SimulationType, int id, double &deltax, int &nx, 
             double XMin_ThisLayer = std::numeric_limits<double>::max();
             double YMin_ThisLayer = std::numeric_limits<double>::max();
             double ZMin_ThisLayer = std::numeric_limits<double>::max();
-            double XMax_ThisLayer = std::numeric_limits<double>::min();
-            double YMax_ThisLayer = std::numeric_limits<double>::min();
-            double ZMax_ThisLayer = std::numeric_limits<double>::min();
+            double XMax_ThisLayer = std::numeric_limits<double>::lowest();
+            double YMax_ThisLayer = std::numeric_limits<double>::lowest();
+            double ZMax_ThisLayer = std::numeric_limits<double>::lowest();
 
             // Units are assumed to be in meters, meters, seconds, seconds, and K/second
             std::vector<double> XCoordinates(1000000), YCoordinates(1000000), ZCoordinates(1000000);
@@ -760,7 +760,7 @@ void ReadTemperatureData(int id, double &deltax, double HT_deltax, int &HTtoCAra
         // Read data from the remaining lines - values should be separated by commas
         // Space separated data is no longer accepted by ExaCA
         double ZMin_ThisLayer = std::numeric_limits<double>::max();
-        double ZMax_ThisLayer = std::numeric_limits<double>::min();
+        double ZMax_ThisLayer = std::numeric_limits<double>::lowest();
         while (!TemperatureFile.eof()) {
             std::vector<std::string> ParsedLine(6); // Each line has an x, y, z, tm, tl, cr
             std::string ReadLine;
@@ -1315,7 +1315,7 @@ void TempInit_ReadDataNoRemelt(int id, int &nx, int &MyYSlices, int &MyYOffset, 
                         double FHighY = (float)(j - LowY) / (float)(HTtoCAratio);
                         double FLowY = 1.0 - FHighY;
                         if (HighY >= UpperYBound - LowerYBound)
-                            HighY = UpperYBound - LowerYBound;
+                            HighY = LowY;
                         double Pt1 = CritTL[LowZ][LowX][LowY];
                         double Pt2 = CritTL[LowZ][HighX][LowY];
                         double Pt12 = FLowX * Pt1 + FHighX * Pt2;

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -76,7 +76,7 @@ void TempInit_ReadDataNoRemelt(int id, int &nx, int &MyYSlices, int &MyYOffset, 
                                ViewF &UndercoolingChange, double XMin, double YMin, double ZMin, double *ZMinLayer,
                                double *ZMaxLayer, int LayerHeight, int NumberOfLayers, int *FinishTimeStep,
                                double FreezingRange, ViewI &LayerID, int *FirstValue, int *LastValue,
-                               std::vector<double> RawData);
+                               std::vector<double> RawData, int ny);
 void calcMaxSolidificationEventsR(int id, int layernumber, int TempFilesInSeries, ViewI_H MaxSolidificationEvents_Host,
                                   int StartRange, int EndRange, std::vector<double> RawData, double XMin, double YMin,
                                   double deltax, double *ZMinLayer, int LayerHeight, int nx, int MyYSlices,

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -151,7 +151,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
         TempInit_ReadDataNoRemelt(id, nx, MyYSlices, MyYOffset, deltax, HTtoCAratio, deltat, nz, LocalDomainSize,
                                   CritTimeStep, UndercoolingChange, XMin, YMin, ZMin, ZMinLayer, ZMaxLayer, LayerHeight,
                                   NumberOfLayers, FinishTimeStep, irf.FreezingRange, LayerID, FirstValue, LastValue,
-                                  RawData);
+                                  RawData, ny);
     else if ((SimulationType == "S") && (!RemeltingYN))
         TempInit_SpotNoRemelt(G, R, SimulationType, id, nx, MyYSlices, MyYOffset, deltax, deltat, nz, LocalDomainSize,
                               CritTimeStep, UndercoolingChange, LayerHeight, NumberOfLayers, irf.FreezingRange, LayerID,


### PR DESCRIPTION
Fixed incorrect use of std::numeric_limits and truncated interpolation domain to avoid interpolating regions outside the simulation domain