### PR TITLE
Use remelting logic/data structures for constrained solidification

### DIFF
--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -47,6 +47,7 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
     // "S": array of overlapping hemispherical spots
     // "R": time-temperature history comes from external files
     // Check if simulation type includes remelting ("M" suffix to input problem type)
+    // DirSoldification problems now include remelting logic
     if (SimulationType == "RM") {
         SimulationType = "R";
         RemeltingYN = true;
@@ -55,6 +56,8 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
         SimulationType = "S";
         RemeltingYN = true;
     }
+    else if (SimulationType == "C")
+        RemeltingYN = true;
     else {
         // Simulation does not including remelting logic
         RemeltingYN = false;
@@ -686,32 +689,38 @@ int calcLocalActiveDomainSize(int nx, int MyYSlices, int nzActive) {
 }
 //*****************************************************************************/
 // Initialize temperature data for a constrained solidification test problem
-void TempInit_DirSolidification(double G, double R, int, int &nx, int &MyYSlices, double deltax, double deltat, int nz,
-                                int LocalDomainSize, ViewI &CritTimeStep, ViewF &UndercoolingChange, ViewI &LayerID) {
+void TempInit_DirSolidification(double G, double R, int, int &nx, int &MyYSlices, double deltax, double deltat, int,
+                                int LocalDomainSize, ViewI &CritTimeStep, ViewF &UndercoolingChange, ViewI &LayerID,
+                                ViewI &NumberOfSolidificationEvents, ViewI &SolidificationEventCounter,
+                                ViewI &MeltTimeStep, ViewI MaxSolidificationEvents, ViewF3D &LayerTimeTempHistory) {
 
-    // These views are initialized on the host, filled with data, and then copied to the device for layer "layernumber"
-    // This view is initialized with zeros
-    ViewI_H LayerID_Host("LayerID_H", LocalDomainSize);
-    // These views will be filled with non-zero values
-    ViewI_H CritTimeStep_Host(Kokkos::ViewAllocateWithoutInitializing("CritTimeStep_H"), LocalDomainSize);
-    ViewF_H UndercoolingChange_Host(Kokkos::ViewAllocateWithoutInitializing("UndercoolingChange_H"), LocalDomainSize);
+    // TODO: When all simulations use remelting, set size of these outside of this subroutine since all problems do it
+    Kokkos::resize(NumberOfSolidificationEvents, LocalDomainSize);
+    Kokkos::resize(SolidificationEventCounter, LocalDomainSize);
+    Kokkos::resize(MeltTimeStep, LocalDomainSize);
+    Kokkos::resize(LayerTimeTempHistory, LocalDomainSize, 1, 3);
 
     // Initialize temperature field in Z direction with thermal gradient G set in input file
     // Cells at the bottom surface (Z = 0) are at the liquidus at time step 0 (no wall cells at the bottom boundary)
-    for (int k = 0; k < nz; k++) {
-        for (int i = 0; i < nx; i++) {
-            for (int j = 0; j < MyYSlices; j++) {
-                int GlobalD3D1ConvPosition = k * nx * MyYSlices + i * MyYSlices + j;
-                UndercoolingChange_Host(GlobalD3D1ConvPosition) = R * deltat;
-                CritTimeStep_Host(GlobalD3D1ConvPosition) = (int)((k * G * deltax) / (R * deltat));
-            }
-        }
-    }
-
-    // Copy initialized host data back to device
-    CritTimeStep = Kokkos::create_mirror_view_and_copy(device_memory_space(), CritTimeStep_Host);
-    LayerID = Kokkos::create_mirror_view_and_copy(device_memory_space(), LayerID_Host);
-    UndercoolingChange = Kokkos::create_mirror_view_and_copy(device_memory_space(), UndercoolingChange_Host);
+    Kokkos::parallel_for(
+        "TempInitDirS", LocalDomainSize, KOKKOS_LAMBDA(const int &Coordinate1D) {
+            int ZCoordinate = Coordinate1D / (nx * MyYSlices);
+            // All cells past melting time step
+            LayerTimeTempHistory(Coordinate1D, 0, 0) = -1;
+            MeltTimeStep(Coordinate1D) = -1;
+            // Cells reach liquidus at a time dependent on their Z coordinate
+            LayerTimeTempHistory(Coordinate1D, 0, 1) = static_cast<int>((ZCoordinate * G * deltax) / (R * deltat));
+            CritTimeStep(Coordinate1D) = static_cast<int>((ZCoordinate * G * deltax) / (R * deltat));
+            // Cells cool at a constant rate
+            LayerTimeTempHistory(Coordinate1D, 0, 2) = R * deltat;
+            UndercoolingChange(Coordinate1D) = R * deltat;
+            // DirS not a multilayer problem
+            LayerID(Coordinate1D) = 0;
+            // All cells solidify once
+            MaxSolidificationEvents(0) = 1;
+            SolidificationEventCounter(Coordinate1D) = 0;
+            NumberOfSolidificationEvents(Coordinate1D) = 1;
+        });
 }
 
 // Initialize temperature data for an array of overlapping spot melts (done during simulation initialization, no
@@ -1472,9 +1481,7 @@ void OrientationInit(int, int &NGrainOrientations, ViewF &GrainOrientationData, 
 void SubstrateInit_ConstrainedGrowth(int id, double FractSurfaceSitesActive, int MyYSlices, int nx, int ny,
                                      int MyYOffset, NList NeighborX, NList NeighborY, NList NeighborZ,
                                      ViewF GrainUnitVector, int NGrainOrientations, ViewI CellType, ViewI GrainID,
-                                     ViewF DiagonalLength, ViewF DOCenter, ViewF CritDiagonalLength, double RNGSeed,
-                                     int np, Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, ViewI SendSizeNorth,
-                                     ViewI SendSizeSouth, bool AtNorthBoundary, bool AtSouthBoundary, int BufSize) {
+                                     ViewF DiagonalLength, ViewF DOCenter, ViewF CritDiagonalLength, double RNGSeed) {
 
     // Calls to Xdist(gen) and Y dist(gen) return random locations for grain seeds
     // Since X = 0 and X = nx-1 are the cell centers of the last cells in X, locations are evenly scattered between X =
@@ -1537,25 +1544,6 @@ void SubstrateInit_ConstrainedGrowth(int id, double FractSurfaceSitesActive, int
                 // cell. Octahedron center and cell center overlap for octahedra created as part of a new grain
                 calcCritDiagonalLength(D3D1ConvPosition, cx, cy, cz, cx, cy, cz, NeighborX, NeighborY, NeighborZ,
                                        MyOrientation, GrainUnitVector, CritDiagonalLength);
-                // If this new active cell is in the halo region, load the send buffers
-                if (np > 1) {
-
-                    int GhostGID = GrainID(D3D1ConvPosition);
-                    float GhostDOCX = GlobalX + 0.5;
-                    float GhostDOCY = GlobalY + 0.5;
-                    float GhostDOCZ = GlobalZ + 0.5;
-                    float GhostDL = 0.01;
-                    // Collect data for the ghost nodes, if necessary
-                    bool DataFitsInBuffer =
-                        loadghostnodes(GhostGID, GhostDOCX, GhostDOCY, GhostDOCZ, GhostDL, SendSizeNorth, SendSizeSouth,
-                                       MyYSlices, GlobalX, LocalY, 0, AtNorthBoundary, AtSouthBoundary, BufferSouthSend,
-                                       BufferNorthSend, NGrainOrientations, BufSize);
-                    if (!(DataFitsInBuffer)) {
-                        // This cell's data did not fit in the buffer with current size BufSize - mark with temporary
-                        // type
-                        CellType(D3D1ConvPosition) = ActiveFailedBufferLoad;
-                    }
-                } // End if statement for serial/parallel code
             }
         });
     if (id == 0)

--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -695,10 +695,10 @@ void TempInit_DirSolidification(double G, double R, int, int &nx, int &MyYSlices
                                 ViewI &MeltTimeStep, ViewI MaxSolidificationEvents, ViewF3D &LayerTimeTempHistory) {
 
     // TODO: When all simulations use remelting, set size of these outside of this subroutine since all problems do it
-    Kokkos::resize(NumberOfSolidificationEvents, LocalDomainSize);
-    Kokkos::resize(SolidificationEventCounter, LocalDomainSize);
-    Kokkos::resize(MeltTimeStep, LocalDomainSize);
-    Kokkos::resize(LayerTimeTempHistory, LocalDomainSize, 1, 3);
+    Kokkos::realloc(NumberOfSolidificationEvents, LocalDomainSize);
+    Kokkos::realloc(SolidificationEventCounter, LocalDomainSize);
+    Kokkos::realloc(MeltTimeStep, LocalDomainSize);
+    Kokkos::realloc(LayerTimeTempHistory, LocalDomainSize, 1, 3);
 
     // Initialize temperature field in Z direction with thermal gradient G set in input file
     // Cells at the bottom surface (Z = 0) are at the liquidus at time step 0 (no wall cells at the bottom boundary)

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -49,7 +49,8 @@ int calcnzActive(int ZBound_Low, int ZBound_High, int id, int layernumber);
 int calcLocalActiveDomainSize(int nx, int MyYSlices, int nzActive);
 void TempInit_DirSolidification(double G, double R, int id, int &nx, int &MyYSlices, double deltax, double deltat,
                                 int nz, int LocalDomainSize, ViewI &CritTimeStep, ViewF &UndercoolingChange,
-                                ViewI &LayerID);
+                                ViewI &LayerID, ViewI &NumberOfSolidificationEvents, ViewI &SolidificationEventCounter,
+                                ViewI &MeltTimeStep, ViewI MaxSolidificationEvents, ViewF3D &LayerTimeTempHistory);
 int calcMaxSolidificationEventsSpot(int nx, int MyYSlices, int NumberOfSpots, int NSpotsX, int SpotRadius,
                                     int SpotOffset, int MyYOffset);
 void OrientationInit(int id, int &NGrainOrientations, ViewF &ReadOrientationData, std::string GrainOrientationFile,
@@ -94,9 +95,7 @@ void TempInit_ReadDataRemelt(int layernumber, int id, int nx, int MyYSlices, int
 void SubstrateInit_ConstrainedGrowth(int id, double FractSurfaceSitesActive, int MyYSlices, int nx, int ny,
                                      int MyYOffset, NList NeighborX, NList NeighborY, NList NeighborZ,
                                      ViewF GrainUnitVector, int NGrainOrientations, ViewI CellType, ViewI GrainID,
-                                     ViewF DiagonalLength, ViewF DOCenter, ViewF CritDiagonalLength, double RNGSeed,
-                                     int np, Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, ViewI SendSizeNorth,
-                                     ViewI SendSizeSouth, bool AtNorthBoundary, bool AtSouthBoundary, int BufSize);
+                                     ViewF DiagonalLength, ViewF DOCenter, ViewF CritDiagonalLength, double RNGSeed);
 int getBaseplateSizeZ(int nz, double *ZMaxLayer, double ZMin, double deltax, int LayerHeight,
                       bool BaseplateThroughPowder, bool PowderFirstLayer);
 void SubstrateInit_FromFile(std::string SubstrateFileName, int nz, int nx, int MyYSlices, int MyYOffset, int pid,

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -338,8 +338,11 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
             // Cell capture performed in two steps - first, adding cells of interest to a steering vector (different
             // subroutine called with versus without remelting), and second, iterating over the steering vector to
             // perform active cell creation and capture operations
+            // Constrained/directional solidification problem has views needed for modeling remelt events but does not
+            // have cells that undergo remelting - the steering vector operation for this problem can be constructed
+            // using FillSteeringVector_NoRemelt
             StartCreateSVTime = MPI_Wtime();
-            if (RemeltingYN)
+            if ((RemeltingYN) && (SimulationType != "C"))
                 FillSteeringVector_Remelt(cycle, LocalActiveDomainSize, nx, MyYSlices, NeighborX, NeighborY, NeighborZ,
                                           CritTimeStep, UndercoolingCurrent, UndercoolingChange, CellType, GrainID,
                                           ZBound_Low, nzActive, SteeringVector, numSteer, numSteer_Host, MeltTimeStep);

--- a/unit_test/tstInit.cpp
+++ b/unit_test/tstInit.cpp
@@ -155,6 +155,7 @@ void testInputReadFromFile(bool PrintDebugFiles) {
 
         // These are different for all 3 test problems
         if (FileName == InputFilenames[0]) {
+            EXPECT_TRUE(RemeltingYN);
             EXPECT_TRUE(PrintTimeSeries);
             EXPECT_EQ(TimeSeriesInc, 5250);
             EXPECT_FALSE(PrintIdleTimeSeriesFrames);
@@ -177,6 +178,7 @@ void testInputReadFromFile(bool PrintDebugFiles) {
             EXPECT_EQ(PrintDebug, 0);
         }
         else if (FileName == InputFilenames[1]) {
+            EXPECT_FALSE(RemeltingYN);
             EXPECT_TRUE(PrintTimeSeries);
             EXPECT_EQ(TimeSeriesInc, 37500);
             EXPECT_TRUE(PrintIdleTimeSeriesFrames);
@@ -205,6 +207,7 @@ void testInputReadFromFile(bool PrintDebugFiles) {
             EXPECT_EQ(PrintDebug, 0);
         }
         else if (FileName == InputFilenames[2]) {
+            EXPECT_FALSE(RemeltingYN);
             EXPECT_DOUBLE_EQ(deltat, 1.5 * pow(10, -6));
             EXPECT_EQ(TempFilesInSeries, 2);
             EXPECT_EQ(NumberOfLayers, 2);

--- a/unit_test/tstKokkosInitMPI.hpp
+++ b/unit_test/tstKokkosInitMPI.hpp
@@ -41,16 +41,6 @@ void testSubstrateInit_ConstrainedGrowth() {
     int MyYOffset = 4 * id;
     int LocalActiveDomainSize = nx * MyYSlices * nzActive;
     int LocalDomainSize = nx * MyYSlices * nz;
-    // MPI rank locations relative to the global grid
-    bool AtNorthBoundary, AtSouthBoundary;
-    if (id == 0)
-        AtSouthBoundary = true;
-    else
-        AtSouthBoundary = false;
-    if (id == np - 1)
-        AtNorthBoundary = true;
-    else
-        AtNorthBoundary = false;
 
     double FractSurfaceSitesActive = 0.5; // Each rank will have 2 active cells each, on average
     double RNGSeed = 0.0;
@@ -71,19 +61,9 @@ void testSubstrateInit_ConstrainedGrowth() {
     ViewF DOCenter(Kokkos::ViewAllocateWithoutInitializing("DOCenter"), 3 * LocalActiveDomainSize);
     ViewF CritDiagonalLength(Kokkos::ViewAllocateWithoutInitializing("CritDiagonalLength"), 26 * LocalActiveDomainSize);
 
-    // Buffer size estimate
-    int BufSize = nx * nzActive;
-
-    // Send/recv buffers for ghost node data should be initialized with zeros
-    Buffer2D BufferSouthSend("BufferSouthSend", BufSize, 8);
-    Buffer2D BufferNorthSend("BufferNorthSend", BufSize, 8);
-    // Init to 0
-    ViewI SendSizeNorth("SendSizeNorth", 1);
-    ViewI SendSizeSouth("SendSizeSouth", 1);
     SubstrateInit_ConstrainedGrowth(id, FractSurfaceSitesActive, MyYSlices, nx, ny, MyYOffset, NeighborX, NeighborY,
                                     NeighborZ, GrainUnitVector, NGrainOrientations, CellType, GrainID, DiagonalLength,
-                                    DOCenter, CritDiagonalLength, RNGSeed, np, BufferNorthSend, BufferSouthSend,
-                                    SendSizeNorth, SendSizeSouth, AtNorthBoundary, AtSouthBoundary, BufSize);
+                                    DOCenter, CritDiagonalLength, RNGSeed);
 
     // Copy CellType, GrainID views to host to check values
     ViewI_H CellType_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), CellType);


### PR DESCRIPTION
This is necessary to enable removal of the "no remelt" logic and problem types in a future release. Also converts initialization to Kokkos parallel loops

~While this results in a slowdown for directional solidification problems (Problem type "C") of up to 10% on GPU and up to 30% on CPU depending on the problem size/resources used,~ Slight slowdown after using the no-remelt steering vector for this problem type
