### PR TITLE
Modified log file to write/analysis to read orientations filename

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -14,12 +14,15 @@ This is where the required inputs for analysis are given; these inputs are:
 
 * Path to/name of log (.log) file associated with the microstructure of interest
 * Path to/name of microstructure (.vtk) file
-* Path to file of grain orientations (rotation matrix form)
 * Path to/base (without file extension) name of data files of output resulting from this analysis
+
+Three deprecated inputs may also be given here, though these will be ignored in a future release; these inputs are:
+* Path to file of grain orientations (rotation matrix form)
 * Path to file of grain orientations (Bunge Euler angle form ZXZ)
 * Path to file corresponding to grain orientation IPF-Z colors as fractional RGB values
 
-Nothing other than values for these 6 inputs (separated by a colon from the rest of the line) should be given here. If "Path to file of grain orientations (Bunge Euler angle form ZXZ)" is not given, the deprecated form of printing ExaCA cross-section data is assumed - this will be removed in a future release, at which point the lack of including a value for this input will result in a runtime error. If "Path to file corresponding to grain orientation IPF-Z colors as fractional RGB values" is not given, the default file (examples/Substrate/GrainOrientationRGB_IPF-Z.csv) will be used to map orientations to RGB values - the lack of inclusion of this input in future releases will also result in a runtime error.
+Values for these inputs should be separated by a colon from the rest of the line. The paths to the 3 grain orientation files will only be be used if they cannot be extracted from the log file. The grain orientation files "examples/Substrate/GrainOrientationVectors.csv", "examples/Substrate/GrainOrientationEulerAnglesBungeZXZ.csv", and "examples/Substrate/GrainOrientationRGB_IPF-Z.csv" are used by the example problems. If a custom file of grain orientation vectors was used by ExaCA to simulate a microstructure (i.e., "path/to/file/GrainOrientationVectors_customname.csv"), this requires that the corresponding 2 orientation files are also provided ("path/to/file/GrainOrientationEulerAnglesBungeZXZ_customname.csv" and "path/to/file/GrainOrientationRGB_IPF-Z_customname.csv") and that they are properly formatted (see `examples/README.md` for more details).
+ If the orientation file data is not given in the log file, and "Path to file of grain orientations (Bunge Euler angle form ZXZ)" is not given in the analysis inputs file, the deprecated form of printing ExaCA cross-section data is assumed. If "Path to file corresponding to grain orientation IPF-Z colors as fractional RGB values" is not given, the default file (examples/Substrate/GrainOrientationRGB_IPF-Z.csv) will be used to map orientations to RGB values. In the future these paths will be required and missing input will result in a runtime error.
 
 ## Section 1: ExaConstit representative volume element (RVE) printing
 

--- a/analysis/src/GAutils.hpp
+++ b/analysis/src/GAutils.hpp
@@ -25,7 +25,8 @@ int FindTopOrBottom(int ***LayerID, int XLow, int XHigh, int YLow, int YHigh, in
 // These are used in reading/parsing ExaCA microstructure data
 bool checkLogFormat(std::string LogFile);
 void ParseLogFile(std::string LogFile, int &nx, int &ny, int &nz, double &deltax, int &NumberOfLayers,
-                  std::vector<double> &XYZBounds);
+                  std::vector<double> &XYZBounds, std::string &RotationFilename, std::string &EulerAnglesFilename,
+                  std::string &RGBFilename, bool OrientationFilesInInput);
 void ParseLogFile_Old(std::string LogFile, int &nx, int &ny, int &nz, double &deltax, int &NumberOfLayers,
                       bool UseXYZBounds, std::vector<double> &XYZBounds);
 void ReadASCIIField(std::ifstream &InputDataStream, int nx, int ny, int nz, ViewI3D_H FieldOfInterest);
@@ -33,7 +34,7 @@ void ReadBinaryField(std::ifstream &InputDataStream, int nx, int ny, int nz, Vie
                      std::string FieldName);
 void ParseFilenames(std::string AnalysisFile, std::string &LogFile, std::string &MicrostructureFile,
                     std::string &RotationFilename, std::string &OutputFileName, std::string &EulerAnglesFilename,
-                    std::string &RGBFilename);
+                    std::string &RGBFilename, bool &OrientationFilesInInput);
 void InitializeData(std::string MicrostructureFile, int nx, int ny, int nz, ViewI3D_H GrainID, ViewI3D_H LayerID);
 void ParseAnalysisFile(std::string AnalysisFile, std::string RotationFilename, int &NumberOfOrientations,
                        bool *AnalysisTypes, std::vector<int> &XLow_RVE, std::vector<int> &XHigh_RVE,
@@ -45,8 +46,8 @@ void ParseAnalysisFile(std::string AnalysisFile, std::string RotationFilename, i
                        std::vector<bool> &BimodalAnalysis, std::vector<std::string> &CSLabels);
 std::vector<int> FindUniqueGrains(const std::vector<int> GrainIDVector);
 
-void CheckInputFiles(std::string BaseFileName, std::string &LogFile, std::string &MicrostructureFile,
-                     std::string &RotationFilename, std::string &RGBFilename, std::string &EulerAnglesFilename);
+void CheckInputFiles(std::string LogFile, std::string MicrostructureFile, std::string &RotationFilename,
+                     std::string &RGBFilename, std::string &EulerAnglesFilename);
 std::vector<int> FindUniqueGrains(std::vector<int> GrainIDVector);
 template <typename ReturnType, typename FirstType, typename SecondType>
 ReturnType DivideCast(FirstType Int1, SecondType Int2) {

--- a/analysis/src/runGA.cpp
+++ b/analysis/src/runGA.cpp
@@ -22,6 +22,7 @@
 int main(int argc, char *argv[]) {
 
     // Read command line input to obtain name of analysis file
+    bool OrientationFilesInInput;
     std::string AnalysisFile, LogFile, MicrostructureFile, RotationFilename, EulerAnglesFilename, OutputFileName,
         RGBFilename;
     double deltax;
@@ -34,7 +35,7 @@ int main(int argc, char *argv[]) {
         // If the file of orientations is given in both rotation matrix and Euler angle form, it is assumed that the new
         // output format is used for cross-section orientation data Otherwise, the old format is used
         ParseFilenames(AnalysisFile, LogFile, MicrostructureFile, RotationFilename, OutputFileName, EulerAnglesFilename,
-                       RGBFilename);
+                       RGBFilename, OrientationFilesInInput);
     }
     std::cout << "Performing analysis of " << MicrostructureFile << " , using the log file " << LogFile
               << " and the options specified in " << AnalysisFile << std::endl;
@@ -49,7 +50,8 @@ int main(int argc, char *argv[]) {
         std::vector<double> XYZBounds(6);
         bool NewLogFormatYN = checkLogFormat(LogFile);
         if (NewLogFormatYN)
-            ParseLogFile(LogFile, nx, ny, nz, deltax, NumberOfLayers, XYZBounds);
+            ParseLogFile(LogFile, nx, ny, nz, deltax, NumberOfLayers, XYZBounds, RotationFilename, EulerAnglesFilename,
+                         RGBFilename, OrientationFilesInInput);
         else
             ParseLogFile_Old(LogFile, nx, ny, nz, deltax, NumberOfLayers, true, XYZBounds);
 

--- a/src/CAparsefiles.cpp
+++ b/src/CAparsefiles.cpp
@@ -78,6 +78,14 @@ bool parseInputFromList(std::string line, std::vector<std::string> InputKeys, st
     return FoundInput;
 }
 
+// Given a string, return the value following the colon with the whitespace removed
+std::string parseInputAfterColon(std::string line) {
+    std::size_t colon = line.find(":");
+    std::string lineaftercolon = line.substr(colon + 1, std::string::npos);
+    lineaftercolon = removeWhitespace(lineaftercolon);
+    return lineaftercolon;
+}
+
 // Get a line from a file, verify the required input was included with the correct format, and parse the input
 std::string parseInput(std::ifstream &stream, std::string key) {
 

--- a/src/CAparsefiles.cpp
+++ b/src/CAparsefiles.cpp
@@ -78,14 +78,6 @@ bool parseInputFromList(std::string line, std::vector<std::string> InputKeys, st
     return FoundInput;
 }
 
-// Given a string, return the value following the colon with the whitespace removed
-std::string parseInputAfterColon(std::string line) {
-    std::size_t colon = line.find(":");
-    std::string lineaftercolon = line.substr(colon + 1, std::string::npos);
-    lineaftercolon = removeWhitespace(lineaftercolon);
-    return lineaftercolon;
-}
-
 // Get a line from a file, verify the required input was included with the correct format, and parse the input
 std::string parseInput(std::ifstream &stream, std::string key) {
 

--- a/src/CAparsefiles.hpp
+++ b/src/CAparsefiles.hpp
@@ -21,6 +21,7 @@ void skipLines(std::ifstream &stream, std::string seperator);
 std::string removeWhitespace(std::string line, int pos = -1);
 bool parseInputFromList(std::string line, std::vector<std::string> InputKeys, std::vector<std::string> &ParsedInputs,
                         int NumInputs = 1);
+std::string parseInputAfterColon(std::string line);
 std::string parseInput(std::ifstream &stream, std::string key);
 bool getInputBool(std::string val_input);
 int getInputInt(std::string val_input);

--- a/src/CAprint.cpp
+++ b/src/CAprint.cpp
@@ -588,7 +588,7 @@ void PrintExaCALog(int id, int np, std::string InputFile, std::string Simulation
                    double InitMaxTime, double InitMinTime, double NuclMaxTime, double NuclMinTime,
                    double CreateSVMinTime, double CreateSVMaxTime, double CaptureMaxTime, double CaptureMinTime,
                    double GhostMaxTime, double GhostMinTime, double OutMaxTime, double OutMinTime, double XMin,
-                   double XMax, double YMin, double YMax, double ZMin, double ZMax) {
+                   double XMax, double YMin, double YMax, double ZMin, double ZMax, std::string GrainOrientationFile) {
 
     int *YSlices = new int[np];
     int *YOffset = new int[np];
@@ -610,6 +610,7 @@ void PrintExaCALog(int id, int np, std::string InputFile, std::string Simulation
         ExaCALog << "Init/run/output timing breakdown (in seconds): " << InitTime << "/" << RunTime << "/" << OutTime
                  << std::endl;
         ExaCALog << "Simulation was type: " << SimulationType << std::endl;
+        ExaCALog << "Grain orientation file: " << GrainOrientationFile << std::endl;
         ExaCALog << "Domain size in x: " << nx << std::endl;
         ExaCALog << "Domain size in y: " << ny << std::endl;
         ExaCALog << "Domain size in z: " << nz << std::endl;

--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -46,7 +46,7 @@ void PrintExaCALog(int id, int np, std::string InputFile, std::string Simulation
                    double InitMaxTime, double InitMinTime, double NuclMaxTime, double NuclMinTime,
                    double CreateSVMinTime, double CreateSVMaxTime, double CaptureMaxTime, double CaptureMinTime,
                    double GhostMaxTime, double GhostMinTime, double OutMaxTime, double OutMinTime, double XMin,
-                   double XMax, double YMin, double YMax, double ZMin, double ZMax);
+                   double XMax, double YMin, double YMax, double ZMin, double ZMax, std::string GrainOrientationFile);
 void PrintCAFields(int nx, int ny, int nz, ViewI3D_H GrainID_WholeDomain, ViewI3D_H LayerID_WholeDomain,
                    ViewI3D_H CritTimeStep_WholeDomain, ViewI3D_H CellType_WholeDomain,
                    ViewF3D_H UndercoolingChange_WholeDomain, ViewF3D_H UndercoolingCurrent_WholeDomain,

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -527,5 +527,5 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                   NSpotsX, NSpotsY, SpotOffset, SpotRadius, OutputFile, InitTime, RunTime, OutTime, cycle, InitMaxTime,
                   InitMinTime, NuclMaxTime, NuclMinTime, CreateSVMinTime, CreateSVMaxTime, CaptureMaxTime,
                   CaptureMinTime, GhostMaxTime, GhostMinTime, OutMaxTime, OutMinTime, XMin, XMax, YMin, YMax, ZMin,
-                  ZMax);
+                  ZMax, GrainOrientationFile);
 }


### PR DESCRIPTION
The orientations file used is now printed as part of the ExaCA log file, and this file name is parsed when running the analysis executable. If reading an older data set that does not have this file name in the log file, the orientation file names are parsed using the analysis input file as was done previously. Additionally, the default orientation file name is no longer hardcoded for runs with the `grain_analysis_amb` executable, allowing analysis of ExaCA data sets created using alternative orientation files (i.e., those recently merged into the ExaCA-Data repository https://github.com/LLNL/ExaCA-Data/pull/2)