### PR TITLE
Reduce size of send/recv buffers for communication

### DIFF
--- a/src/CAghostnodes.cpp
+++ b/src/CAghostnodes.cpp
@@ -8,8 +8,105 @@
 #include "CAupdate.hpp"
 #include "mpi.h"
 
+#include <algorithm>
 #include <cmath>
 #include <vector>
+
+// Set first index in send buffers to -1 (placeholder) for all cells in the buffer, and reset the counts of number of
+// cells contained in buffers to 0s
+void ResetSendBuffers(int BufSize, Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, ViewI SendSizeNorth,
+                      ViewI SendSizeSouth) {
+
+    Kokkos::parallel_for(
+        "BufferReset", BufSize, KOKKOS_LAMBDA(const int &i) {
+            BufferNorthSend(i, 0) = -1.0;
+            BufferSouthSend(i, 0) = -1.0;
+        });
+    Kokkos::parallel_for(
+        "HaloCountReset", 1, KOKKOS_LAMBDA(const int) {
+            SendSizeNorth(0) = 0;
+            SendSizeSouth(0) = 0;
+        });
+}
+
+// Count the number of cells' in halo regions where the data did not fit into the send buffers, and resize the buffers
+// if necessary, returning the new buffer size
+int ResizeBuffers(Buffer2D &BufferNorthSend, Buffer2D &BufferSouthSend, Buffer2D &BufferNorthRecv,
+                  Buffer2D &BufferSouthRecv, ViewI SendSizeNorth, ViewI SendSizeSouth, ViewI_H SendSizeNorth_Host,
+                  ViewI_H SendSizeSouth_Host, int OldBufSize) {
+
+    int NewBufSize;
+    SendSizeNorth_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), SendSizeNorth);
+    SendSizeSouth_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), SendSizeSouth);
+    int max_count_local = max(SendSizeNorth_Host(0), SendSizeSouth_Host(0));
+    int max_count_global;
+    MPI_Allreduce(&max_count_local, &max_count_global, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+    if (max_count_global > OldBufSize) {
+        // Increase buffer size to fit all data
+        // Either 20 cells or 10% of previous size as additional padding (whichever is larger)
+        int needed_buffer_capacity = max_count_global - OldBufSize;
+        int padded_capacity_percent = round(0.1 * needed_buffer_capacity);
+        int padded_capacity = std::max(20, padded_capacity_percent);
+        NewBufSize = OldBufSize + needed_buffer_capacity + padded_capacity;
+        Kokkos::resize(BufferNorthSend, NewBufSize, 8);
+        Kokkos::resize(BufferSouthSend, NewBufSize, 8);
+        Kokkos::resize(BufferNorthRecv, NewBufSize, 8);
+        Kokkos::resize(BufferSouthRecv, NewBufSize, 8);
+        // Reset count variables on device to the old buffer size
+        Kokkos::parallel_for(
+            "ResetCounts", 1, KOKKOS_LAMBDA(const int &) {
+                SendSizeNorth(0) = OldBufSize;
+                SendSizeSouth(0) = OldBufSize;
+            });
+    }
+    else
+        NewBufSize = OldBufSize;
+    return NewBufSize;
+}
+
+// Refill the buffers as necessary starting from the old count size, using the data from cells marked with type
+// ActiveFailedBufferLoad
+void RefillBuffers(int nx, int nzActive, int MyYSlices, int ZBound_Low, ViewI CellType, Buffer2D BufferNorthSend,
+                   Buffer2D BufferSouthSend, ViewI SendSizeNorth, ViewI SendSizeSouth, bool AtNorthBoundary,
+                   bool AtSouthBoundary, ViewI GrainID, ViewF DOCenter, ViewF DiagonalLength, int NGrainOrientations) {
+
+    Kokkos::parallel_for(
+        "FillSendBuffersOverflow", nx, KOKKOS_LAMBDA(const int &i) {
+            for (int k = 0; k < nzActive; k++) {
+                int GlobalCellCoordinateSouth = (k + ZBound_Low) * nx * MyYSlices + i * MyYSlices + 1;
+                int GlobalCellCoordinateNorth = (k + ZBound_Low) * nx * MyYSlices + i * MyYSlices + MyYSlices - 2;
+                if (CellType(GlobalCellCoordinateSouth) == ActiveFailedBufferLoad) {
+                    int ActiveLayerCoordinateSouth = k * nx * MyYSlices + i * MyYSlices + 1;
+                    int GhostGID = GrainID(GlobalCellCoordinateSouth);
+                    float GhostDOCX = DOCenter(3 * ActiveLayerCoordinateSouth);
+                    float GhostDOCY = DOCenter(3 * ActiveLayerCoordinateSouth + 1);
+                    float GhostDOCZ = DOCenter(3 * ActiveLayerCoordinateSouth + 2);
+                    float GhostDL = DiagonalLength(ActiveLayerCoordinateSouth);
+                    // Collect data for the ghost nodes, if necessary
+                    // Data loaded into the ghost nodes is for the cell that was just captured
+                    loadghostnodes(GhostGID, GhostDOCX, GhostDOCY, GhostDOCZ, GhostDL, SendSizeNorth, SendSizeSouth,
+                                   MyYSlices, i, 1, k, AtNorthBoundary, AtSouthBoundary, BufferSouthSend,
+                                   BufferNorthSend, NGrainOrientations);
+                    CellType(GlobalCellCoordinateSouth) = Active;
+                }
+                if (CellType(GlobalCellCoordinateNorth) == ActiveFailedBufferLoad) {
+                    int ActiveLayerCoordinateNorth = k * nx * MyYSlices + i * MyYSlices + MyYSlices - 2;
+                    int GhostGID = GrainID(GlobalCellCoordinateNorth);
+                    float GhostDOCX = DOCenter(3 * ActiveLayerCoordinateNorth);
+                    float GhostDOCY = DOCenter(3 * ActiveLayerCoordinateNorth + 1);
+                    float GhostDOCZ = DOCenter(3 * ActiveLayerCoordinateNorth + 2);
+                    float GhostDL = DiagonalLength(ActiveLayerCoordinateNorth);
+                    // Collect data for the ghost nodes, if necessary
+                    // Data loaded into the ghost nodes is for the cell that was just captured
+                    loadghostnodes(GhostGID, GhostDOCX, GhostDOCY, GhostDOCZ, GhostDL, SendSizeNorth, SendSizeSouth,
+                                   MyYSlices, i, MyYSlices - 2, k, AtNorthBoundary, AtSouthBoundary, BufferSouthSend,
+                                   BufferNorthSend, NGrainOrientations);
+                    CellType(GlobalCellCoordinateNorth) = Active;
+                }
+            }
+        });
+    Kokkos::fence();
+}
 
 //*****************************************************************************/
 // 1D domain decomposition: update ghost nodes with new cell data from Nucleation and CellCapture routines
@@ -17,22 +114,18 @@ void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int 
                   NList NeighborX, NList NeighborY, NList NeighborZ, ViewI CellType, ViewF DOCenter, ViewI GrainID,
                   ViewF GrainUnitVector, ViewF DiagonalLength, ViewF CritDiagonalLength, int NGrainOrientations,
                   Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, Buffer2D BufferNorthRecv,
-                  Buffer2D BufferSouthRecv, int BufSizeX, int BufSizeZ, int ZBound_Low) {
+                  Buffer2D BufferSouthRecv, int BufSize, int ZBound_Low, ViewI SendSizeNorth, ViewI SendSizeSouth) {
 
     std::vector<MPI_Request> SendRequests(2, MPI_REQUEST_NULL);
     std::vector<MPI_Request> RecvRequests(2, MPI_REQUEST_NULL);
 
     // Send data to each other rank (MPI_Isend)
-    MPI_Isend(BufferSouthSend.data(), 6 * BufSizeX * BufSizeZ, MPI_FLOAT, NeighborRank_South, 0, MPI_COMM_WORLD,
-              &SendRequests[0]);
-    MPI_Isend(BufferNorthSend.data(), 6 * BufSizeX * BufSizeZ, MPI_FLOAT, NeighborRank_North, 0, MPI_COMM_WORLD,
-              &SendRequests[1]);
+    MPI_Isend(BufferSouthSend.data(), 8 * BufSize, MPI_FLOAT, NeighborRank_South, 0, MPI_COMM_WORLD, &SendRequests[0]);
+    MPI_Isend(BufferNorthSend.data(), 8 * BufSize, MPI_FLOAT, NeighborRank_North, 0, MPI_COMM_WORLD, &SendRequests[1]);
 
     // Receive buffers for all neighbors (MPI_Irecv)
-    MPI_Irecv(BufferSouthRecv.data(), 6 * BufSizeX * BufSizeZ, MPI_FLOAT, NeighborRank_South, 0, MPI_COMM_WORLD,
-              &RecvRequests[0]);
-    MPI_Irecv(BufferNorthRecv.data(), 6 * BufSizeX * BufSizeZ, MPI_FLOAT, NeighborRank_North, 0, MPI_COMM_WORLD,
-              &RecvRequests[1]);
+    MPI_Irecv(BufferSouthRecv.data(), 8 * BufSize, MPI_FLOAT, NeighborRank_South, 0, MPI_COMM_WORLD, &RecvRequests[0]);
+    MPI_Irecv(BufferNorthRecv.data(), 8 * BufSize, MPI_FLOAT, NeighborRank_North, 0, MPI_COMM_WORLD, &RecvRequests[1]);
 
     // unpack in any order
     bool unpack_complete = false;
@@ -46,57 +139,60 @@ void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int 
         }
         // Otherwise unpack the next buffer.
         else {
-            int RecvBufSize = BufSizeX * BufSizeZ;
             Kokkos::parallel_for(
-                "BufferUnpack", RecvBufSize, KOKKOS_LAMBDA(const int &BufPosition) {
+                "BufferUnpack", BufSize, KOKKOS_LAMBDA(const int &BufPosition) {
                     int RankX, RankY, RankZ, NewGrainID;
                     long int CellLocation;
-                    double DOCenterX, DOCenterY, DOCenterZ, NewDiagonalLength;
+                    float DOCenterX, DOCenterY, DOCenterZ, NewDiagonalLength;
                     bool Place = false;
-                    RankZ = BufPosition / BufSizeX;
-                    RankX = BufPosition % BufSizeX;
-                    // Which rank was the data received from?
-                    if ((unpack_index == 0) && (NeighborRank_South != MPI_PROC_NULL)) {
+                    // Which rank was the data received from? Is there valid data at this position in the buffer (i.e.,
+                    // not set to -1.0)?
+                    if ((unpack_index == 0) && (BufferSouthRecv(BufPosition, 0) != -1.0) &&
+                        (NeighborRank_South != MPI_PROC_NULL)) {
                         // Data receieved from South
+                        RankX = static_cast<int>(BufferSouthRecv(BufPosition, 0));
                         RankY = 0;
+                        RankZ = static_cast<int>(BufferSouthRecv(BufPosition, 1));
                         CellLocation = RankZ * nx * MyYSlices + MyYSlices * RankX + RankY;
                         int GlobalCellLocation = CellLocation + ZBound_Low * nx * MyYSlices;
-                        if ((BufferSouthRecv(BufPosition, 5) > 0) && (CellType(GlobalCellLocation) == Liquid)) {
+                        if (CellType(GlobalCellLocation) == Liquid) {
                             Place = true;
-                            int MyGrainOrientation = static_cast<int>(BufferSouthRecv(BufPosition, 0));
-                            int MyGrainNumber = static_cast<int>(BufferSouthRecv(BufPosition, 1));
+                            int MyGrainOrientation = static_cast<int>(BufferSouthRecv(BufPosition, 2));
+                            int MyGrainNumber = static_cast<int>(BufferSouthRecv(BufPosition, 3));
                             NewGrainID = getGrainID(NGrainOrientations, MyGrainOrientation, MyGrainNumber);
-                            DOCenterX = BufferSouthRecv(BufPosition, 2);
-                            DOCenterY = BufferSouthRecv(BufPosition, 3);
-                            DOCenterZ = BufferSouthRecv(BufPosition, 4);
-                            NewDiagonalLength = BufferSouthRecv(BufPosition, 5);
+                            DOCenterX = BufferSouthRecv(BufPosition, 4);
+                            DOCenterY = BufferSouthRecv(BufPosition, 5);
+                            DOCenterZ = BufferSouthRecv(BufPosition, 6);
+                            NewDiagonalLength = BufferSouthRecv(BufPosition, 7);
                         }
                     }
-                    else if ((unpack_index == 1) && (NeighborRank_North != MPI_PROC_NULL)) {
+                    else if ((unpack_index == 1) && (BufferNorthRecv(BufPosition, 0) != -1.0) &&
+                             (NeighborRank_North != MPI_PROC_NULL)) {
                         // Data received from North
+                        RankX = static_cast<int>(BufferNorthRecv(BufPosition, 0));
                         RankY = MyYSlices - 1;
+                        RankZ = static_cast<int>(BufferNorthRecv(BufPosition, 1));
                         CellLocation = RankZ * nx * MyYSlices + MyYSlices * RankX + RankY;
                         int GlobalCellLocation = CellLocation + ZBound_Low * nx * MyYSlices;
-                        if ((BufferNorthRecv(BufPosition, 5) > 0) && (CellType(GlobalCellLocation) == Liquid)) {
+                        if (CellType(GlobalCellLocation) == Liquid) {
                             Place = true;
-                            int MyGrainOrientation = static_cast<int>(BufferNorthRecv(BufPosition, 0));
-                            int MyGrainNumber = static_cast<int>(BufferNorthRecv(BufPosition, 1));
+                            int MyGrainOrientation = static_cast<int>(BufferNorthRecv(BufPosition, 2));
+                            int MyGrainNumber = static_cast<int>(BufferNorthRecv(BufPosition, 3));
                             NewGrainID = getGrainID(NGrainOrientations, MyGrainOrientation, MyGrainNumber);
-                            DOCenterX = BufferNorthRecv(BufPosition, 2);
-                            DOCenterY = BufferNorthRecv(BufPosition, 3);
-                            DOCenterZ = BufferNorthRecv(BufPosition, 4);
-                            NewDiagonalLength = BufferNorthRecv(BufPosition, 5);
+                            DOCenterX = BufferNorthRecv(BufPosition, 4);
+                            DOCenterY = BufferNorthRecv(BufPosition, 5);
+                            DOCenterZ = BufferNorthRecv(BufPosition, 6);
+                            NewDiagonalLength = BufferNorthRecv(BufPosition, 7);
                         }
                     }
                     if (Place) {
                         int GlobalZ = RankZ + ZBound_Low;
                         int GlobalCellLocation = GlobalZ * nx * MyYSlices + RankX * MyYSlices + RankY;
-
                         // Update this ghost node cell's information with data from other rank
                         GrainID(GlobalCellLocation) = NewGrainID;
-                        DOCenter((long int)(3) * CellLocation) = static_cast<float>(DOCenterX);
-                        DOCenter((long int)(3) * CellLocation + (long int)(1)) = static_cast<float>(DOCenterY);
-                        DOCenter((long int)(3) * CellLocation + (long int)(2)) = static_cast<float>(DOCenterZ);
+                        DOCenter((long int)(3) * CellLocation) = DOCenterX;
+                        DOCenter((long int)(3) * CellLocation + (long int)(1)) = DOCenterY;
+                        DOCenter((long int)(3) * CellLocation + (long int)(2)) = DOCenterZ;
                         int MyOrientation = getGrainOrientation(GrainID(GlobalCellLocation), NGrainOrientations);
                         DiagonalLength(CellLocation) = static_cast<float>(NewDiagonalLength);
                         // Global coordinates of cell center
@@ -114,6 +210,8 @@ void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int 
         }
     }
 
+    // Reset send buffer data to -1 (used as placeholder) and reset the number of cells stored in the buffers to 0
+    ResetSendBuffers(BufSize, BufferNorthSend, BufferSouthSend, SendSizeNorth, SendSizeSouth);
     // Wait on send requests
     MPI_Waitall(2, SendRequests.data(), MPI_STATUSES_IGNORE);
     Kokkos::fence();

--- a/src/CAghostnodes.hpp
+++ b/src/CAghostnodes.hpp
@@ -12,40 +12,6 @@
 #include <Kokkos_Core.hpp>
 
 // Load data (GrainID, DOCenter, DiagonalLength) into ghost nodes if the given RankY is associated with a 1D halo region
-// Does not check for buffer overflow (buffer resize was already executed to fit data)
-KOKKOS_INLINE_FUNCTION void loadghostnodes(const int GhostGID, const float GhostDOCX, const float GhostDOCY,
-                                           const float GhostDOCZ, const float GhostDL, ViewI SendSizeNorth,
-                                           ViewI SendSizeSouth, const int MyYSlices, const int RankX, const int RankY,
-                                           const int RankZ, const bool AtNorthBoundary, const bool AtSouthBoundary,
-                                           Buffer2D BufferSouthSend, Buffer2D BufferNorthSend, int NGrainOrientations) {
-
-    if ((RankY == 1) && (!(AtSouthBoundary))) {
-        int GNPositionSouth = Kokkos::atomic_fetch_add(&SendSizeSouth(0), 1);
-        BufferSouthSend(GNPositionSouth, 0) = static_cast<float>(RankX);
-        BufferSouthSend(GNPositionSouth, 1) = static_cast<float>(RankZ);
-        BufferSouthSend(GNPositionSouth, 2) =
-            static_cast<float>(getGrainOrientation(GhostGID, NGrainOrientations, false));
-        BufferSouthSend(GNPositionSouth, 3) = static_cast<float>(getGrainNumber(GhostGID, NGrainOrientations));
-        BufferSouthSend(GNPositionSouth, 4) = GhostDOCX;
-        BufferSouthSend(GNPositionSouth, 5) = GhostDOCY;
-        BufferSouthSend(GNPositionSouth, 6) = GhostDOCZ;
-        BufferSouthSend(GNPositionSouth, 7) = GhostDL;
-    }
-    else if ((RankY == MyYSlices - 2) && (!(AtNorthBoundary))) {
-        int GNPositionNorth = Kokkos::atomic_fetch_add(&SendSizeNorth(0), 1);
-        BufferNorthSend(GNPositionNorth, 0) = static_cast<float>(RankX);
-        BufferNorthSend(GNPositionNorth, 1) = static_cast<float>(RankZ);
-        BufferNorthSend(GNPositionNorth, 2) =
-            static_cast<float>(getGrainOrientation(GhostGID, NGrainOrientations, false));
-        BufferNorthSend(GNPositionNorth, 3) = static_cast<float>(getGrainNumber(GhostGID, NGrainOrientations));
-        BufferNorthSend(GNPositionNorth, 4) = GhostDOCX;
-        BufferNorthSend(GNPositionNorth, 5) = GhostDOCY;
-        BufferNorthSend(GNPositionNorth, 6) = GhostDOCZ;
-        BufferNorthSend(GNPositionNorth, 7) = GhostDL;
-    }
-}
-
-// Load data (GrainID, DOCenter, DiagonalLength) into ghost nodes if the given RankY is associated with a 1D halo region
 // Uses check to ensure that the buffer position does not reach the buffer size - if it does, return false (otherwise
 // return true) but keep incrementing the send size counters for use resizing the buffers in the future
 KOKKOS_INLINE_FUNCTION bool loadghostnodes(const int GhostGID, const float GhostDOCX, const float GhostDOCY,
@@ -93,10 +59,11 @@ void ResetSendBuffers(int BufSize, Buffer2D BufferNorthSend, Buffer2D BufferSout
                       ViewI SendSizeSouth);
 int ResizeBuffers(Buffer2D &BufferNorthSend, Buffer2D &BufferSouthSend, Buffer2D &BufferNorthRecv,
                   Buffer2D &BufferSouthRecv, ViewI SendSizeNorth, ViewI SendSizeSouth, ViewI_H SendSizeNorth_Host,
-                  ViewI_H SendSizeSouth_Host, int OldBufSize);
+                  ViewI_H SendSizeSouth_Host, int OldBufSize, int MaxBufSize);
 void RefillBuffers(int nx, int nzActive, int MyYSlices, int ZBound_Low, ViewI CellType, Buffer2D BufferNorthSend,
                    Buffer2D BufferSouthSend, ViewI SendSizeNorth, ViewI SendSizeSouth, bool AtNorthBoundary,
-                   bool AtSouthBoundary, ViewI GrainID, ViewF DOCenter, ViewF DiagonalLength, int NGrainOrientations);
+                   bool AtSouthBoundary, ViewI GrainID, ViewF DOCenter, ViewF DiagonalLength, int NGrainOrientations,
+                   int BufSize);
 void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int nx, int MyYSlices, int MyYOffset,
                   NList NeighborX, NList NeighborY, NList NeighborZ, ViewI CellType, ViewF DOCenter, ViewI GrainID,
                   ViewF GrainUnitVector, ViewF DiagonalLength, ViewF CritDiagonalLength, int NGrainOrientations,

--- a/src/CAghostnodes.hpp
+++ b/src/CAghostnodes.hpp
@@ -59,9 +59,9 @@ void ResetSendBuffers(int BufSize, Buffer2D BufferNorthSend, Buffer2D BufferSout
                       ViewI SendSizeSouth);
 int ResizeBuffers(Buffer2D &BufferNorthSend, Buffer2D &BufferSouthSend, Buffer2D &BufferNorthRecv,
                   Buffer2D &BufferSouthRecv, ViewI SendSizeNorth, ViewI SendSizeSouth, ViewI_H SendSizeNorth_Host,
-                  ViewI_H SendSizeSouth_Host, int OldBufSize, int MaxBufSize, int numcells_buffer_padding = 25);
-int ResetBufferCapacity(Buffer2D &BufferNorthSend, Buffer2D &BufferSouthSend, Buffer2D &BufferNorthRecv,
-                        Buffer2D &BufferSouthRecv, int NewBufSize = 25);
+                  ViewI_H SendSizeSouth_Host, int OldBufSize, int NumCellsBufferPadding = 25);
+void ResetBufferCapacity(Buffer2D &BufferNorthSend, Buffer2D &BufferSouthSend, Buffer2D &BufferNorthRecv,
+                         Buffer2D &BufferSouthRecv, int NewBufSize);
 void RefillBuffers(int nx, int nzActive, int MyYSlices, int ZBound_Low, ViewI CellType, Buffer2D BufferNorthSend,
                    Buffer2D BufferSouthSend, ViewI SendSizeNorth, ViewI SendSizeSouth, bool AtNorthBoundary,
                    bool AtSouthBoundary, ViewI GrainID, ViewF DOCenter, ViewF DiagonalLength, int NGrainOrientations,

--- a/src/CAghostnodes.hpp
+++ b/src/CAghostnodes.hpp
@@ -59,7 +59,9 @@ void ResetSendBuffers(int BufSize, Buffer2D BufferNorthSend, Buffer2D BufferSout
                       ViewI SendSizeSouth);
 int ResizeBuffers(Buffer2D &BufferNorthSend, Buffer2D &BufferSouthSend, Buffer2D &BufferNorthRecv,
                   Buffer2D &BufferSouthRecv, ViewI SendSizeNorth, ViewI SendSizeSouth, ViewI_H SendSizeNorth_Host,
-                  ViewI_H SendSizeSouth_Host, int OldBufSize, int MaxBufSize);
+                  ViewI_H SendSizeSouth_Host, int OldBufSize, int MaxBufSize, int numcells_buffer_padding = 25);
+int ResetBufferCapacity(Buffer2D &BufferNorthSend, Buffer2D &BufferSouthSend, Buffer2D &BufferNorthRecv,
+                        Buffer2D &BufferSouthRecv, int NewBufSize = 25);
 void RefillBuffers(int nx, int nzActive, int MyYSlices, int ZBound_Low, ViewI CellType, Buffer2D BufferNorthSend,
                    Buffer2D BufferSouthSend, ViewI SendSizeNorth, ViewI SendSizeSouth, bool AtNorthBoundary,
                    bool AtSouthBoundary, ViewI GrainID, ViewF DOCenter, ViewF DiagonalLength, int NGrainOrientations,

--- a/src/CAghostnodes.hpp
+++ b/src/CAghostnodes.hpp
@@ -12,37 +12,95 @@
 #include <Kokkos_Core.hpp>
 
 // Load data (GrainID, DOCenter, DiagonalLength) into ghost nodes if the given RankY is associated with a 1D halo region
+// Does not check for buffer overflow (buffer resize was already executed to fit data)
 KOKKOS_INLINE_FUNCTION void loadghostnodes(const int GhostGID, const float GhostDOCX, const float GhostDOCY,
-                                           const float GhostDOCZ, const float GhostDL, const int BufSizeX,
-                                           const int MyYSlices, const int RankX, const int RankY, const int RankZ,
-                                           const bool AtNorthBoundary, const bool AtSouthBoundary,
+                                           const float GhostDOCZ, const float GhostDL, ViewI SendSizeNorth,
+                                           ViewI SendSizeSouth, const int MyYSlices, const int RankX, const int RankY,
+                                           const int RankZ, const bool AtNorthBoundary, const bool AtSouthBoundary,
                                            Buffer2D BufferSouthSend, Buffer2D BufferNorthSend, int NGrainOrientations) {
 
     if ((RankY == 1) && (!(AtSouthBoundary))) {
-        int GNPosition = RankZ * BufSizeX + RankX;
-        int MyGrainOrientation = getGrainOrientation(GhostGID, NGrainOrientations, false);
-        BufferSouthSend(GNPosition, 0) = static_cast<float>(MyGrainOrientation);
-        BufferSouthSend(GNPosition, 1) = getGrainNumber(GhostGID, NGrainOrientations);
-        BufferSouthSend(GNPosition, 2) = GhostDOCX;
-        BufferSouthSend(GNPosition, 3) = GhostDOCY;
-        BufferSouthSend(GNPosition, 4) = GhostDOCZ;
-        BufferSouthSend(GNPosition, 5) = GhostDL;
+        int GNPositionSouth = Kokkos::atomic_fetch_add(&SendSizeSouth(0), 1);
+        BufferSouthSend(GNPositionSouth, 0) = static_cast<float>(RankX);
+        BufferSouthSend(GNPositionSouth, 1) = static_cast<float>(RankZ);
+        BufferSouthSend(GNPositionSouth, 2) =
+            static_cast<float>(getGrainOrientation(GhostGID, NGrainOrientations, false));
+        BufferSouthSend(GNPositionSouth, 3) = static_cast<float>(getGrainNumber(GhostGID, NGrainOrientations));
+        BufferSouthSend(GNPositionSouth, 4) = GhostDOCX;
+        BufferSouthSend(GNPositionSouth, 5) = GhostDOCY;
+        BufferSouthSend(GNPositionSouth, 6) = GhostDOCZ;
+        BufferSouthSend(GNPositionSouth, 7) = GhostDL;
     }
     else if ((RankY == MyYSlices - 2) && (!(AtNorthBoundary))) {
-        int GNPosition = RankZ * BufSizeX + RankX;
-        int MyGrainOrientation = getGrainOrientation(GhostGID, NGrainOrientations, false);
-        BufferNorthSend(GNPosition, 0) = static_cast<float>(MyGrainOrientation);
-        BufferNorthSend(GNPosition, 1) = getGrainNumber(GhostGID, NGrainOrientations);
-        BufferNorthSend(GNPosition, 2) = GhostDOCX;
-        BufferNorthSend(GNPosition, 3) = GhostDOCY;
-        BufferNorthSend(GNPosition, 4) = GhostDOCZ;
-        BufferNorthSend(GNPosition, 5) = GhostDL;
+        int GNPositionNorth = Kokkos::atomic_fetch_add(&SendSizeNorth(0), 1);
+        BufferNorthSend(GNPositionNorth, 0) = static_cast<float>(RankX);
+        BufferNorthSend(GNPositionNorth, 1) = static_cast<float>(RankZ);
+        BufferNorthSend(GNPositionNorth, 2) =
+            static_cast<float>(getGrainOrientation(GhostGID, NGrainOrientations, false));
+        BufferNorthSend(GNPositionNorth, 3) = static_cast<float>(getGrainNumber(GhostGID, NGrainOrientations));
+        BufferNorthSend(GNPositionNorth, 4) = GhostDOCX;
+        BufferNorthSend(GNPositionNorth, 5) = GhostDOCY;
+        BufferNorthSend(GNPositionNorth, 6) = GhostDOCZ;
+        BufferNorthSend(GNPositionNorth, 7) = GhostDL;
     }
 }
+
+// Load data (GrainID, DOCenter, DiagonalLength) into ghost nodes if the given RankY is associated with a 1D halo region
+// Uses check to ensure that the buffer position does not reach the buffer size - if it does, return false (otherwise
+// return true) but keep incrementing the send size counters for use resizing the buffers in the future
+KOKKOS_INLINE_FUNCTION bool loadghostnodes(const int GhostGID, const float GhostDOCX, const float GhostDOCY,
+                                           const float GhostDOCZ, const float GhostDL, ViewI SendSizeNorth,
+                                           ViewI SendSizeSouth, const int MyYSlices, const int RankX, const int RankY,
+                                           const int RankZ, const bool AtNorthBoundary, const bool AtSouthBoundary,
+                                           Buffer2D BufferSouthSend, Buffer2D BufferNorthSend, int NGrainOrientations,
+                                           int BufSize) {
+    bool DataFitsInBuffer = true;
+    if ((RankY == 1) && (!(AtSouthBoundary))) {
+        int GNPositionSouth = Kokkos::atomic_fetch_add(&SendSizeSouth(0), 1);
+        if (GNPositionSouth >= BufSize)
+            DataFitsInBuffer = false;
+        else {
+            BufferSouthSend(GNPositionSouth, 0) = static_cast<float>(RankX);
+            BufferSouthSend(GNPositionSouth, 1) = static_cast<float>(RankZ);
+            BufferSouthSend(GNPositionSouth, 2) =
+                static_cast<float>(getGrainOrientation(GhostGID, NGrainOrientations, false));
+            BufferSouthSend(GNPositionSouth, 3) = static_cast<float>(getGrainNumber(GhostGID, NGrainOrientations));
+            BufferSouthSend(GNPositionSouth, 4) = GhostDOCX;
+            BufferSouthSend(GNPositionSouth, 5) = GhostDOCY;
+            BufferSouthSend(GNPositionSouth, 6) = GhostDOCZ;
+            BufferSouthSend(GNPositionSouth, 7) = GhostDL;
+        }
+    }
+    else if ((RankY == MyYSlices - 2) && (!(AtNorthBoundary))) {
+        int GNPositionNorth = Kokkos::atomic_fetch_add(&SendSizeNorth(0), 1);
+        if (GNPositionNorth >= BufSize)
+            DataFitsInBuffer = false;
+        else {
+            BufferNorthSend(GNPositionNorth, 0) = static_cast<float>(RankX);
+            BufferNorthSend(GNPositionNorth, 1) = static_cast<float>(RankZ);
+            BufferNorthSend(GNPositionNorth, 2) =
+                static_cast<float>(getGrainOrientation(GhostGID, NGrainOrientations, false));
+            BufferNorthSend(GNPositionNorth, 3) = static_cast<float>(getGrainNumber(GhostGID, NGrainOrientations));
+            BufferNorthSend(GNPositionNorth, 4) = GhostDOCX;
+            BufferNorthSend(GNPositionNorth, 5) = GhostDOCY;
+            BufferNorthSend(GNPositionNorth, 6) = GhostDOCZ;
+            BufferNorthSend(GNPositionNorth, 7) = GhostDL;
+        }
+    }
+    return DataFitsInBuffer;
+}
+void ResetSendBuffers(int BufSize, Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, ViewI SendSizeNorth,
+                      ViewI SendSizeSouth);
+int ResizeBuffers(Buffer2D &BufferNorthSend, Buffer2D &BufferSouthSend, Buffer2D &BufferNorthRecv,
+                  Buffer2D &BufferSouthRecv, ViewI SendSizeNorth, ViewI SendSizeSouth, ViewI_H SendSizeNorth_Host,
+                  ViewI_H SendSizeSouth_Host, int OldBufSize);
+void RefillBuffers(int nx, int nzActive, int MyYSlices, int ZBound_Low, ViewI CellType, Buffer2D BufferNorthSend,
+                   Buffer2D BufferSouthSend, ViewI SendSizeNorth, ViewI SendSizeSouth, bool AtNorthBoundary,
+                   bool AtSouthBoundary, ViewI GrainID, ViewF DOCenter, ViewF DiagonalLength, int NGrainOrientations);
 void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int nx, int MyYSlices, int MyYOffset,
                   NList NeighborX, NList NeighborY, NList NeighborZ, ViewI CellType, ViewF DOCenter, ViewI GrainID,
                   ViewF GrainUnitVector, ViewF DiagonalLength, ViewF CritDiagonalLength, int NGrainOrientations,
                   Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, Buffer2D BufferNorthRecv,
-                  Buffer2D BufferSouthRecv, int BufSizeX, int BufSizeZ, int ZBound_Low);
+                  Buffer2D BufferSouthRecv, int BufSize, int ZBound_Low, ViewI SendSizeNorth, ViewI SendSizeSouth);
 
 #endif

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -109,8 +109,8 @@ void SubstrateInit_ConstrainedGrowth(int id, double FractSurfaceSitesActive, int
                                      int MyYOffset, NList NeighborX, NList NeighborY, NList NeighborZ,
                                      ViewF GrainUnitVector, int NGrainOrientations, ViewI CellType, ViewI GrainID,
                                      ViewF DiagonalLength, ViewF DOCenter, ViewF CritDiagonalLength, double RNGSeed,
-                                     int np, Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, int BufSizeX,
-                                     bool AtNorthBoundary, bool AtSouthBoundary);
+                                     int np, Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, ViewI SendSizeNorth,
+                                     ViewI SendSizeSouth, bool AtNorthBoundary, bool AtSouthBoundary, int BufSize);
 void SubstrateInit_FromFile(std::string SubstrateFileName, int nz, int nx, int MyYSlices, int MyYOffset, int pid,
                             ViewI &GrainID, int nzActive, bool BaseplateThroughPowder);
 void BaseplateInit_FromGrainSpacing(float SubstrateGrainSpacing, int nx, int ny, double *ZMinLayer, double *ZMaxLayer,
@@ -126,7 +126,8 @@ void CellTypeInit_NoRemelt(int layernumber, int id, int np, int nx, int MyYSlice
                            NList NeighborX, NList NeighborY, NList NeighborZ, int NGrainOrientations,
                            ViewF GrainUnitVector, ViewF DiagonalLength, ViewI GrainID, ViewF CritDiagonalLength,
                            ViewF DOCenter, ViewI LayerID, Buffer2D BufferNorthSend, Buffer2D BufferSouthSend,
-                           int BufSizeX, bool AtNorthBoundary, bool AtSouthBoundary);
+                           bool AtNorthBoundary, bool AtSouthBoundary, ViewI SendSizeNorth, ViewI SendSizeSouth,
+                           int BufSize);
 void NucleiInit(int layernumber, double RNGSeed, int MyYSlices, int MyYOffset, int nx, int ny, int nzActive,
                 int ZBound_Low, int id, double NMax, double dTN, double dTsigma, double deltax, ViewI &NucleiLocation,
                 ViewI_H &NucleationTimes_Host, ViewI &NucleiGrainID, ViewI CellType, ViewI CritTimeStep,
@@ -148,8 +149,7 @@ void placeNucleiData_Remelt(int NucleiMultiplier, int Nuclei_ThisLayerSingle, Vi
                             std::vector<double> NucleiUndercooling_WholeDomain_V,
                             std::vector<int> &NucleiGrainID_MyRank_V, std::vector<int> &NucleiLocation_MyRank_V,
                             std::vector<int> &NucleationTimes_MyRank_V, int &PossibleNuclei_ThisRankThisLayer);
-void ZeroResetViews(int LocalActiveDomainSize, int BufSizeX, int BufSizeZ, ViewF &DiagonalLength,
-                    ViewF &CritDiagonalLength, ViewF &DOCenter, Buffer2D &BufferNorthSend, Buffer2D &BufferSouthSend,
-                    Buffer2D &BufferNorthRecv, Buffer2D &BufferSouthRecv, ViewI &SteeringVector);
+void ZeroResetViews(int LocalActiveDomainSize, ViewF &DiagonalLength, ViewF &CritDiagonalLength, ViewF &DOCenter,
+                    ViewI &SteeringVector);
 
 #endif

--- a/src/CAtypes.hpp
+++ b/src/CAtypes.hpp
@@ -16,7 +16,8 @@ enum TypeNames {
     TemporaryInit = 4,
     Liquid = 5,
     TempSolid = 6,
-    FutureActive = 7
+    FutureActive = 7,
+    ActiveFailedBufferLoad = 8
 };
 
 // Use Kokkos::DefaultExecutionSpace

--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -88,17 +88,16 @@ void FillSteeringVector_NoRemelt(int cycle, int LocalActiveDomainSize, int nx, i
 void FillSteeringVector_Remelt(int cycle, int LocalActiveDomainSize, int nx, int MyYSlices, NList NeighborX,
                                NList NeighborY, NList NeighborZ, ViewI CritTimeStep, ViewF UndercoolingCurrent,
                                ViewF UndercoolingChange, ViewI CellType, ViewI GrainID, int ZBound_Low, int nzActive,
-                               ViewI SteeringVector, ViewI numSteer, ViewI_H numSteer_Host, ViewI MeltTimeStep,
-                               int BufSizeX, bool AtNorthBoundary, bool AtSouthBoundary, Buffer2D BufferNorthSend,
-                               Buffer2D BufferSouthSend, int NGrainOrientations);
+                               ViewI SteeringVector, ViewI numSteer, ViewI_H numSteer_Host, ViewI MeltTimeStep);
 void CellCapture(int id, int np, int cycle, int LocalActiveDomainSize, int LocalDomainSize, int nx, int MyYSlices,
                  InterfacialResponseFunction irf, int MyYOffset, NList NeighborX, NList NeighborY, NList NeighborZ,
                  ViewI CritTimeStep, ViewF UndercoolingCurrent, ViewF UndercoolingChange, ViewF GrainUnitVector,
                  ViewF CritDiagonalLength, ViewF DiagonalLength, ViewI CellType, ViewF DOCenter, ViewI GrainID,
-                 int NGrainOrientations, Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, int BufSizeX,
-                 int ZBound_Low, int nzActive, int nz, ViewI SteeringVector, ViewI numSteer_G, ViewI_H numSteer_H,
-                 bool AtNorthBoundary, bool AtSouthBoundary, ViewI SolidificationEventCounter, ViewI MeltTimeStep,
-                 ViewF3D LayerTimeTempHistory, ViewI NumberOfSolidificationEvents, bool RemeltingYN);
+                 int NGrainOrientations, Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, ViewI SendSizeNorth,
+                 ViewI SendSizeSouth, int ZBound_Low, int nzActive, int nz, ViewI SteeringVector, ViewI numSteer_G,
+                 ViewI_H numSteer_H, bool AtNorthBoundary, bool AtSouthBoundary, ViewI SolidificationEventCounter,
+                 ViewI MeltTimeStep, ViewF3D LayerTimeTempHistory, ViewI NumberOfSolidificationEvents, bool RemeltingYN,
+                 int &BufSize);
 void JumpTimeStep(int &cycle, unsigned long int RemainingCellsOfInterest, ViewI FutureWorkView,
                   unsigned long int LocalIncompleteCells, int LocalActiveDomainSize, int MyYSlices, int ZBound_Low,
                   bool RemeltingYN, ViewI CellType, ViewI LayerID, int id, int layernumber, int np, int nx, int ny,

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -301,6 +301,9 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                      NeighborZ, CellType, DOCenter, GrainID, GrainUnitVector, DiagonalLength, CritDiagonalLength,
                      NGrainOrientations, BufferNorthSend, BufferSouthSend, BufferNorthRecv, BufferSouthRecv, BufSize,
                      ZBound_Low, SendSizeNorth, SendSizeSouth);
+        // If not using remelting, the initial number of active cells to communicate is usually much larger than the
+        // number on any given time step - reset the buffer sizes to the initial value of 25
+        BufSize = ResetBufferCapacity(BufferNorthSend, BufferSouthSend, BufferNorthRecv, BufferSouthRecv, BufSize);
     }
 
     // If specified, print initial values in some views for debugging purposes
@@ -522,6 +525,9 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                              NeighborY, NeighborZ, CellType, DOCenter, GrainID, GrainUnitVector, DiagonalLength,
                              CritDiagonalLength, NGrainOrientations, BufferNorthSend, BufferSouthSend, BufferNorthRecv,
                              BufferSouthRecv, BufSize, ZBound_Low, SendSizeNorth, SendSizeSouth);
+                // If not using remelting, the initial number of active cells to communicate is usually much larger than
+                // the number on any given time step - reset the buffer sizes to the initial value of 25
+                ResetBufferCapacity(BufferNorthSend, BufferSouthSend, BufferNorthRecv, BufferSouthRecv);
             }
             if (id == 0)
                 std::cout << "New layer ghost nodes initialized" << std::endl;

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -197,23 +197,41 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     ViewF CritDiagonalLength(Kokkos::ViewAllocateWithoutInitializing("CritDiagonalLength"), 26 * LocalActiveDomainSize);
 
     // Buffers for ghost node data (fixed size)
-    int BufSizeX = nx;
-    int BufSizeZ = nzActive;
-
-    // Send/recv buffers for ghost node data should be initialized with zeros
-    Buffer2D BufferSouthSend("BufferSouthSend", BufSizeX * BufSizeZ, 6);
-    Buffer2D BufferNorthSend("BufferNorthSend", BufSizeX * BufSizeZ, 6);
-    Buffer2D BufferSouthRecv("BufferSouthRecv", BufSizeX * BufSizeZ, 6);
-    Buffer2D BufferNorthRecv("BufferNorthRecv", BufSizeX * BufSizeZ, 6);
+    int BufSize = 25; // initial estimate
+    Buffer2D BufferSouthSend(Kokkos::ViewAllocateWithoutInitializing("BufferSouthSend"), BufSize, 8);
+    Buffer2D BufferNorthSend(Kokkos::ViewAllocateWithoutInitializing("BufferNorthSend"), BufSize, 8);
+    Buffer2D BufferSouthRecv(Kokkos::ViewAllocateWithoutInitializing("BufferSouthRecv"), BufSize, 8);
+    Buffer2D BufferNorthRecv(Kokkos::ViewAllocateWithoutInitializing("BufferNorthRecv"), BufSize, 8);
+    ViewI SendSizeSouth(Kokkos::ViewAllocateWithoutInitializing("SendSizeSouth"), 1);
+    ViewI SendSizeNorth(Kokkos::ViewAllocateWithoutInitializing("SendSizeNorth"), 1);
+    ViewI_H SendSizeSouth_Host(Kokkos::ViewAllocateWithoutInitializing("SendSizeSouth_Host"), 1);
+    ViewI_H SendSizeNorth_Host(Kokkos::ViewAllocateWithoutInitializing("SendSizeNorth_Host"), 1);
+    // Send/recv buffers for ghost node data should be initialized with -1s in the first index as placeholders for empty
+    // positions in the buffer, and with send size counts of 0
+    ResetSendBuffers(BufSize, BufferNorthSend, BufferSouthSend, SendSizeNorth, SendSizeSouth);
 
     // Initialize the grain structure and cell types - for either a constrained solidification problem, using a
     // substrate from a file, or generating a substrate using the existing CA algorithm
     int NextLayer_FirstEpitaxialGrainID;
     if (SimulationType == "C") {
-        SubstrateInit_ConstrainedGrowth(id, FractSurfaceSitesActive, MyYSlices, nx, ny, MyYOffset, NeighborX, NeighborY,
-                                        NeighborZ, GrainUnitVector, NGrainOrientations, CellType, GrainID,
-                                        DiagonalLength, DOCenter, CritDiagonalLength, RNGSeed, np, BufferNorthSend,
-                                        BufferSouthSend, BufSizeX, AtNorthBoundary, AtSouthBoundary);
+        SubstrateInit_ConstrainedGrowth(
+            id, FractSurfaceSitesActive, MyYSlices, nx, ny, MyYOffset, NeighborX, NeighborY, NeighborZ, GrainUnitVector,
+            NGrainOrientations, CellType, GrainID, DiagonalLength, DOCenter, CritDiagonalLength, RNGSeed, np,
+            BufferNorthSend, BufferSouthSend, SendSizeNorth, SendSizeSouth, AtNorthBoundary, AtSouthBoundary, BufSize);
+        // Count the number of cells' in halo regions where the data did not fit into the send buffers
+        // Reduce across all ranks, as the same BufSize should be maintained across all ranks
+        // If any rank overflowed its buffer size, resize all buffers to the new size plus 10% padding
+        int OldBufSize = BufSize;
+        BufSize = ResizeBuffers(BufferNorthSend, BufferSouthSend, BufferNorthRecv, BufferSouthRecv, SendSizeNorth,
+                                SendSizeSouth, SendSizeNorth_Host, SendSizeSouth_Host, OldBufSize);
+        if (OldBufSize != BufSize) {
+            if (id == 0)
+                std::cout << "Resized number of cells stored in send/recv buffers from " << OldBufSize << " to "
+                          << BufSize << std::endl;
+            RefillBuffers(nx, nzActive, MyYSlices, ZBound_Low, CellType, BufferNorthSend, BufferSouthSend,
+                          SendSizeNorth, SendSizeSouth, AtNorthBoundary, AtSouthBoundary, GrainID, DOCenter,
+                          DiagonalLength, NGrainOrientations);
+        }
     }
     else {
         if (UseSubstrateFile)
@@ -230,8 +248,22 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
             CellTypeInit_NoRemelt(0, id, np, nx, MyYSlices, MyYOffset, ZBound_Low, nz, LocalActiveDomainSize,
                                   LocalDomainSize, CellType, CritTimeStep, NeighborX, NeighborY, NeighborZ,
                                   NGrainOrientations, GrainUnitVector, DiagonalLength, GrainID, CritDiagonalLength,
-                                  DOCenter, LayerID, BufferNorthSend, BufferSouthSend, BufSizeX, AtNorthBoundary,
-                                  AtSouthBoundary);
+                                  DOCenter, LayerID, BufferNorthSend, BufferSouthSend, AtNorthBoundary, AtSouthBoundary,
+                                  SendSizeNorth, SendSizeSouth, BufSize);
+            // Count the number of cells' in halo regions where the data did not fit into the send buffers
+            // Reduce across all ranks, as the same BufSize should be maintained across all ranks
+            // If any rank overflowed its buffer size, resize all buffers to the new size plus 10% padding
+            int OldBufSize = BufSize;
+            BufSize = ResizeBuffers(BufferNorthSend, BufferSouthSend, BufferNorthRecv, BufferSouthRecv, SendSizeNorth,
+                                    SendSizeSouth, SendSizeNorth_Host, SendSizeSouth_Host, OldBufSize);
+            if (OldBufSize != BufSize) {
+                if (id == 0)
+                    std::cout << "Resized number of cells stored in send/recv buffers from " << OldBufSize << " to "
+                              << BufSize << std::endl;
+                RefillBuffers(nx, nzActive, MyYSlices, ZBound_Low, CellType, BufferNorthSend, BufferSouthSend,
+                              SendSizeNorth, SendSizeSouth, AtNorthBoundary, AtSouthBoundary, GrainID, DOCenter,
+                              DiagonalLength, NGrainOrientations);
+            }
         }
     }
     MPI_Barrier(MPI_COMM_WORLD);
@@ -266,8 +298,8 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     if ((np > 1) && (!(RemeltingYN))) {
         GhostNodes1D(-1, id, NeighborRank_North, NeighborRank_South, nx, MyYSlices, MyYOffset, NeighborX, NeighborY,
                      NeighborZ, CellType, DOCenter, GrainID, GrainUnitVector, DiagonalLength, CritDiagonalLength,
-                     NGrainOrientations, BufferNorthSend, BufferSouthSend, BufferNorthRecv, BufferSouthRecv, BufSizeX,
-                     BufSizeZ, ZBound_Low);
+                     NGrainOrientations, BufferNorthSend, BufferSouthSend, BufferNorthRecv, BufferSouthRecv, BufSize,
+                     ZBound_Low, SendSizeNorth, SendSizeSouth);
     }
 
     // If specified, print initial values in some views for debugging purposes
@@ -327,23 +359,41 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
             if (RemeltingYN)
                 FillSteeringVector_Remelt(cycle, LocalActiveDomainSize, nx, MyYSlices, NeighborX, NeighborY, NeighborZ,
                                           CritTimeStep, UndercoolingCurrent, UndercoolingChange, CellType, GrainID,
-                                          ZBound_Low, nzActive, SteeringVector, numSteer, numSteer_Host, MeltTimeStep,
-                                          BufSizeX, AtNorthBoundary, AtSouthBoundary, BufferNorthSend, BufferSouthSend,
-                                          NGrainOrientations);
+                                          ZBound_Low, nzActive, SteeringVector, numSteer, numSteer_Host, MeltTimeStep);
             else
                 FillSteeringVector_NoRemelt(cycle, LocalActiveDomainSize, nx, MyYSlices, CritTimeStep,
                                             UndercoolingCurrent, UndercoolingChange, CellType, ZBound_Low, layernumber,
                                             LayerID, SteeringVector, numSteer, numSteer_Host);
             CreateSVTime += MPI_Wtime() - StartCreateSVTime;
-
+            //            if ((cycle > 21885) && (id == 1))
+            //                std::cout << "Cycle " << cycle << " Rank 1 south buffer size is " << SendSizeSouth(0) <<
+            //                std::endl;
             StartCaptureTime = MPI_Wtime();
             CellCapture(id, np, cycle, LocalActiveDomainSize, LocalDomainSize, nx, MyYSlices, irf, MyYOffset, NeighborX,
                         NeighborY, NeighborZ, CritTimeStep, UndercoolingCurrent, UndercoolingChange, GrainUnitVector,
                         CritDiagonalLength, DiagonalLength, CellType, DOCenter, GrainID, NGrainOrientations,
-                        BufferNorthSend, BufferSouthSend, BufSizeX, ZBound_Low, nzActive, nz, SteeringVector, numSteer,
-                        numSteer_Host, AtNorthBoundary, AtSouthBoundary, SolidificationEventCounter, MeltTimeStep,
-                        LayerTimeTempHistory, NumberOfSolidificationEvents, RemeltingYN);
+                        BufferNorthSend, BufferSouthSend, SendSizeNorth, SendSizeSouth, ZBound_Low, nzActive, nz,
+                        SteeringVector, numSteer, numSteer_Host, AtNorthBoundary, AtSouthBoundary,
+                        SolidificationEventCounter, MeltTimeStep, LayerTimeTempHistory, NumberOfSolidificationEvents,
+                        RemeltingYN, BufSize);
+            // Count the number of cells' in halo regions where the data did not fit into the send buffers
+            // Reduce across all ranks, as the same BufSize should be maintained across all ranks
+            // If any rank overflowed its buffer size, resize all buffers to the new size plus 10% padding
+            int OldBufSize = BufSize;
+            BufSize = ResizeBuffers(BufferNorthSend, BufferSouthSend, BufferNorthRecv, BufferSouthRecv, SendSizeNorth,
+                                    SendSizeSouth, SendSizeNorth_Host, SendSizeSouth_Host, OldBufSize);
+            if (OldBufSize != BufSize) {
+                if (id == 0)
+                    std::cout << "Resized number of cells stored in send/recv buffers from " << OldBufSize << " to "
+                              << BufSize << std::endl;
+                RefillBuffers(nx, nzActive, MyYSlices, ZBound_Low, CellType, BufferNorthSend, BufferSouthSend,
+                              SendSizeNorth, SendSizeSouth, AtNorthBoundary, AtSouthBoundary, GrainID, DOCenter,
+                              DiagonalLength, NGrainOrientations);
+            }
             CaptureTime += MPI_Wtime() - StartCaptureTime;
+            //            if ((cycle > 21885) && (id == 1))
+            //                std::cout << "Cycle " << cycle << " Rank 1 south buffer size is " << SendSizeSouth(0) <<
+            //                std::endl;
 
             if (np > 1) {
                 // Update ghost nodes
@@ -351,9 +401,12 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                 GhostNodes1D(cycle, id, NeighborRank_North, NeighborRank_South, nx, MyYSlices, MyYOffset, NeighborX,
                              NeighborY, NeighborZ, CellType, DOCenter, GrainID, GrainUnitVector, DiagonalLength,
                              CritDiagonalLength, NGrainOrientations, BufferNorthSend, BufferSouthSend, BufferNorthRecv,
-                             BufferSouthRecv, BufSizeX, BufSizeZ, ZBound_Low);
+                             BufferSouthRecv, BufSize, ZBound_Low, SendSizeNorth, SendSizeSouth);
                 GhostTime += MPI_Wtime() - StartGhostTime;
             }
+            //            if ((cycle > 21885) && (id == 1))
+            //                std::cout << "Cycle " << cycle << " Rank 1 south buffer size is " << SendSizeSouth(0) <<
+            //                std::endl;
 
             if (cycle % 1000 == 0) {
 
@@ -420,18 +473,10 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                 }
             }
 
-            // Update buffer size
-            BufSizeZ = nzActive;
-
             // Resize and zero all view data relating to the active region from the last layer, in preparation for the
             // next layer
-            ZeroResetViews(LocalActiveDomainSize, BufSizeX, BufSizeZ, DiagonalLength, CritDiagonalLength, DOCenter,
-                           BufferNorthSend, BufferSouthSend, BufferNorthRecv, BufferSouthRecv, SteeringVector);
-
+            ZeroResetViews(LocalActiveDomainSize, DiagonalLength, CritDiagonalLength, DOCenter, SteeringVector);
             MPI_Barrier(MPI_COMM_WORLD);
-            if (id == 0)
-                std::cout << "Resize executed and new layer set up, GN dimensions are " << BufSizeX << " " << BufSizeZ
-                          << std::endl;
 
             // If the baseplate was initialized from a substrate grain spacing, initialize powder layer grain structure
             // for the next layer "layernumber + 1" Otherwise, the entire substrate (baseplate + powder) was read from a
@@ -443,12 +488,28 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
             // Initialize active cell data structures and nuclei locations for the next layer "layernumber + 1"
             if (RemeltingYN)
                 CellTypeInit_Remelt(nx, MyYSlices, LocalActiveDomainSize, CellType, CritTimeStep, id, ZBound_Low);
-            else
+            else {
                 CellTypeInit_NoRemelt(layernumber + 1, id, np, nx, MyYSlices, MyYOffset, ZBound_Low, nz,
                                       LocalActiveDomainSize, LocalDomainSize, CellType, CritTimeStep, NeighborX,
                                       NeighborY, NeighborZ, NGrainOrientations, GrainUnitVector, DiagonalLength,
                                       GrainID, CritDiagonalLength, DOCenter, LayerID, BufferNorthSend, BufferSouthSend,
-                                      BufSizeX, AtNorthBoundary, AtSouthBoundary);
+                                      AtNorthBoundary, AtSouthBoundary, SendSizeNorth, SendSizeSouth, BufSize);
+                // Count the number of cells' in halo regions where the data did not fit into the send buffers
+                // Reduce across all ranks, as the same BufSize should be maintained across all ranks
+                // If any rank overflowed its buffer size, resize all buffers to the new size plus 10% padding
+                int OldBufSize = BufSize;
+                BufSize =
+                    ResizeBuffers(BufferNorthSend, BufferSouthSend, BufferNorthRecv, BufferSouthRecv, SendSizeNorth,
+                                  SendSizeSouth, SendSizeNorth_Host, SendSizeSouth_Host, OldBufSize);
+                if (OldBufSize != BufSize) {
+                    if (id == 0)
+                        std::cout << "Resized number of cells stored in send/recv buffers from " << OldBufSize << " to "
+                                  << BufSize << std::endl;
+                    RefillBuffers(nx, nzActive, MyYSlices, ZBound_Low, CellType, BufferNorthSend, BufferSouthSend,
+                                  SendSizeNorth, SendSizeSouth, AtNorthBoundary, AtSouthBoundary, GrainID, DOCenter,
+                                  DiagonalLength, NGrainOrientations);
+                }
+            }
 
             // Initialize potential nucleation event data for next layer "layernumber + 1"
             // Views containing nucleation data will be resized to the possible number of nuclei on a given MPI rank for
@@ -465,7 +526,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                 GhostNodes1D(-1, id, NeighborRank_North, NeighborRank_South, nx, MyYSlices, MyYOffset, NeighborX,
                              NeighborY, NeighborZ, CellType, DOCenter, GrainID, GrainUnitVector, DiagonalLength,
                              CritDiagonalLength, NGrainOrientations, BufferNorthSend, BufferSouthSend, BufferNorthRecv,
-                             BufferSouthRecv, BufSizeX, BufSizeZ, ZBound_Low);
+                             BufferSouthRecv, BufSize, ZBound_Low, SendSizeNorth, SendSizeSouth);
             }
             if (id == 0)
                 std::cout << "New layer ghost nodes initialized" << std::endl;

--- a/unit_test/tstKokkosMPI.hpp
+++ b/unit_test/tstKokkosMPI.hpp
@@ -291,7 +291,6 @@ void testResizeRefillBuffers() {
 
     // Create send/receive buffers with a buffer size too small to hold all of the active cell data
     int BufSize = 1;
-    int MaxBufSize = nx * nzActive;
     Buffer2D BufferSouthSend(Kokkos::ViewAllocateWithoutInitializing("BufferSouthSend"), BufSize, 8);
     Buffer2D BufferNorthSend(Kokkos::ViewAllocateWithoutInitializing("BufferNorthSend"), BufSize, 8);
     Buffer2D BufferSouthRecv(Kokkos::ViewAllocateWithoutInitializing("BufferSouthRecv"), BufSize, 8);
@@ -422,7 +421,7 @@ void testResizeRefillBuffers() {
     // Attempt to resize buffers and load the remaining data
     int OldBufSize = BufSize;
     BufSize = ResizeBuffers(BufferNorthSend, BufferSouthSend, BufferNorthRecv, BufferSouthRecv, SendSizeNorth,
-                            SendSizeSouth, SendSizeNorth_Host, SendSizeSouth_Host, OldBufSize, MaxBufSize);
+                            SendSizeSouth, SendSizeNorth_Host, SendSizeSouth_Host, OldBufSize);
     if (OldBufSize != BufSize)
         RefillBuffers(nx, nzActive, MyYSlices, ZBound_Low, CellType, BufferNorthSend, BufferSouthSend, SendSizeNorth,
                       SendSizeSouth, AtNorthBoundary, AtSouthBoundary, GrainID, DOCenter, DiagonalLength,
@@ -496,8 +495,8 @@ void testResetBufferCapacity() {
         });
 
     // Reduce size back to the default of 25
-    BufSize = ResetBufferCapacity(BufferNorthSend, BufferSouthSend, BufferNorthRecv, BufferSouthRecv);
-    EXPECT_EQ(BufSize, 25);
+    BufSize = 25;
+    ResetBufferCapacity(BufferNorthSend, BufferSouthSend, BufferNorthRecv, BufferSouthRecv, BufSize);
 
     // Copy buffers back to host
     Buffer2D_H BufferNorthSend_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), BufferNorthSend);


### PR DESCRIPTION
Reduced buffer size by using an initial guess (rather than using the max possible size as done previously), and new views to track the number of cells with associated data contained in the buffer. If a rank exceeds the buffer's max capacity, a resize of the buffers is performed across all ranks