### PR TITLE
Separate GrainID components for sending/receiving halo data as floats

### DIFF
--- a/src/CAfunctions.hpp
+++ b/src/CAfunctions.hpp
@@ -12,9 +12,34 @@
 // Inline functions
 
 // Get the orientation of a grain from a given grain ID and the number of possible orientations
-KOKKOS_INLINE_FUNCTION int getGrainOrientation(int MyGrainID, int NGrainOrientations) {
-    int MyOrientation = (abs(MyGrainID) - 1) % NGrainOrientations;
+// By default, start indexing at 0 (GrainID of 1 has Orientation number 0), optionally starting at 1
+// GrainID of 0 is a special case - has orientation 0 no matter what (only used when reconstructing grain ID in
+// getGrainID)
+KOKKOS_INLINE_FUNCTION int getGrainOrientation(int MyGrainID, int NGrainOrientations, bool StartAtZero = true) {
+    int MyOrientation;
+    if (MyGrainID == 0)
+        MyOrientation = 0;
+    else {
+        MyOrientation = (abs(MyGrainID) - 1) % NGrainOrientations;
+        if (!(StartAtZero))
+            MyOrientation++;
+    }
     return MyOrientation;
+}
+// Get the repeat number for the orientation of a grain with a given grain ID
+// 1, 2, 3... or -1, -2, -3...
+KOKKOS_INLINE_FUNCTION int getGrainNumber(int MyGrainID, int NGrainOrientations) {
+    int MyGrainNumber = (abs(MyGrainID) - 1) / NGrainOrientations + 1;
+    if (MyGrainID < 0)
+        MyGrainNumber = -MyGrainNumber;
+    return MyGrainNumber;
+}
+// Get the grain ID from the repeat number of a grain from a given grain ID and the number of possible orientations
+KOKKOS_INLINE_FUNCTION int getGrainID(int NGrainOrientations, int MyGrainOrientation, int MyGrainNumber) {
+    int MyGrainID = NGrainOrientations * (abs(MyGrainNumber) - 1) + MyGrainOrientation;
+    if (MyGrainNumber < 0)
+        MyGrainID = -MyGrainID;
+    return MyGrainID;
 }
 //*****************************************************************************/
 int YMPSlicesCalc(int p, int ny, int np);

--- a/src/CAghostnodes.cpp
+++ b/src/CAghostnodes.cpp
@@ -61,15 +61,15 @@ void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int 
                         RankY = 0;
                         CellLocation = RankZ * nx * MyYSlices + MyYSlices * RankX + RankY;
                         int GlobalCellLocation = CellLocation + ZBound_Low * nx * MyYSlices;
-                        if ((BufferSouthRecv(BufPosition, 4) > 0) && (CellType(GlobalCellLocation) == Liquid)) {
+                        if ((BufferSouthRecv(BufPosition, 5) > 0) && (CellType(GlobalCellLocation) == Liquid)) {
                             Place = true;
                             int MyGrainOrientation = static_cast<int>(BufferSouthRecv(BufPosition, 0));
-                            int MyGrainNumber = static_cast<int>(BufferSouthRecv(BufPosition, 5));
+                            int MyGrainNumber = static_cast<int>(BufferSouthRecv(BufPosition, 1));
                             NewGrainID = getGrainID(NGrainOrientations, MyGrainOrientation, MyGrainNumber);
-                            DOCenterX = BufferSouthRecv(BufPosition, 1);
-                            DOCenterY = BufferSouthRecv(BufPosition, 2);
-                            DOCenterZ = BufferSouthRecv(BufPosition, 3);
-                            NewDiagonalLength = BufferSouthRecv(BufPosition, 4);
+                            DOCenterX = BufferSouthRecv(BufPosition, 2);
+                            DOCenterY = BufferSouthRecv(BufPosition, 3);
+                            DOCenterZ = BufferSouthRecv(BufPosition, 4);
+                            NewDiagonalLength = BufferSouthRecv(BufPosition, 5);
                         }
                     }
                     else if ((unpack_index == 1) && (NeighborRank_North != MPI_PROC_NULL)) {
@@ -77,15 +77,15 @@ void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int 
                         RankY = MyYSlices - 1;
                         CellLocation = RankZ * nx * MyYSlices + MyYSlices * RankX + RankY;
                         int GlobalCellLocation = CellLocation + ZBound_Low * nx * MyYSlices;
-                        if ((BufferNorthRecv(BufPosition, 4) > 0) && (CellType(GlobalCellLocation) == Liquid)) {
+                        if ((BufferNorthRecv(BufPosition, 5) > 0) && (CellType(GlobalCellLocation) == Liquid)) {
                             Place = true;
                             int MyGrainOrientation = static_cast<int>(BufferNorthRecv(BufPosition, 0));
-                            int MyGrainNumber = static_cast<int>(BufferNorthRecv(BufPosition, 5));
+                            int MyGrainNumber = static_cast<int>(BufferNorthRecv(BufPosition, 1));
                             NewGrainID = getGrainID(NGrainOrientations, MyGrainOrientation, MyGrainNumber);
-                            DOCenterX = BufferNorthRecv(BufPosition, 1);
-                            DOCenterY = BufferNorthRecv(BufPosition, 2);
-                            DOCenterZ = BufferNorthRecv(BufPosition, 3);
-                            NewDiagonalLength = BufferNorthRecv(BufPosition, 4);
+                            DOCenterX = BufferNorthRecv(BufPosition, 2);
+                            DOCenterY = BufferNorthRecv(BufPosition, 3);
+                            DOCenterZ = BufferNorthRecv(BufPosition, 4);
+                            NewDiagonalLength = BufferNorthRecv(BufPosition, 5);
                         }
                     }
                     if (Place) {

--- a/src/CAghostnodes.cpp
+++ b/src/CAghostnodes.cpp
@@ -23,15 +23,15 @@ void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int 
     std::vector<MPI_Request> RecvRequests(2, MPI_REQUEST_NULL);
 
     // Send data to each other rank (MPI_Isend)
-    MPI_Isend(BufferSouthSend.data(), 5 * BufSizeX * BufSizeZ, MPI_DOUBLE, NeighborRank_South, 0, MPI_COMM_WORLD,
+    MPI_Isend(BufferSouthSend.data(), 6 * BufSizeX * BufSizeZ, MPI_FLOAT, NeighborRank_South, 0, MPI_COMM_WORLD,
               &SendRequests[0]);
-    MPI_Isend(BufferNorthSend.data(), 5 * BufSizeX * BufSizeZ, MPI_DOUBLE, NeighborRank_North, 0, MPI_COMM_WORLD,
+    MPI_Isend(BufferNorthSend.data(), 6 * BufSizeX * BufSizeZ, MPI_FLOAT, NeighborRank_North, 0, MPI_COMM_WORLD,
               &SendRequests[1]);
 
     // Receive buffers for all neighbors (MPI_Irecv)
-    MPI_Irecv(BufferSouthRecv.data(), 5 * BufSizeX * BufSizeZ, MPI_DOUBLE, NeighborRank_South, 0, MPI_COMM_WORLD,
+    MPI_Irecv(BufferSouthRecv.data(), 6 * BufSizeX * BufSizeZ, MPI_FLOAT, NeighborRank_South, 0, MPI_COMM_WORLD,
               &RecvRequests[0]);
-    MPI_Irecv(BufferNorthRecv.data(), 5 * BufSizeX * BufSizeZ, MPI_DOUBLE, NeighborRank_North, 0, MPI_COMM_WORLD,
+    MPI_Irecv(BufferNorthRecv.data(), 6 * BufSizeX * BufSizeZ, MPI_FLOAT, NeighborRank_North, 0, MPI_COMM_WORLD,
               &RecvRequests[1]);
 
     // unpack in any order
@@ -63,7 +63,9 @@ void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int 
                         int GlobalCellLocation = CellLocation + ZBound_Low * nx * MyYSlices;
                         if ((BufferSouthRecv(BufPosition, 4) > 0) && (CellType(GlobalCellLocation) == Liquid)) {
                             Place = true;
-                            NewGrainID = (int)(BufferSouthRecv(BufPosition, 0));
+                            int MyGrainOrientation = static_cast<int>(BufferSouthRecv(BufPosition, 0));
+                            int MyGrainNumber = static_cast<int>(BufferSouthRecv(BufPosition, 5));
+                            NewGrainID = getGrainID(NGrainOrientations, MyGrainOrientation, MyGrainNumber);
                             DOCenterX = BufferSouthRecv(BufPosition, 1);
                             DOCenterY = BufferSouthRecv(BufPosition, 2);
                             DOCenterZ = BufferSouthRecv(BufPosition, 3);
@@ -77,7 +79,9 @@ void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int 
                         int GlobalCellLocation = CellLocation + ZBound_Low * nx * MyYSlices;
                         if ((BufferNorthRecv(BufPosition, 4) > 0) && (CellType(GlobalCellLocation) == Liquid)) {
                             Place = true;
-                            NewGrainID = (int)(BufferNorthRecv(BufPosition, 0));
+                            int MyGrainOrientation = static_cast<int>(BufferNorthRecv(BufPosition, 0));
+                            int MyGrainNumber = static_cast<int>(BufferNorthRecv(BufPosition, 5));
+                            NewGrainID = getGrainID(NGrainOrientations, MyGrainOrientation, MyGrainNumber);
                             DOCenterX = BufferNorthRecv(BufPosition, 1);
                             DOCenterY = BufferNorthRecv(BufPosition, 2);
                             DOCenterZ = BufferNorthRecv(BufPosition, 3);

--- a/src/CAghostnodes.hpp
+++ b/src/CAghostnodes.hpp
@@ -6,32 +6,37 @@
 #ifndef EXACA_GHOST_HPP
 #define EXACA_GHOST_HPP
 
+#include "CAfunctions.hpp"
 #include "CAtypes.hpp"
 
 #include <Kokkos_Core.hpp>
 
 // Load data (GrainID, DOCenter, DiagonalLength) into ghost nodes if the given RankY is associated with a 1D halo region
-KOKKOS_INLINE_FUNCTION void loadghostnodes(const double GhostGID, const double GhostDOCX, const double GhostDOCY,
-                                           const double GhostDOCZ, const double GhostDL, const int BufSizeX,
+KOKKOS_INLINE_FUNCTION void loadghostnodes(const int GhostGID, const float GhostDOCX, const float GhostDOCY,
+                                           const float GhostDOCZ, const float GhostDL, const int BufSizeX,
                                            const int MyYSlices, const int RankX, const int RankY, const int RankZ,
                                            const bool AtNorthBoundary, const bool AtSouthBoundary,
-                                           Buffer2D BufferSouthSend, Buffer2D BufferNorthSend) {
+                                           Buffer2D BufferSouthSend, Buffer2D BufferNorthSend, int NGrainOrientations) {
 
     if ((RankY == 1) && (!(AtSouthBoundary))) {
         int GNPosition = RankZ * BufSizeX + RankX;
-        BufferSouthSend(GNPosition, 0) = GhostGID;
+        int MyGrainOrientation = getGrainOrientation(GhostGID, NGrainOrientations, false);
+        BufferSouthSend(GNPosition, 0) = MyGrainOrientation;
         BufferSouthSend(GNPosition, 1) = GhostDOCX;
         BufferSouthSend(GNPosition, 2) = GhostDOCY;
         BufferSouthSend(GNPosition, 3) = GhostDOCZ;
         BufferSouthSend(GNPosition, 4) = GhostDL;
+        BufferSouthSend(GNPosition, 5) = getGrainNumber(GhostGID, NGrainOrientations);
     }
     else if ((RankY == MyYSlices - 2) && (!(AtNorthBoundary))) {
         int GNPosition = RankZ * BufSizeX + RankX;
-        BufferNorthSend(GNPosition, 0) = GhostGID;
+        int MyGrainOrientation = getGrainOrientation(GhostGID, NGrainOrientations, false);
+        BufferNorthSend(GNPosition, 0) = MyGrainOrientation;
         BufferNorthSend(GNPosition, 1) = GhostDOCX;
         BufferNorthSend(GNPosition, 2) = GhostDOCY;
         BufferNorthSend(GNPosition, 3) = GhostDOCZ;
         BufferNorthSend(GNPosition, 4) = GhostDL;
+        BufferNorthSend(GNPosition, 5) = getGrainNumber(GhostGID, NGrainOrientations);
     }
 }
 void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int nx, int MyYSlices, int MyYOffset,

--- a/src/CAghostnodes.hpp
+++ b/src/CAghostnodes.hpp
@@ -21,22 +21,22 @@ KOKKOS_INLINE_FUNCTION void loadghostnodes(const int GhostGID, const float Ghost
     if ((RankY == 1) && (!(AtSouthBoundary))) {
         int GNPosition = RankZ * BufSizeX + RankX;
         int MyGrainOrientation = getGrainOrientation(GhostGID, NGrainOrientations, false);
-        BufferSouthSend(GNPosition, 0) = MyGrainOrientation;
-        BufferSouthSend(GNPosition, 1) = GhostDOCX;
-        BufferSouthSend(GNPosition, 2) = GhostDOCY;
-        BufferSouthSend(GNPosition, 3) = GhostDOCZ;
-        BufferSouthSend(GNPosition, 4) = GhostDL;
-        BufferSouthSend(GNPosition, 5) = getGrainNumber(GhostGID, NGrainOrientations);
+        BufferSouthSend(GNPosition, 0) = static_cast<float>(MyGrainOrientation);
+        BufferSouthSend(GNPosition, 1) = getGrainNumber(GhostGID, NGrainOrientations);
+        BufferSouthSend(GNPosition, 2) = GhostDOCX;
+        BufferSouthSend(GNPosition, 3) = GhostDOCY;
+        BufferSouthSend(GNPosition, 4) = GhostDOCZ;
+        BufferSouthSend(GNPosition, 5) = GhostDL;
     }
     else if ((RankY == MyYSlices - 2) && (!(AtNorthBoundary))) {
         int GNPosition = RankZ * BufSizeX + RankX;
         int MyGrainOrientation = getGrainOrientation(GhostGID, NGrainOrientations, false);
-        BufferNorthSend(GNPosition, 0) = MyGrainOrientation;
-        BufferNorthSend(GNPosition, 1) = GhostDOCX;
-        BufferNorthSend(GNPosition, 2) = GhostDOCY;
-        BufferNorthSend(GNPosition, 3) = GhostDOCZ;
-        BufferNorthSend(GNPosition, 4) = GhostDL;
-        BufferNorthSend(GNPosition, 5) = getGrainNumber(GhostGID, NGrainOrientations);
+        BufferNorthSend(GNPosition, 0) = static_cast<float>(MyGrainOrientation);
+        BufferNorthSend(GNPosition, 1) = getGrainNumber(GhostGID, NGrainOrientations);
+        BufferNorthSend(GNPosition, 2) = GhostDOCX;
+        BufferNorthSend(GNPosition, 3) = GhostDOCY;
+        BufferNorthSend(GNPosition, 4) = GhostDOCZ;
+        BufferNorthSend(GNPosition, 5) = GhostDL;
     }
 }
 void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int nx, int MyYSlices, int MyYOffset,

--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -1975,14 +1975,15 @@ void SubstrateInit_ConstrainedGrowth(int id, double FractSurfaceSitesActive, int
                 // If this new active cell is in the halo region, load the send buffers
                 if (np > 1) {
 
-                    float GhostGID = GrainID(D3D1ConvPosition);
+                    int GhostGID = GrainID(D3D1ConvPosition);
                     float GhostDOCX = GlobalX + 0.5;
                     float GhostDOCY = GlobalY + 0.5;
                     float GhostDOCZ = GlobalZ + 0.5;
                     float GhostDL = 0.01;
                     // Collect data for the ghost nodes, if necessary
                     loadghostnodes(GhostGID, GhostDOCX, GhostDOCY, GhostDOCZ, GhostDL, BufSizeX, MyYSlices, GlobalX,
-                                   LocalY, 0, AtNorthBoundary, AtSouthBoundary, BufferSouthSend, BufferNorthSend);
+                                   LocalY, 0, AtNorthBoundary, AtSouthBoundary, BufferSouthSend, BufferNorthSend,
+                                   NGrainOrientations);
                 } // End if statement for serial/parallel code
             }
         });
@@ -2330,14 +2331,15 @@ void CellTypeInit_NoRemelt(int layernumber, int id, int np, int nx, int MyYSlice
                 // If this new active cell is in the halo region, load the send buffers
                 if (np > 1) {
 
-                    double GhostGID = static_cast<double>(MyGrainID);
-                    double GhostDOCX = static_cast<double>(GlobalX + 0.5);
-                    double GhostDOCY = static_cast<double>(GlobalY + 0.5);
-                    double GhostDOCZ = static_cast<double>(GlobalZ + 0.5);
-                    double GhostDL = 0.01;
+                    int GhostGID = MyGrainID;
+                    float GhostDOCX = GlobalX + 0.5;
+                    float GhostDOCY = GlobalY + 0.5;
+                    float GhostDOCZ = GlobalZ + 0.5;
+                    float GhostDL = 0.01;
                     // Collect data for the ghost nodes, if necessary
                     loadghostnodes(GhostGID, GhostDOCX, GhostDOCY, GhostDOCZ, GhostDL, BufSizeX, MyYSlices, GlobalX,
-                                   RankY, RankZ, AtNorthBoundary, AtSouthBoundary, BufferSouthSend, BufferNorthSend);
+                                   RankY, RankZ, AtNorthBoundary, AtSouthBoundary, BufferSouthSend, BufferNorthSend,
+                                   NGrainOrientations);
 
                 } // End if statement for serial/parallel code
             }
@@ -2635,10 +2637,10 @@ void ZeroResetViews(int LocalActiveDomainSize, int BufSizeX, int BufSizeZ, ViewF
     Kokkos::realloc(DiagonalLength, LocalActiveDomainSize);
     Kokkos::realloc(DOCenter, 3 * LocalActiveDomainSize);
     Kokkos::realloc(CritDiagonalLength, 26 * LocalActiveDomainSize);
-    Kokkos::realloc(BufferNorthSend, BufSizeX * BufSizeZ, 5);
-    Kokkos::realloc(BufferSouthSend, BufSizeX * BufSizeZ, 5);
-    Kokkos::realloc(BufferNorthRecv, BufSizeX * BufSizeZ, 5);
-    Kokkos::realloc(BufferSouthRecv, BufSizeX * BufSizeZ, 5);
+    Kokkos::realloc(BufferNorthSend, BufSizeX * BufSizeZ, 6);
+    Kokkos::realloc(BufferSouthSend, BufSizeX * BufSizeZ, 6);
+    Kokkos::realloc(BufferNorthRecv, BufSizeX * BufSizeZ, 6);
+    Kokkos::realloc(BufferSouthRecv, BufSizeX * BufSizeZ, 6);
 
     // Reset active cell data structures on device
     Kokkos::deep_copy(DiagonalLength, 0);

--- a/src/CAtypes.hpp
+++ b/src/CAtypes.hpp
@@ -24,7 +24,7 @@ typedef Kokkos::View<float *> ViewF;
 typedef Kokkos::View<int *> ViewI;
 typedef Kokkos::View<int **> ViewI2D;
 typedef Kokkos::View<int *, Kokkos::MemoryTraits<Kokkos::Atomic>> View_a;
-typedef Kokkos::View<double **> Buffer2D;
+typedef Kokkos::View<float **> Buffer2D;
 typedef Kokkos::View<float *> TestView;
 typedef Kokkos::View<float ***> ViewF3D;
 
@@ -38,7 +38,7 @@ typedef Kokkos::View<float ***, layout, Kokkos::HostSpace> ViewF3D_H;
 typedef Kokkos::View<int *, layout, Kokkos::HostSpace> ViewI_H;
 typedef Kokkos::View<int **, layout, Kokkos::HostSpace> ViewI2D_H;
 typedef Kokkos::View<int ***, layout, Kokkos::HostSpace> ViewI3D_H;
-typedef Kokkos::View<double **, layout, Kokkos::HostSpace> Buffer2D_H;
+typedef Kokkos::View<float **, layout, Kokkos::HostSpace> Buffer2D_H;
 
 typedef Kokkos::Array<int, 26> NList;
 

--- a/src/CAupdate.cpp
+++ b/src/CAupdate.cpp
@@ -425,7 +425,8 @@ void CellCapture(int, int np, int, int, int, int nx, int MyYSlices, InterfacialR
                                                        CritDiagonalLength);
 
                                 if (np > 1) {
-
+                                    // TODO: Test loading ghost nodes in a separate kernel, potentially adopting this
+                                    // change if the slowdown is minor
                                     int GhostGID = h;
                                     float GhostDOCX = cx;
                                     float GhostDOCY = cy;
@@ -499,7 +500,8 @@ void CellCapture(int, int np, int, int, int, int nx, int MyYSlices, InterfacialR
                 calcCritDiagonalLength(D3D1ConvPosition, cx, cy, cz, cx, cy, cz, NeighborX, NeighborY, NeighborZ,
                                        MyOrientation, GrainUnitVector, CritDiagonalLength);
                 if (np > 1) {
-
+                    // TODO: Test loading ghost nodes in a separate kernel, potentially adopting this change if the
+                    // slowdown is minor
                     int GhostGID = MyGrainID;
                     float GhostDOCX = GlobalX + 0.5;
                     float GhostDOCY = GlobalY + 0.5;

--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -90,7 +90,7 @@ void FillSteeringVector_Remelt(int cycle, int LocalActiveDomainSize, int nx, int
                                ViewF UndercoolingChange, ViewI CellType, ViewI GrainID, int ZBound_Low, int nzActive,
                                ViewI SteeringVector, ViewI numSteer, ViewI_H numSteer_Host, ViewI MeltTimeStep,
                                int BufSizeX, bool AtNorthBoundary, bool AtSouthBoundary, Buffer2D BufferNorthSend,
-                               Buffer2D BufferSouthSend);
+                               Buffer2D BufferSouthSend, int NGrainOrientations);
 void CellCapture(int id, int np, int cycle, int LocalActiveDomainSize, int LocalDomainSize, int nx, int MyYSlices,
                  InterfacialResponseFunction irf, int MyYOffset, NList NeighborX, NList NeighborY, NList NeighborZ,
                  ViewI CritTimeStep, ViewF UndercoolingCurrent, ViewF UndercoolingChange, ViewF GrainUnitVector,

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -201,10 +201,10 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     int BufSizeZ = nzActive;
 
     // Send/recv buffers for ghost node data should be initialized with zeros
-    Buffer2D BufferSouthSend("BufferSouthSend", BufSizeX * BufSizeZ, 5);
-    Buffer2D BufferNorthSend("BufferNorthSend", BufSizeX * BufSizeZ, 5);
-    Buffer2D BufferSouthRecv("BufferSouthRecv", BufSizeX * BufSizeZ, 5);
-    Buffer2D BufferNorthRecv("BufferNorthRecv", BufSizeX * BufSizeZ, 5);
+    Buffer2D BufferSouthSend("BufferSouthSend", BufSizeX * BufSizeZ, 6);
+    Buffer2D BufferNorthSend("BufferNorthSend", BufSizeX * BufSizeZ, 6);
+    Buffer2D BufferSouthRecv("BufferSouthRecv", BufSizeX * BufSizeZ, 6);
+    Buffer2D BufferNorthRecv("BufferNorthRecv", BufSizeX * BufSizeZ, 6);
 
     // Initialize the grain structure and cell types - for either a constrained solidification problem, using a
     // substrate from a file, or generating a substrate using the existing CA algorithm
@@ -328,7 +328,8 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                 FillSteeringVector_Remelt(cycle, LocalActiveDomainSize, nx, MyYSlices, NeighborX, NeighborY, NeighborZ,
                                           CritTimeStep, UndercoolingCurrent, UndercoolingChange, CellType, GrainID,
                                           ZBound_Low, nzActive, SteeringVector, numSteer, numSteer_Host, MeltTimeStep,
-                                          BufSizeX, AtNorthBoundary, AtSouthBoundary, BufferNorthSend, BufferSouthSend);
+                                          BufSizeX, AtNorthBoundary, AtSouthBoundary, BufferNorthSend, BufferSouthSend,
+                                          NGrainOrientations);
             else
                 FillSteeringVector_NoRemelt(cycle, LocalActiveDomainSize, nx, MyYSlices, CritTimeStep,
                                             UndercoolingCurrent, UndercoolingChange, CellType, ZBound_Low, layernumber,

--- a/unit_test/tstKokkosInitMPI.hpp
+++ b/unit_test/tstKokkosInitMPI.hpp
@@ -382,14 +382,14 @@ void testCellTypeInit_NoRemelt() {
             // Check the south buffer - Data being sent to the "south" (BufferSouthSend) is from active cells at Y = 1
             int D3D1ConvPositionGlobal_South = k * nx * MyYSlices + i * MyYSlices + 1; // Position of cell on grid
             if ((CellType_Host(D3D1ConvPositionGlobal_South) == Active) && (!(AtSouthBoundary))) {
-                EXPECT_FLOAT_EQ(BufferSouthSend_H(GNPosition, 1), i + 0.5);
-                EXPECT_FLOAT_EQ(BufferSouthSend_H(GNPosition, 2), 1 + MyYOffset + 0.5);
-                EXPECT_FLOAT_EQ(BufferSouthSend_H(GNPosition, 3), k + 0.5);
-                EXPECT_FLOAT_EQ(BufferSouthSend_H(GNPosition, 4), 0.01);
                 int MyGrainOrientation = static_cast<int>(BufferSouthSend_H(GNPosition, 0));
-                int MyGrainNumber = static_cast<int>(BufferSouthSend_H(GNPosition, 5));
+                int MyGrainNumber = static_cast<int>(BufferSouthSend_H(GNPosition, 1));
                 int ExpectedGrainID = getGrainID(NGrainOrientations, MyGrainOrientation, MyGrainNumber);
                 EXPECT_EQ(ExpectedGrainID, 1);
+                EXPECT_FLOAT_EQ(BufferSouthSend_H(GNPosition, 2), i + 0.5);
+                EXPECT_FLOAT_EQ(BufferSouthSend_H(GNPosition, 3), 1 + MyYOffset + 0.5);
+                EXPECT_FLOAT_EQ(BufferSouthSend_H(GNPosition, 4), k + 0.5);
+                EXPECT_FLOAT_EQ(BufferSouthSend_H(GNPosition, 5), 0.01);
             }
             else {
                 for (int l = 0; l < 6; l++) {
@@ -399,14 +399,14 @@ void testCellTypeInit_NoRemelt() {
             // Check the north buffer - Data being sent to the "north" (BufferNorthSend) is from active cells at Y = 2
             int D3D1ConvPositionGlobal_North = k * nx * MyYSlices + i * MyYSlices + 2;
             if ((CellType_Host(D3D1ConvPositionGlobal_North) == Active) && (!(AtNorthBoundary))) {
-                EXPECT_FLOAT_EQ(BufferNorthSend_H(GNPosition, 1), i + 0.5);
-                EXPECT_FLOAT_EQ(BufferNorthSend_H(GNPosition, 2), 2 + MyYOffset + 0.5);
-                EXPECT_FLOAT_EQ(BufferNorthSend_H(GNPosition, 3), k + 0.5);
-                EXPECT_FLOAT_EQ(BufferNorthSend_H(GNPosition, 4), 0.01);
                 int MyGrainOrientation = static_cast<int>(BufferNorthSend_H(GNPosition, 0));
-                int MyGrainNumber = static_cast<int>(BufferNorthSend_H(GNPosition, 5));
+                int MyGrainNumber = static_cast<int>(BufferNorthSend_H(GNPosition, 1));
                 int ExpectedGrainID = getGrainID(NGrainOrientations, MyGrainOrientation, MyGrainNumber);
                 EXPECT_EQ(ExpectedGrainID, 1);
+                EXPECT_FLOAT_EQ(BufferNorthSend_H(GNPosition, 2), i + 0.5);
+                EXPECT_FLOAT_EQ(BufferNorthSend_H(GNPosition, 3), 2 + MyYOffset + 0.5);
+                EXPECT_FLOAT_EQ(BufferNorthSend_H(GNPosition, 4), k + 0.5);
+                EXPECT_FLOAT_EQ(BufferNorthSend_H(GNPosition, 5), 0.01);
             }
             else {
                 for (int l = 0; l < 6; l++) {

--- a/unit_test/tstKokkosInitMPI.hpp
+++ b/unit_test/tstKokkosInitMPI.hpp
@@ -76,8 +76,8 @@ void testSubstrateInit_ConstrainedGrowth() {
     int BufSizeZ = nzActive;
 
     // Send/recv buffers for ghost node data should be initialized with zeros
-    Buffer2D BufferSouthSend("BufferSouthSend", BufSizeX * BufSizeZ, 5);
-    Buffer2D BufferNorthSend("BufferNorthSend", BufSizeX * BufSizeZ, 5);
+    Buffer2D BufferSouthSend("BufferSouthSend", BufSizeX * BufSizeZ, 6);
+    Buffer2D BufferNorthSend("BufferNorthSend", BufSizeX * BufSizeZ, 6);
     SubstrateInit_ConstrainedGrowth(id, FractSurfaceSitesActive, MyYSlices, nx, ny, MyYOffset, NeighborX, NeighborY,
                                     NeighborZ, GrainUnitVector, NGrainOrientations, CellType, GrainID, DiagonalLength,
                                     DOCenter, CritDiagonalLength, RNGSeed, np, BufferNorthSend, BufferSouthSend,
@@ -284,7 +284,9 @@ void testCellTypeInit_NoRemelt() {
     ViewI LayerID = Kokkos::create_mirror_view_and_copy(memory_space(), LayerID_Host);
 
     // Initialize an orientation for the grain being tested
-    int NGrainOrientations = 1;
+    // Changed number of orientations to avoid overlap with testFillSteeringVector_Remelt (which used NGrainOrientations
+    // = 1), but leaving the other orientation uninitialized as the grain has an ID of 1
+    int NGrainOrientations = 2;
     ViewF_H GrainUnitVector_Host(Kokkos::ViewAllocateWithoutInitializing("GrainUnitVector_Host"),
                                  9 * NGrainOrientations);
     GrainUnitVector_Host(0) = 0.848294;  // x1
@@ -310,8 +312,8 @@ void testCellTypeInit_NoRemelt() {
     int BufSizeX = nx;
 
     // Send buffers for ghost node data should be initialized with zeros
-    Buffer2D BufferSouthSend("BufferSouthSend", BufSizeX * nzActive, 5);
-    Buffer2D BufferNorthSend("BufferNorthSend", BufSizeX * nzActive, 5);
+    Buffer2D BufferSouthSend("BufferSouthSend", BufSizeX * nzActive, 6);
+    Buffer2D BufferNorthSend("BufferNorthSend", BufSizeX * nzActive, 6);
 
     // Initialize cell types and active cell data structures
     CellTypeInit_NoRemelt(layernumber, id, np, nx, MyYSlices, MyYOffset, ZBound_Low, nz, LocalActiveDomainSize,
@@ -382,28 +384,34 @@ void testCellTypeInit_NoRemelt() {
             // Check the south buffer - Data being sent to the "south" (BufferSouthSend) is from active cells at Y = 1
             int D3D1ConvPositionGlobal_South = k * nx * MyYSlices + i * MyYSlices + 1; // Position of cell on grid
             if ((CellType_Host(D3D1ConvPositionGlobal_South) == Active) && (!(AtSouthBoundary))) {
-                EXPECT_FLOAT_EQ(BufferSouthSend_H(GNPosition, 0), 1);
                 EXPECT_FLOAT_EQ(BufferSouthSend_H(GNPosition, 1), i + 0.5);
                 EXPECT_FLOAT_EQ(BufferSouthSend_H(GNPosition, 2), 1 + MyYOffset + 0.5);
                 EXPECT_FLOAT_EQ(BufferSouthSend_H(GNPosition, 3), k + 0.5);
                 EXPECT_FLOAT_EQ(BufferSouthSend_H(GNPosition, 4), 0.01);
+                int MyGrainOrientation = static_cast<int>(BufferSouthSend_H(GNPosition, 0));
+                int MyGrainNumber = static_cast<int>(BufferSouthSend_H(GNPosition, 5));
+                int ExpectedGrainID = getGrainID(NGrainOrientations, MyGrainOrientation, MyGrainNumber);
+                EXPECT_EQ(ExpectedGrainID, 1);
             }
             else {
-                for (int l = 0; l < 5; l++) {
+                for (int l = 0; l < 6; l++) {
                     EXPECT_FLOAT_EQ(BufferSouthSend_H(GNPosition, l), 0.0);
                 }
             }
             // Check the north buffer - Data being sent to the "north" (BufferNorthSend) is from active cells at Y = 2
             int D3D1ConvPositionGlobal_North = k * nx * MyYSlices + i * MyYSlices + 2;
             if ((CellType_Host(D3D1ConvPositionGlobal_North) == Active) && (!(AtNorthBoundary))) {
-                EXPECT_FLOAT_EQ(BufferNorthSend_H(GNPosition, 0), 1);
                 EXPECT_FLOAT_EQ(BufferNorthSend_H(GNPosition, 1), i + 0.5);
                 EXPECT_FLOAT_EQ(BufferNorthSend_H(GNPosition, 2), 2 + MyYOffset + 0.5);
                 EXPECT_FLOAT_EQ(BufferNorthSend_H(GNPosition, 3), k + 0.5);
                 EXPECT_FLOAT_EQ(BufferNorthSend_H(GNPosition, 4), 0.01);
+                int MyGrainOrientation = static_cast<int>(BufferNorthSend_H(GNPosition, 0));
+                int MyGrainNumber = static_cast<int>(BufferNorthSend_H(GNPosition, 5));
+                int ExpectedGrainID = getGrainID(NGrainOrientations, MyGrainOrientation, MyGrainNumber);
+                EXPECT_EQ(ExpectedGrainID, 1);
             }
             else {
-                for (int l = 0; l < 5; l++) {
+                for (int l = 0; l < 6; l++) {
                     EXPECT_FLOAT_EQ(BufferNorthSend_H(GNPosition, l), 0.0);
                 }
             }

--- a/unit_test/tstKokkosInitMPI.hpp
+++ b/unit_test/tstKokkosInitMPI.hpp
@@ -284,9 +284,7 @@ void testCellTypeInit_NoRemelt() {
     ViewI LayerID = Kokkos::create_mirror_view_and_copy(memory_space(), LayerID_Host);
 
     // Initialize an orientation for the grain being tested
-    // Changed number of orientations to avoid overlap with testFillSteeringVector_Remelt (which used NGrainOrientations
-    // = 1), but leaving the other orientation uninitialized as the grain has an ID of 1
-    int NGrainOrientations = 2;
+    int NGrainOrientations = 1;
     ViewF_H GrainUnitVector_Host(Kokkos::ViewAllocateWithoutInitializing("GrainUnitVector_Host"),
                                  9 * NGrainOrientations);
     GrainUnitVector_Host(0) = 0.848294;  // x1

--- a/unit_test/tstKokkosMPI.hpp
+++ b/unit_test/tstKokkosMPI.hpp
@@ -160,10 +160,10 @@ void testGhostNodes1D() {
     int BufSizeZ = nzActive;
 
     // Send/recv buffers for ghost node data should be initialized with zeros
-    Buffer2D BufferSouthSend("BufferSouthSend", BufSizeX * BufSizeZ, 5);
-    Buffer2D BufferNorthSend("BufferNorthSend", BufSizeX * BufSizeZ, 5);
-    Buffer2D BufferSouthRecv("BufferSouthRecv", BufSizeX * BufSizeZ, 5);
-    Buffer2D BufferNorthRecv("BufferNorthRecv", BufSizeX * BufSizeZ, 5);
+    Buffer2D BufferSouthSend("BufferSouthSend", BufSizeX * BufSizeZ, 6);
+    Buffer2D BufferNorthSend("BufferNorthSend", BufSizeX * BufSizeZ, 6);
+    Buffer2D BufferSouthRecv("BufferSouthRecv", BufSizeX * BufSizeZ, 6);
+    Buffer2D BufferNorthRecv("BufferNorthRecv", BufSizeX * BufSizeZ, 6);
 
     // Fill send buffers
     Kokkos::parallel_for(
@@ -176,13 +176,14 @@ void testGhostNodes1D() {
             int GlobalZ = RankZ + ZBound_Low;
             int GlobalD3D1ConvPosition = GlobalZ * MyXSlices * MyYSlices + RankX * MyYSlices + RankY;
             if (CellType(GlobalD3D1ConvPosition) == Active) {
-                double GhostGID = static_cast<double>(GrainID(GlobalD3D1ConvPosition));
-                double GhostDOCX = static_cast<double>(DOCenter(3 * D3D1ConvPosition));
-                double GhostDOCY = static_cast<double>(DOCenter(3 * D3D1ConvPosition + 1));
-                double GhostDOCZ = static_cast<double>(DOCenter(3 * D3D1ConvPosition + 2));
-                double GhostDL = static_cast<double>(DiagonalLength(D3D1ConvPosition));
+                int GhostGID = GrainID(GlobalD3D1ConvPosition);
+                float GhostDOCX = DOCenter(3 * D3D1ConvPosition);
+                float GhostDOCY = DOCenter(3 * D3D1ConvPosition + 1);
+                float GhostDOCZ = DOCenter(3 * D3D1ConvPosition + 2);
+                float GhostDL = DiagonalLength(D3D1ConvPosition);
                 loadghostnodes(GhostGID, GhostDOCX, GhostDOCY, GhostDOCZ, GhostDL, BufSizeX, MyYSlices, RankX, RankY,
-                               RankZ, AtNorthBoundary, AtSouthBoundary, BufferSouthSend, BufferNorthSend);
+                               RankZ, AtNorthBoundary, AtSouthBoundary, BufferSouthSend, BufferNorthSend,
+                               NGrainOrientations);
             }
         });
 


### PR DESCRIPTION
Performance improvement by using `float` instead of `double` for send and receive buffers. Previously, this was not possible as GrainID values with magnitudes larger than 16,777,215 could not be precisely converted to `float` and back to `int` - but by separating the GrainID values sent into 2 components (a " unique orientation" and a "grain repeat number"), these 2 components could be converted to float values, be sent/received, and combined again back into a GrainID. For example, a GrainID of 20,001,123 in a simulation with 10,000 unique grain orientations would have a "unique orientation" of 1,123 and a "grain repeat number" of 2,000 - and while 20,001,123 may not be able to be converted to `float` and back to `int` without issues, 1,123 and 2,000 both can be.