### PR TITLE
Track GrainID of powder grains

### DIFF
--- a/analysis/src/GAprint.cpp
+++ b/analysis/src/GAprint.cpp
@@ -549,7 +549,7 @@ void PrintCrossSectionData(int NumberOfCrossSections, std::string BaseFileName,
                            std::vector<bool> PrintSectionPF, std::vector<bool> PrintSectionIPF,
                            std::vector<bool> BimodalAnalysis, bool NewOrientationFormatYN, double deltax,
                            ViewF_H GrainUnitVector, ViewF_H GrainEulerAngles, ViewF_H GrainRGBValues,
-                           std::vector<std::string> CSLabels) {
+                           std::vector<std::string> CSLabels, int FirstPowderGrainID) {
 
     // Open file of cross-section quantities of interest
     std::ofstream QoIs;
@@ -600,6 +600,7 @@ void PrintCrossSectionData(int NumberOfCrossSections, std::string BaseFileName,
                 GrainplotIPF << std::fixed << std::setprecision(6);
             }
             int NucleatedGrainCells = 0;
+            int PowderGrainCells = 0;
             int UnmeltedCells = 0;
             int CrossSectionSize = (Index1High - Index1Low) * (Index2High - Index2Low);
             std::vector<int> CrossSectionGrainIDs(CrossSectionSize);
@@ -628,6 +629,8 @@ void PrintCrossSectionData(int NumberOfCrossSections, std::string BaseFileName,
                     // Count number of cells in this cross-section have GrainID < 0 (grains formed via nucleation)
                     if (GrainID(ZLoc, XLoc, YLoc) < 0)
                         NucleatedGrainCells++;
+                    else if (GrainID(ZLoc, XLoc, YLoc) >= FirstPowderGrainID)
+                        PowderGrainCells++;
                     // Add this GrainID to the vector of GrainIDs for this cross-section only if it is not equal to 0
                     if (GrainID(ZLoc, XLoc, YLoc) == 0)
                         UnmeltedCells++;
@@ -660,6 +663,7 @@ void PrintCrossSectionData(int NumberOfCrossSections, std::string BaseFileName,
             }
             double AreaFractNucleatedGrains = DivideCast<double>(NucleatedGrainCells, CrossSectionSize);
             double AreaFractUnmelted = DivideCast<double>(UnmeltedCells, CrossSectionSize);
+            double AreaFractPowderGrains = DivideCast<double>(PowderGrainCells, CrossSectionSize);
             std::cout << "The fraction of the cross-section that went unmelted (not assigned a GrainID) is "
                       << AreaFractUnmelted << std::endl;
             // Resize cross-section to exclude unmelted cells
@@ -667,6 +671,15 @@ void PrintCrossSectionData(int NumberOfCrossSections, std::string BaseFileName,
             CrossSectionGrainIDs.resize(CrossSectionSize);
             QoIs << "The fraction of grains in this cross-section formed via nucleation events is "
                  << AreaFractNucleatedGrains << std::endl;
+            std::cout << "The fraction of grains in this cross-section formed via nucleation events is "
+                      << AreaFractNucleatedGrains << std::endl;
+            // Only print this information if a valid lower limit to powder layer grain IDs was given
+            if (FirstPowderGrainID != std::numeric_limits<int>::max()) {
+                QoIs << "The fraction of grains in this cross-section formed from the powder is "
+                     << AreaFractPowderGrains << std::endl;
+                std::cout << "The fraction of grains in this cross-section formed from the powder is "
+                          << AreaFractPowderGrains << std::endl;
+            }
             if (PrintSectionIPF[n])
                 GrainplotIPF.close();
             if (PrintSectionPF[n]) {

--- a/analysis/src/GAprint.hpp
+++ b/analysis/src/GAprint.hpp
@@ -38,7 +38,7 @@ void PrintCrossSectionData(int NumberOfCrossSections, std::string BaseFileName,
                            std::vector<bool> PrintSectionPF, std::vector<bool> PrintSectionIPF,
                            std::vector<bool> BimodalAnalysis, bool NewOrientationFormatYN, double deltax,
                            ViewF_H GrainUnitVector, ViewF_H GrainEulerAngles, ViewF_H GrainRGBValues,
-                           std::vector<std::string> CSLabels);
+                           std::vector<std::string> CSLabels, int FirstPowderGrainID);
 void PrintMisorientationData(bool *AnalysisTypes, std::string BaseFileName, int XMin, int XMax, int YMin, int YMax,
                              int ZMin, int ZMax, ViewI3D_H LayerID, ViewF_H GrainUnitVector, ViewI3D_H GrainID,
                              int NumberOfOrientations);

--- a/analysis/src/GAutils.hpp
+++ b/analysis/src/GAutils.hpp
@@ -24,7 +24,7 @@ int FindTopOrBottom(int ***LayerID, int XLow, int XHigh, int YLow, int YHigh, in
 
 // These are used in reading/parsing ExaCA microstructure data
 void ParseLogFile(std::string LogFile, int &nx, int &ny, int &nz, double &deltax, int &NumberOfLayers,
-                  bool UseXYZBounds, std::vector<double> &XYZBounds);
+                  bool UseXYZBounds, std::vector<double> &XYZBounds, int &FirstPowderGrainID);
 void ReadASCIIField(std::ifstream &InputDataStream, int nx, int ny, int nz, ViewI3D_H FieldOfInterest);
 void ReadBinaryField(std::ifstream &InputDataStream, int nx, int ny, int nz, ViewI3D_H FieldOfInterest,
                      std::string FieldName);

--- a/analysis/src/runGA.cpp
+++ b/analysis/src/runGA.cpp
@@ -47,9 +47,9 @@ int main(int argc, char *argv[]) {
 
         // Given the input file name, parse the paraview file for the cell size, x, y, and z dimensions, number of
         // layers
-        int nx, ny, nz, NumberOfLayers;
+        int nx, ny, nz, NumberOfLayers, FirstPowderGrainID;
         std::vector<double> XYZBounds(6);
-        ParseLogFile(LogFile, nx, ny, nz, deltax, NumberOfLayers, false, XYZBounds);
+        ParseLogFile(LogFile, nx, ny, nz, deltax, NumberOfLayers, false, XYZBounds, FirstPowderGrainID);
 
         // Allocate memory blocks for GrainID and LayerID data
         ViewI3D_H GrainID(Kokkos::ViewAllocateWithoutInitializing("GrainID"), nz, nx, ny);
@@ -113,7 +113,7 @@ int main(int argc, char *argv[]) {
         PrintCrossSectionData(NumberOfCrossSections, OutputFileName, CrossSectionPlane, CrossSectionLocation, nx, ny,
                               nz, NumberOfOrientations, GrainID, PrintSectionPF, PrintSectionIPF, BimodalAnalysis,
                               NewOrientationFormatYN, deltax, GrainUnitVector_Host, GrainEulerAngles_Host,
-                              GrainRGBValues_Host, CSLabels);
+                              GrainRGBValues_Host, CSLabels, FirstPowderGrainID);
 
         // Part 3: Representative volume grain statistics
         // Print data to std::out and if analysis option 0 is toggled, to the file

--- a/analysis/src/runGA_AMB.cpp
+++ b/analysis/src/runGA_AMB.cpp
@@ -41,9 +41,9 @@ int main(int argc, char *argv[]) {
     {
         // Given the input file name, parse the paraview file for the cell size, x, y, and z dimensions, number of
         // layers, X, Y, Z lower and upper bounds
-        int nx, ny, nz, NumberOfLayers;
+        int nx, ny, nz, NumberOfLayers, FirstPowderGrainID;
         std::vector<double> XYZBounds(6);
-        ParseLogFile(LogFile, nx, ny, nz, deltax, NumberOfLayers, true, XYZBounds);
+        ParseLogFile(LogFile, nx, ny, nz, deltax, NumberOfLayers, true, XYZBounds, FirstPowderGrainID);
 
         // Allocate memory blocks for GrainID and LayerID data
         ViewI3D_H GrainID(Kokkos::ViewAllocateWithoutInitializing("GrainID"), nz, nx, ny);
@@ -84,7 +84,8 @@ int main(int argc, char *argv[]) {
         std::vector<std::string> CSLabels = {CSNameXY, CSNameYZ};
         PrintCrossSectionData(NumberOfCrossSections, BaseFileName, CrossSectionPlane, CrossSectionLocation, nx, ny, nz,
                               NumberOfOrientations, GrainID, PrintSectionPF, PrintSectionIPF, BimodalAnalysis, true,
-                              deltax, GrainUnitVector_Host, GrainEulerAngles_Host, GrainRGBValues_Host, CSLabels);
+                              deltax, GrainUnitVector_Host, GrainEulerAngles_Host, GrainRGBValues_Host, CSLabels,
+                              FirstPowderGrainID);
     }
     // Finalize kokkos and end program
     Kokkos::finalize();

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -96,10 +96,12 @@ void SubstrateInit_ConstrainedGrowth(int id, double FractSurfaceSitesActive, int
                                      int np, Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, int BufSizeX,
                                      bool AtNorthBoundary, bool AtSouthBoundary);
 void SubstrateInit_FromFile(std::string SubstrateFileName, int nz, int nx, int MyYSlices, int MyYOffset, int pid,
-                            ViewI &GrainID, int nzActive, bool BaseplateThroughPowder);
+                            ViewI &GrainID, int nzActive, bool BaseplateThroughPowder,
+                            int &NextLayer_FirstEpitaxialGrainID, int &FirstPowderGrainID);
 void BaseplateInit_FromGrainSpacing(float SubstrateGrainSpacing, int nx, int ny, double *ZMinLayer, double *ZMaxLayer,
                                     int MyYSlices, int MyYOffset, int id, double deltax, ViewI GrainID, double RNGSeed,
-                                    int &NextLayer_FirstEpitaxialGrainID, int nz, double BaseplateThroughPowder);
+                                    int &NextLayer_FirstEpitaxialGrainID, int nz, bool BaseplateThroughPowder,
+                                    int &FirstPowderGrainID);
 void PowderInit(int layernumber, int nx, int ny, int LayerHeight, double *ZMaxLayer, double ZMin, double deltax,
                 int MyYSlices, int MyYOffset, int id, ViewI GrainID, double RNGSeed,
                 int &NextLayer_FirstEpitaxialGrainID, double PowderDensity);

--- a/src/CAprint.cpp
+++ b/src/CAprint.cpp
@@ -588,7 +588,8 @@ void PrintExaCALog(int id, int np, std::string InputFile, std::string Simulation
                    double InitMaxTime, double InitMinTime, double NuclMaxTime, double NuclMinTime,
                    double CreateSVMinTime, double CreateSVMaxTime, double CaptureMaxTime, double CaptureMinTime,
                    double GhostMaxTime, double GhostMinTime, double OutMaxTime, double OutMinTime, double XMin,
-                   double XMax, double YMin, double YMax, double ZMin, double ZMax) {
+                   double XMax, double YMin, double YMax, double ZMin, double ZMax, int FirstPowderGrainID,
+                   double PowderDensity) {
 
     int *YSlices = new int[np];
     int *YOffset = new int[np];
@@ -626,15 +627,11 @@ void PrintExaCALog(int id, int np, std::string InputFile, std::string Simulation
             ExaCALog << "The thermal gradient was " << G << " K/m, and the cooling rate " << R << " K/s" << std::endl;
             ExaCALog << "The fraction of surface sites active was " << FractSurfaceSitesActive << std::endl;
         }
-        else if (SimulationType == "S") {
-            ExaCALog << "A total of " << NSpotsX << " in X and " << NSpotsY << " in Y were considered" << std::endl;
-            ExaCALog << "The spots were offset by " << SpotOffset << " microns, and had radii of " << SpotRadius
-                     << " microns" << std::endl;
-            ExaCALog << "This pattern was repeated for " << NumberOfLayers << " layers" << std::endl;
-        }
         else {
             ExaCALog << NumberOfLayers << " layers were simulated, with an offset of " << LayerHeight << " cells"
                      << std::endl;
+            ExaCALog << "Powder layer (if used) grain IDs start at: " << FirstPowderGrainID << std::endl;
+            ExaCALog << "Density of active sites in the powder layer was: " << PowderDensity << std::endl;
             if (RemeltingYN)
                 ExaCALog << "Remelting was included" << std::endl;
             else
@@ -643,13 +640,22 @@ void PrintExaCALog(int id, int np, std::string InputFile, std::string Simulation
                 ExaCALog << "The substrate file was " << SubstrateFileName << std::endl;
             else
                 ExaCALog << "The mean substrate grain size was " << SubstrateGrainSpacing << " microns" << std::endl;
-            if (SimulationType == "R") {
-                ExaCALog << "The " << TempFilesInSeries << " temperature file(s) repeated in the " << NumberOfLayers
-                         << " layer simulation were: " << std::endl;
-                for (int i = 0; i < TempFilesInSeries; i++) {
-                    std::cout << temp_paths[i] << std::endl;
-                }
+            if (SimulationType == "S") {
+                ExaCALog << "A total of " << NSpotsX << " in X and " << NSpotsY << " in Y were considered" << std::endl;
+                ExaCALog << "The spots were offset by " << SpotOffset << " microns, and had radii of " << SpotRadius
+                         << " microns" << std::endl;
+            }
+            else {
                 ExaCALog << "The temperature data resolution was " << HT_deltax << " microns" << std::endl;
+                ExaCALog << "The " << TempFilesInSeries << " temperature file(s) repeated in the " << NumberOfLayers
+                         << " layer simulation were: ";
+                for (int i = 0; i < TempFilesInSeries; i++) {
+                    ExaCALog << temp_paths[i];
+                    if (i < TempFilesInSeries - 1)
+                        ExaCALog << ",";
+                    else
+                        ExaCALog << std::endl;
+                }
             }
         }
         ExaCALog << "The decomposition scheme used was a 1D decomposition along the Y direction" << std::endl;

--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -46,7 +46,8 @@ void PrintExaCALog(int id, int np, std::string InputFile, std::string Simulation
                    double InitMaxTime, double InitMinTime, double NuclMaxTime, double NuclMinTime,
                    double CreateSVMinTime, double CreateSVMaxTime, double CaptureMaxTime, double CaptureMinTime,
                    double GhostMaxTime, double GhostMinTime, double OutMaxTime, double OutMinTime, double XMin,
-                   double XMax, double YMin, double YMax, double ZMin, double ZMax);
+                   double XMax, double YMin, double YMax, double ZMin, double ZMax, int FirstPowderGrainID,
+                   double PowderDensity);
 void PrintCAFields(int nx, int ny, int nz, ViewI3D_H GrainID_WholeDomain, ViewI3D_H LayerID_WholeDomain,
                    ViewI3D_H CritTimeStep_WholeDomain, ViewI3D_H CellType_WholeDomain,
                    ViewF3D_H UndercoolingChange_WholeDomain, ViewF3D_H UndercoolingCurrent_WholeDomain,

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -195,7 +195,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
 
     // Initialize the grain structure and cell types - for either a constrained solidification problem, using a
     // substrate from a file, or generating a substrate using the existing CA algorithm
-    int NextLayer_FirstEpitaxialGrainID;
+    int NextLayer_FirstEpitaxialGrainID, FirstPowderGrainID;
     if (SimulationType == "C") {
         SubstrateInit_ConstrainedGrowth(id, FractSurfaceSitesActive, MyYSlices, nx, ny, MyYOffset, NeighborX, NeighborY,
                                         NeighborZ, GrainUnitVector, NGrainOrientations, CellType, GrainID,
@@ -205,11 +205,11 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     else {
         if (UseSubstrateFile)
             SubstrateInit_FromFile(SubstrateFileName, nz, nx, MyYSlices, MyYOffset, id, GrainID, nzActive,
-                                   BaseplateThroughPowder);
+                                   BaseplateThroughPowder, NextLayer_FirstEpitaxialGrainID, FirstPowderGrainID);
         else
             BaseplateInit_FromGrainSpacing(SubstrateGrainSpacing, nx, ny, ZMinLayer, ZMaxLayer, MyYSlices, MyYOffset,
                                            id, deltax, GrainID, RNGSeed, NextLayer_FirstEpitaxialGrainID, nz,
-                                           BaseplateThroughPowder);
+                                           BaseplateThroughPowder, FirstPowderGrainID);
         // Separate routine for active cell data structure init for problems other than constrained solidification
         if (RemeltingYN)
             CellTypeInit_Remelt(nx, MyYSlices, LocalActiveDomainSize, CellType, CritTimeStep, id, ZBound_Low);
@@ -514,5 +514,5 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                   NSpotsX, NSpotsY, SpotOffset, SpotRadius, OutputFile, InitTime, RunTime, OutTime, cycle, InitMaxTime,
                   InitMinTime, NuclMaxTime, NuclMinTime, CreateSVMinTime, CreateSVMaxTime, CaptureMaxTime,
                   CaptureMinTime, GhostMaxTime, GhostMinTime, OutMaxTime, OutMinTime, XMin, XMax, YMin, YMax, ZMin,
-                  ZMax);
+                  ZMax, FirstPowderGrainID, PowderDensity);
 }

--- a/unit_test/tstKokkosInitMPI.hpp
+++ b/unit_test/tstKokkosInitMPI.hpp
@@ -135,12 +135,13 @@ void testBaseplateInit_FromGrainSpacing() {
     double SubstrateGrainSpacing =
         3.0; // This grain spacing ensures that there will be 1 grain per number of MPI ranks present
     double RNGSeed = 0.0;
-    int NextLayer_FirstEpitaxialGrainID;
+    int NextLayer_FirstEpitaxialGrainID, FirstPowderGrainID;
     // Initialize GrainIDs to 0 on device
     ViewI GrainID("GrainID_Device", LocalDomainSize);
 
     BaseplateInit_FromGrainSpacing(SubstrateGrainSpacing, nx, ny, ZMinLayer, ZMaxLayer, MyYSlices, MyYOffset, id,
-                                   deltax, GrainID, RNGSeed, NextLayer_FirstEpitaxialGrainID, nz, false);
+                                   deltax, GrainID, RNGSeed, NextLayer_FirstEpitaxialGrainID, nz, false,
+                                   FirstPowderGrainID);
 
     // Copy results back to host to check
     ViewI_H GrainID_H = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), GrainID);
@@ -154,9 +155,10 @@ void testBaseplateInit_FromGrainSpacing() {
     for (int i = BaseplateSize; i < LocalDomainSize; i++) {
         EXPECT_EQ(GrainID_H(i), 0);
     }
-    // Next unused GrainID should be the number of grains present in the baseplate plus 2 (since GrainID = 0 is not used
+    // Next unused GrainID should be the number of grains present in the baseplate plus 1 (since GrainID = 0 is not used
     // for any baseplate grains)
-    EXPECT_EQ(NextLayer_FirstEpitaxialGrainID, np + 2);
+    EXPECT_EQ(NextLayer_FirstEpitaxialGrainID, np + 1);
+    EXPECT_EQ(FirstPowderGrainID, NextLayer_FirstEpitaxialGrainID);
 }
 
 void testPowderInit() {


### PR DESCRIPTION
Baseplate grain ID values span 1 through `NumberOfBaseplateGrains`, larger grain ID values come from active sites in the powder layer. The fraction of active sites in the powder layer, as well as the smallest of the powder layer grain ID values, are recorded in the .log file (minor rearrangements to `PrintExaCALog`). The fraction of each cross-section analyzed consisting of powder layer grains is printed to the console/files when running the analysis scripts.