### PR TITLE
Use separate format action in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -83,12 +83,6 @@ jobs:
             ${exaca_cmake_opts[@]}
           cmake --build build --parallel 2
           cmake --install build
-      - name: Format ExaCA
-        if: ${{ matrix.distro == 'ubuntu:latest' }}
-        working-directory: build
-        run: |
-          make format
-          git diff --exit-code
       - name: Unit test ExaCA
         run: |
           CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --target test

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,12 @@
+name: Clang-Format Check
+on: [pull_request]
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run clang-format style check
+      uses: jidicula/clang-format-action@v4.6.2
+      with:
+        clang-format-version: '14'


### PR DESCRIPTION
Use independent format action. This will 1) run faster (rather than waiting until after the build it will check and fail right away) and 2) be more clear as to why a build failed (rather than being hidden inside the main CI build)