### PR TITLE
Option to use a powder layer on layer 0

### DIFF
--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -647,15 +647,10 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
             PowderActiveFraction = 1.0; // defaults to a unique grain at each site in the powder layers
         // Should a powder layer be initialized at the top of the baseplate for the first layer? (Defaults to false,
         // where the baseplate spans all of layer 0, and only starting with layer 1 is a powder layer present)
-        std::cout << "THE OPTION SHOULD BE " << inputdata["Substrate"].contains("PowderFirstLayer") << std::endl;
-        if (inputdata["Substrate"].contains("PowderFirstLayer")) {
+        if (inputdata["Substrate"].contains("PowderFirstLayer"))
             PowderFirstLayer = inputdata["Substrate"]["PowderFirstLayer"];
-            std::cout << "found, is " << PowderFirstLayer << std::endl;
-        }
-        else {
+        else
             PowderFirstLayer = false;
-            std::cout << "not found" << std::endl;
-        }
         if ((BaseplateThroughPowder) && ((PowderFirstLayer) || (inputdata["Substrate"].contains("PowderDensity"))))
             throw std::runtime_error(
                 "Error: if the option to extend the baseplate through the powder layers is toggled, options regarding "

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -28,7 +28,7 @@ void InputReadFromFile_Old(int id, std::string InputFile, std::string &Simulatio
                            int &NSpotsX, int &NSpotsY, int &SpotOffset, int &SpotRadius, bool &PrintTimeSeries,
                            int &TimeSeriesInc, bool &PrintIdleTimeSeriesFrames, bool &PrintDefaultRVE, double &RNGSeed,
                            bool &BaseplateThroughPowder, double &PowderDensity, int &RVESize, bool &LayerwiseTempRead,
-                           bool &PrintBinary);
+                           bool &PrintBinary, bool &PowderFirstLayer);
 void InputReadFromFile(int id, std::string InputFile, std::string &SimulationType, double &deltax, double &NMax,
                        double &dTN, double &dTsigma, std::string &OutputFile, std::string &GrainOrientationFile,
                        int &TempFilesInSeries, std::vector<std::string> &temp_paths, double &HT_deltax,
@@ -40,7 +40,7 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
                        int &NSpotsY, int &SpotOffset, int &SpotRadius, bool &PrintTimeSeries, int &TimeSeriesInc,
                        bool &PrintIdleTimeSeriesFrames, bool &PrintDefaultRVE, double &RNGSeed,
                        bool &BaseplateThroughPowder, double &PowderActiveFraction, int &RVESize,
-                       bool &LayerwiseTempRead, bool &PrintBinary);
+                       bool &LayerwiseTempRead, bool &PrintBinary, bool &PowderFirstLayer);
 void checkPowderOverflow(int nx, int ny, int LayerHeight, int NumberOfLayers, bool BaseplateThroughPowder,
                          double PowderDensity);
 void NeighborListInit(NList &NeighborX, NList &NeighborY, NList &NeighborZ);
@@ -112,10 +112,12 @@ void SubstrateInit_ConstrainedGrowth(int id, double FractSurfaceSitesActive, int
                                      int np, Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, ViewI SendSizeNorth,
                                      ViewI SendSizeSouth, bool AtNorthBoundary, bool AtSouthBoundary, int BufSize);
 void SubstrateInit_FromFile(std::string SubstrateFileName, int nz, int nx, int MyYSlices, int MyYOffset, int pid,
-                            ViewI &GrainID, int nzActive, bool BaseplateThroughPowder);
+                            ViewI &GrainID, int nzActive, bool BaseplateThroughPowder, bool PowderFirstLayer,
+                            int LayerHeight);
 void BaseplateInit_FromGrainSpacing(float SubstrateGrainSpacing, int nx, int ny, double *ZMinLayer, double *ZMaxLayer,
                                     int MyYSlices, int MyYOffset, int id, double deltax, ViewI GrainID, double RNGSeed,
-                                    int &NextLayer_FirstEpitaxialGrainID, int nz, double BaseplateThroughPowder);
+                                    int &NextLayer_FirstEpitaxialGrainID, int nz, double BaseplateThroughPowder,
+                                    bool PowderFirstLayer, int LayerHeight);
 void PowderInit(int layernumber, int nx, int ny, int LayerHeight, double *ZMaxLayer, double ZMin, double deltax,
                 int MyYSlices, int MyYOffset, int id, ViewI GrainID, double RNGSeed,
                 int &NextLayer_FirstEpitaxialGrainID, double PowderActiveFraction);

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -111,10 +111,12 @@ void SubstrateInit_ConstrainedGrowth(int id, double FractSurfaceSitesActive, int
                                      ViewF DiagonalLength, ViewF DOCenter, ViewF CritDiagonalLength, double RNGSeed,
                                      int np, Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, ViewI SendSizeNorth,
                                      ViewI SendSizeSouth, bool AtNorthBoundary, bool AtSouthBoundary, int BufSize);
+int getBaseplateSizeZ(int nz, double *ZMaxLayer, double ZMin, double deltax, int LayerHeight,
+                      bool BaseplateThroughPowder, bool PowderFirstLayer);
 void SubstrateInit_FromFile(std::string SubstrateFileName, int nz, int nx, int MyYSlices, int MyYOffset, int pid,
-                            ViewI &GrainID, int nzActive, bool BaseplateThroughPowder, bool PowderFirstLayer,
-                            int LayerHeight);
-void BaseplateInit_FromGrainSpacing(float SubstrateGrainSpacing, int nx, int ny, double *ZMinLayer, double *ZMaxLayer,
+                            ViewI &GrainID, double ZMin, double *ZMaxLayer, bool BaseplateThroughPowder,
+                            bool PowderFirstLayer, int LayerHeight, double deltax);
+void BaseplateInit_FromGrainSpacing(float SubstrateGrainSpacing, int nx, int ny, double ZMin, double *ZMaxLayer,
                                     int MyYSlices, int MyYOffset, int id, double deltax, ViewI GrainID, double RNGSeed,
                                     int &NextLayer_FirstEpitaxialGrainID, int nz, double BaseplateThroughPowder,
                                     bool PowderFirstLayer, int LayerHeight);

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -238,11 +238,11 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     else {
         // Generate the baseplate microstructure, or read it from a file
         if (UseSubstrateFile)
-            SubstrateInit_FromFile(SubstrateFileName, nz, nx, MyYSlices, MyYOffset, id, GrainID, nzActive,
-                                   BaseplateThroughPowder, PowderFirstLayer, LayerHeight);
+            SubstrateInit_FromFile(SubstrateFileName, nz, nx, MyYSlices, MyYOffset, id, GrainID, ZMin, ZMaxLayer,
+                                   BaseplateThroughPowder, PowderFirstLayer, LayerHeight, deltax);
         else
-            BaseplateInit_FromGrainSpacing(SubstrateGrainSpacing, nx, ny, ZMinLayer, ZMaxLayer, MyYSlices, MyYOffset,
-                                           id, deltax, GrainID, RNGSeed, NextLayer_FirstEpitaxialGrainID, nz,
+            BaseplateInit_FromGrainSpacing(SubstrateGrainSpacing, nx, ny, ZMin, ZMaxLayer, MyYSlices, MyYOffset, id,
+                                           deltax, GrainID, RNGSeed, NextLayer_FirstEpitaxialGrainID, nz,
                                            BaseplateThroughPowder, PowderFirstLayer, LayerHeight);
         // Optionally generate powder grain structure for top of layer 0
         if (PowderFirstLayer)

--- a/unit_test/tstInit.cpp
+++ b/unit_test/tstInit.cpp
@@ -107,7 +107,8 @@ void WriteTestDataR_json(std::string InputFilename, bool PrintDebugFiles) {
     TestDataFile << "   }," << std::endl;
     TestDataFile << "   \"Substrate\": {" << std::endl;
     TestDataFile << "      \"SubstrateFilename\": \"DummySubstrate.txt\"," << std::endl;
-    TestDataFile << "      \"PowderDensity\": 1000" << std::endl;
+    TestDataFile << "      \"PowderDensity\": 1000," << std::endl;
+    TestDataFile << "      \"PowderFirstLayer\": true" << std::endl;
     TestDataFile << "   }," << std::endl;
     TestDataFile << "   \"Printing\": {" << std::endl;
     TestDataFile << "      \"PathToOutput\": \"ExaCA\"," << std::endl;
@@ -186,7 +187,7 @@ void testInputReadFromFile(bool JsonInputFormat, bool PrintDebugFiles) {
             PowderActiveFraction;
         bool RemeltingYN, PrintMisorientation, PrintFinalUndercoolingVals, PrintFullOutput, PrintTimeSeries,
             UseSubstrateFile, PrintIdleTimeSeriesFrames, PrintDefaultRVE = false, BaseplateThroughPowder,
-                                                         LayerwiseTempRead, PrintBinary;
+                                                         LayerwiseTempRead, PrintBinary, PowderFirstLayer;
         std::string SimulationType, OutputFile, GrainOrientationFile, temppath, tempfile, SubstrateFileName,
             PathToOutput, MaterialFileName;
         std::vector<std::string> temp_paths;
@@ -200,7 +201,7 @@ void testInputReadFromFile(bool JsonInputFormat, bool PrintDebugFiles) {
                               PrintMisorientation, PrintFinalUndercoolingVals, PrintFullOutput, NSpotsX, NSpotsY,
                               SpotOffset, SpotRadius, PrintTimeSeries, TimeSeriesInc, PrintIdleTimeSeriesFrames,
                               PrintDefaultRVE, RNGSeed, BaseplateThroughPowder, PowderActiveFraction, RVESize,
-                              LayerwiseTempRead, PrintBinary);
+                              LayerwiseTempRead, PrintBinary, PowderFirstLayer);
 #else
             throw std::runtime_error("Error: attempted to parse json input file without ExaCA_ENABLE_JSON=ON");
 #endif
@@ -213,7 +214,7 @@ void testInputReadFromFile(bool JsonInputFormat, bool PrintDebugFiles) {
                 FractSurfaceSitesActive, PathToOutput, PrintDebug, PrintMisorientation, PrintFinalUndercoolingVals,
                 PrintFullOutput, NSpotsX, NSpotsY, SpotOffset, SpotRadius, PrintTimeSeries, TimeSeriesInc,
                 PrintIdleTimeSeriesFrames, PrintDefaultRVE, RNGSeed, BaseplateThroughPowder, PowderActiveFraction,
-                RVESize, LayerwiseTempRead, PrintBinary);
+                RVESize, LayerwiseTempRead, PrintBinary, PowderFirstLayer);
 
         InterfacialResponseFunction irf(0, MaterialFileName, deltat, deltax, JsonInputFormat);
 
@@ -271,6 +272,8 @@ void testInputReadFromFile(bool JsonInputFormat, bool PrintDebugFiles) {
             EXPECT_EQ(LayerHeight, 20);
             EXPECT_FALSE(UseSubstrateFile);
             EXPECT_FALSE(BaseplateThroughPowder);
+            // Option defaults to false
+            EXPECT_FALSE(PowderFirstLayer);
             EXPECT_FLOAT_EQ(SubstrateGrainSpacing, 25.0);
             EXPECT_TRUE(OutputFile == "TestProblemSpot");
             EXPECT_FALSE(PrintFinalUndercoolingVals);
@@ -288,6 +291,11 @@ void testInputReadFromFile(bool JsonInputFormat, bool PrintDebugFiles) {
             EXPECT_TRUE(UseSubstrateFile);
             EXPECT_FALSE(LayerwiseTempRead);
             EXPECT_DOUBLE_EQ(PowderActiveFraction, 0.001);
+            // Option defaults to false, is set to true with JSON input file
+            if (JsonInputFormat)
+                EXPECT_TRUE(PowderFirstLayer);
+            else
+                EXPECT_FALSE(PowderFirstLayer);
             EXPECT_DOUBLE_EQ(HT_deltax, deltax);
             EXPECT_TRUE(OutputFile == "Test");
             EXPECT_TRUE(temp_paths[0] == ".//1DummyTemperature.txt");

--- a/unit_test/tstKokkosInitMPI.hpp
+++ b/unit_test/tstKokkosInitMPI.hpp
@@ -122,6 +122,7 @@ void testBaseplateInit_FromGrainSpacing(bool PowderFirstLayer) {
     double ZMinLayer[1];
     double ZMaxLayer[1];
     ZMinLayer[0] = 0;
+    double ZMin = ZMinLayer[0];
     ZMaxLayer[0] = 2 * pow(10, -6);
     int nx = 3;
     // Each rank is assigned a different portion of the domain in Y
@@ -132,9 +133,9 @@ void testBaseplateInit_FromGrainSpacing(bool PowderFirstLayer) {
     int BaseplateSize;
     int LayerHeight = 2;
     if (PowderFirstLayer)
-        BaseplateSize = nx * MyYSlices * (round((ZMaxLayer[0] - ZMinLayer[0]) / deltax) + 1 - LayerHeight);
+        BaseplateSize = nx * MyYSlices * (round((ZMaxLayer[0] - ZMin) / deltax) + 1 - LayerHeight);
     else
-        BaseplateSize = nx * MyYSlices * (round((ZMaxLayer[0] - ZMinLayer[0]) / deltax) + 1);
+        BaseplateSize = nx * MyYSlices * (round((ZMaxLayer[0] - ZMin) / deltax) + 1);
     int LocalDomainSize = nx * MyYSlices * nz;
     // There are 36 * np total cells in this domain (nx * ny * nz)
     // Each rank has 36 cells - the bottom 27 cells are assigned baseplate Grain ID values, unless the powder layer of
@@ -152,9 +153,9 @@ void testBaseplateInit_FromGrainSpacing(bool PowderFirstLayer) {
     // Initialize GrainIDs to 0 on device
     ViewI GrainID("GrainID_Device", LocalDomainSize);
 
-    BaseplateInit_FromGrainSpacing(SubstrateGrainSpacing, nx, ny, ZMinLayer, ZMaxLayer, MyYSlices, MyYOffset, id,
-                                   deltax, GrainID, RNGSeed, NextLayer_FirstEpitaxialGrainID, nz, false,
-                                   PowderFirstLayer, LayerHeight);
+    BaseplateInit_FromGrainSpacing(SubstrateGrainSpacing, nx, ny, ZMin, ZMaxLayer, MyYSlices, MyYOffset, id, deltax,
+                                   GrainID, RNGSeed, NextLayer_FirstEpitaxialGrainID, nz, false, PowderFirstLayer,
+                                   LayerHeight);
 
     // Copy results back to host to check
     ViewI_H GrainID_H = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), GrainID);

--- a/unit_test/tstKokkosInitMPI.hpp
+++ b/unit_test/tstKokkosInitMPI.hpp
@@ -109,7 +109,7 @@ void testSubstrateInit_ConstrainedGrowth() {
     }
 }
 
-void testBaseplateInit_FromGrainSpacing() {
+void testBaseplateInit_FromGrainSpacing(bool PowderFirstLayer) {
 
     int id, np;
     // Get number of processes
@@ -118,6 +118,7 @@ void testBaseplateInit_FromGrainSpacing() {
     MPI_Comm_rank(MPI_COMM_WORLD, &id);
     // Create test data
     int nz = 4;
+    int nzActive = 3;
     double ZMinLayer[1];
     double ZMaxLayer[1];
     ZMinLayer[0] = 0;
@@ -128,27 +129,44 @@ void testBaseplateInit_FromGrainSpacing() {
     int MyYSlices = 3;
     int MyYOffset = 3 * id;
     double deltax = 1 * pow(10, -6);
-    int BaseplateSize = nx * MyYSlices * (round((ZMaxLayer[0] - ZMinLayer[0]) / deltax) + 1);
+    int BaseplateSize;
+    int LayerHeight = 2;
+    if (PowderFirstLayer)
+        BaseplateSize = nx * MyYSlices * (round((ZMaxLayer[0] - ZMinLayer[0]) / deltax) + 1 - LayerHeight);
+    else
+        BaseplateSize = nx * MyYSlices * (round((ZMaxLayer[0] - ZMinLayer[0]) / deltax) + 1);
     int LocalDomainSize = nx * MyYSlices * nz;
     // There are 36 * np total cells in this domain (nx * ny * nz)
-    // Each rank has 36 cells - the bottom 27 cells are assigned baseplate Grain ID values
-    // The top cells (Z = 4) are outside the "active" portion of the domain and are not assigned Grain IDs with the rest
-    // of the baseplate
-    double SubstrateGrainSpacing =
-        3.0; // This grain spacing ensures that there will be 1 grain per number of MPI ranks present
+    // Each rank has 36 cells - the bottom 27 cells are assigned baseplate Grain ID values, unless the powder layer of
+    // height 2 is used, in which case only the bottom 9 cells should be assigned baseplate Grain ID values The top
+    // cells (Z = 3) are outside the "active" portion of the domain and are not assigned Grain IDs with the rest of the
+    // baseplate This grain spacing ensures that there will be 1 grain per number of MPI ranks present (larger when
+    // powder layer is present as the baseplate will only have a third as many cells)
+    double SubstrateGrainSpacing;
+    if (PowderFirstLayer)
+        SubstrateGrainSpacing = 2.08;
+    else
+        SubstrateGrainSpacing = 3.0;
     double RNGSeed = 0.0;
     int NextLayer_FirstEpitaxialGrainID;
     // Initialize GrainIDs to 0 on device
     ViewI GrainID("GrainID_Device", LocalDomainSize);
 
     BaseplateInit_FromGrainSpacing(SubstrateGrainSpacing, nx, ny, ZMinLayer, ZMaxLayer, MyYSlices, MyYOffset, id,
-                                   deltax, GrainID, RNGSeed, NextLayer_FirstEpitaxialGrainID, nz, false);
+                                   deltax, GrainID, RNGSeed, NextLayer_FirstEpitaxialGrainID, nz, false,
+                                   PowderFirstLayer, LayerHeight);
 
     // Copy results back to host to check
     ViewI_H GrainID_H = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), GrainID);
 
     // Check the results for baseplate grains - cells should have GrainIDs between 1 and np (inclusive) if they are part
     // of the active domain, or 0 (unassigned) if not part of the active domain
+    // In the case where there is powder on the first layer, the baseplate size is "LayerHeight" fewer cells in the Z
+    // direction
+    if (PowderFirstLayer)
+        EXPECT_EQ(BaseplateSize, nx * MyYSlices * (nzActive - LayerHeight));
+    else
+        EXPECT_EQ(BaseplateSize, nx * MyYSlices * nzActive);
     for (int i = 0; i < BaseplateSize; i++) {
         EXPECT_GT(GrainID_H(i), 0);
         EXPECT_LT(GrainID_H(i), np + 1);
@@ -694,7 +712,9 @@ void testNucleiInit(bool RemeltingYN) {
 //---------------------------------------------------------------------------//
 TEST(TEST_CATEGORY, grain_init_tests) {
     testSubstrateInit_ConstrainedGrowth();
-    testBaseplateInit_FromGrainSpacing();
+    // w/ and w/o space left for powder layer
+    testBaseplateInit_FromGrainSpacing(true);
+    testBaseplateInit_FromGrainSpacing(false);
     testPowderInit();
 }
 TEST(TEST_CATEGORY, cell_init_test) {


### PR DESCRIPTION
Previously, the baseplate would span all of layer 0, and powder would only be used on successive layers. This adds the option to have the powder layer exist on all layers