### PR TITLE
Renamed powder density variable, fixed incorrect cout messages

### DIFF
--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -23,8 +23,8 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
                        bool &PrintMisorientation, bool &PrintFinalUndercoolingVals, bool &PrintFullOutput, int &NSpotsX,
                        int &NSpotsY, int &SpotOffset, int &SpotRadius, bool &PrintTimeSeries, int &TimeSeriesInc,
                        bool &PrintIdleTimeSeriesFrames, bool &PrintDefaultRVE, double &RNGSeed,
-                       bool &BaseplateThroughPowder, double &PowderDensity, int &RVESize, bool &LayerwiseTempRead,
-                       bool &PrintBinary);
+                       bool &BaseplateThroughPowder, double &PowderActiveFraction, int &RVESize,
+                       bool &LayerwiseTempRead, bool &PrintBinary);
 void checkPowderOverflow(int nx, int ny, int LayerHeight, int NumberOfLayers, bool BaseplateThroughPowder,
                          double PowderDensity);
 void NeighborListInit(NList &NeighborX, NList &NeighborY, NList &NeighborZ);
@@ -102,7 +102,7 @@ void BaseplateInit_FromGrainSpacing(float SubstrateGrainSpacing, int nx, int ny,
                                     int &NextLayer_FirstEpitaxialGrainID, int nz, double BaseplateThroughPowder);
 void PowderInit(int layernumber, int nx, int ny, int LayerHeight, double *ZMaxLayer, double ZMin, double deltax,
                 int MyYSlices, int MyYOffset, int id, ViewI GrainID, double RNGSeed,
-                int &NextLayer_FirstEpitaxialGrainID, double PowderDensity);
+                int &NextLayer_FirstEpitaxialGrainID, double PowderActiveFraction);
 void CellTypeInit_Remelt(int nx, int MyYSlices, int LocalActiveDomainSize, ViewI CellType, ViewI CritTimeStep, int id,
                          int ZBound_Low);
 void CellTypeInit_NoRemelt(int layernumber, int id, int np, int nx, int MyYSlices, int MyYOffset, int ZBound_Low,

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -29,7 +29,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
         PrintTimeSeries, PrintIdleTimeSeriesFrames, PrintDefaultRVE, BaseplateThroughPowder, LayerwiseTempRead,
         PrintBinary;
     float SubstrateGrainSpacing;
-    double HT_deltax, deltax, deltat, FractSurfaceSitesActive, G, R, NMax, dTN, dTsigma, RNGSeed, PowderDensity;
+    double HT_deltax, deltax, deltat, FractSurfaceSitesActive, G, R, NMax, dTN, dTsigma, RNGSeed, PowderActiveFraction;
     std::string SubstrateFileName, MaterialFileName, SimulationType, OutputFile, GrainOrientationFile, PathToOutput;
     std::vector<std::string> temp_paths;
 
@@ -40,7 +40,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                       FractSurfaceSitesActive, PathToOutput, PrintDebug, PrintMisorientation,
                       PrintFinalUndercoolingVals, PrintFullOutput, NSpotsX, NSpotsY, SpotOffset, SpotRadius,
                       PrintTimeSeries, TimeSeriesInc, PrintIdleTimeSeriesFrames, PrintDefaultRVE, RNGSeed,
-                      BaseplateThroughPowder, PowderDensity, RVESize, LayerwiseTempRead, PrintBinary);
+                      BaseplateThroughPowder, PowderActiveFraction, RVESize, LayerwiseTempRead, PrintBinary);
     // Read material data.
     InterfacialResponseFunction irf(id, MaterialFileName, deltat, deltax);
 
@@ -86,7 +86,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
 
     // Ensure that input powder layer init options are compatible with this domain size, if needed for this problem type
     if ((SimulationType == "R") || (SimulationType == "S"))
-        checkPowderOverflow(nx, ny, LayerHeight, NumberOfLayers, BaseplateThroughPowder, PowderDensity);
+        checkPowderOverflow(nx, ny, LayerHeight, NumberOfLayers, BaseplateThroughPowder, PowderActiveFraction);
 
     // Decompose the domain into subdomains on each MPI rank: Calculate MyYSlices and MyYOffset for each rank, where
     // each subdomain contains "MyYSlices" in Y, offset from the full domain origin by "MyYOffset" cells in Y
@@ -424,7 +424,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
             // file, and the powder layers have already been initialized
             if ((!(UseSubstrateFile)) && (!(BaseplateThroughPowder)))
                 PowderInit(layernumber + 1, nx, ny, LayerHeight, ZMaxLayer, ZMin, deltax, MyYSlices, MyYOffset, id,
-                           GrainID, RNGSeed, NextLayer_FirstEpitaxialGrainID, PowderDensity);
+                           GrainID, RNGSeed, NextLayer_FirstEpitaxialGrainID, PowderActiveFraction);
 
             // Initialize active cell data structures and nuclei locations for the next layer "layernumber + 1"
             if (RemeltingYN)


### PR DESCRIPTION
Renamed `PowderDensity` to `PowderActiveFraction` - while the input file value is a density (number/unit volume), it is stored as a fraction between 0 and 1. Also replaced incorrect values in cout messages during powder layer initialization