### PR TITLE
Bug fix in normalization of power law interfacial response

### DIFF
--- a/src/CAinterfacialresponse.hpp
+++ b/src/CAinterfacialresponse.hpp
@@ -142,10 +142,24 @@ struct InterfacialResponseFunction {
 #endif
 
     void normalize(const double deltat, const double deltax) {
-        A *= deltat / deltax;
-        B *= deltat / deltax;
-        C *= deltat / deltax;
-        D *= deltat / deltax;
+        if (function == cubic) {
+            // Normalize all 4 coefficients: V = A*x^3 + B*x^2 + C*x + D
+            A *= deltat / deltax;
+            B *= deltat / deltax;
+            C *= deltat / deltax;
+            D *= deltat / deltax;
+        }
+        else if (function == quadratic) {
+            // Normalize the 3 relevant coefficients: V = A*x^2 + B*x + C
+            A *= deltat / deltax;
+            B *= deltat / deltax;
+            C *= deltat / deltax;
+        }
+        else if (function == power) {
+            // Normalize only the leading and last coefficient: V = A*x^B + C
+            A *= deltat / deltax;
+            C *= deltat / deltax;
+        }
     }
 
     // Compute velocity from local undercooling.

--- a/unit_test/tstInit.cpp
+++ b/unit_test/tstInit.cpp
@@ -449,13 +449,19 @@ void testInterfacialResponse() {
             BTest = 3.12;
             CTest = 0;
             FreezingRangeTest = 26.5;
-            ExpectedV = (deltat / deltax) * (ATest * pow(LocU, (deltat / deltax) * BTest) + CTest);
+            ExpectedV = (deltat / deltax) * (ATest * pow(LocU, BTest) + CTest);
         }
         else {
             throw std::runtime_error("File not set up for testing.");
         }
+        // For all IRFs, A and C should be normalized by deltat/deltax (i.e., 2)
+        // For the power law IRF (SS316), B is dimensionless and should not be normalized unlike the other IRFs where
+        // all coefficients are normalized
         EXPECT_DOUBLE_EQ(irf.A, ATest * 2);
-        EXPECT_DOUBLE_EQ(irf.B, BTest * 2);
+        if (file_name == "SS316.json")
+            EXPECT_DOUBLE_EQ(irf.B, BTest);
+        else
+            EXPECT_DOUBLE_EQ(irf.B, BTest * 2);
         EXPECT_DOUBLE_EQ(irf.C, CTest * 2);
         if (file_name == "Inconel625.json") {
             EXPECT_DOUBLE_EQ(irf.D, DTest * 2);


### PR DESCRIPTION
Unlike the quadratic and cubic interfacial responses that have all coefficients normalized by (deltat/deltax), the exponential coefficient in V = A*(undercooling)^B + C is dimensionless and should not be normalized

Fixup of #140 