### PR TITLE
Change logic to account for cells that melt/resolidify in rapid succession

### DIFF
--- a/src/CAghostnodes.cpp
+++ b/src/CAghostnodes.cpp
@@ -98,17 +98,19 @@ void RefillBuffers(int nx, int nzActive, int MyYSlices, int ZBound_Low, ViewI Ce
                     CellType(GlobalCellCoordinateSouth) = Active;
                     // If data doesn't fit in the buffer after the resize, warn that buffer data may have been lost
                     if (!(DataFitsInBuffer))
-                        printf("Warning: Send/recv buffer resize failed to include all necessary data, predicted "
+                        printf("Error: Send/recv buffer resize failed to include all necessary data, predicted "
                                "results at MPI processor boundaries may be inaccurate\n");
                 }
                 else if (CellType(GlobalCellCoordinateSouth) == LiquidFailedBufferLoad) {
-                    bool DataFitsInBuffer =
-                        loadghostnodes_liquid(SendSizeNorth, SendSizeSouth, MyYSlices, i, 1, k, AtNorthBoundary,
-                                              AtSouthBoundary, BufferSouthSend, BufferNorthSend, BufSize);
+                    // Dummy values for first 4 arguments (Grain ID and octahedron center coordinates), 0 for diagonal
+                    // length
+                    bool DataFitsInBuffer = loadghostnodes(
+                        -1, -1.0, -1.0, -1.0, 0.0, SendSizeNorth, SendSizeSouth, MyYSlices, i, 1, k, AtNorthBoundary,
+                        AtSouthBoundary, BufferSouthSend, BufferNorthSend, NGrainOrientations, BufSize);
                     CellType(GlobalCellCoordinateSouth) = Liquid;
                     // If data doesn't fit in the buffer after the resize, warn that buffer data may have been lost
                     if (!(DataFitsInBuffer))
-                        printf("Warning: Send/recv buffer resize failed to include all necessary data, predicted "
+                        printf("Error: Send/recv buffer resize failed to include all necessary data, predicted "
                                "results at MPI processor boundaries may be inaccurate\n");
                 }
                 if (CellType(GlobalCellCoordinateNorth) == ActiveFailedBufferLoad) {
@@ -127,17 +129,20 @@ void RefillBuffers(int nx, int nzActive, int MyYSlices, int ZBound_Low, ViewI Ce
                     CellType(GlobalCellCoordinateNorth) = Active;
                     // If data doesn't fit in the buffer after the resize, warn that buffer data may have been lost
                     if (!(DataFitsInBuffer))
-                        printf("Warning: Send/recv buffer resize failed to include all necessary data, predicted "
+                        printf("Error: Send/recv buffer resize failed to include all necessary data, predicted "
                                "results at MPI processor boundaries may be inaccurate\n");
                 }
                 else if (CellType(GlobalCellCoordinateNorth) == LiquidFailedBufferLoad) {
-                    bool DataFitsInBuffer = loadghostnodes_liquid(SendSizeNorth, SendSizeSouth, MyYSlices, i,
-                                                                  MyYSlices - 2, k, AtNorthBoundary, AtSouthBoundary,
-                                                                  BufferSouthSend, BufferNorthSend, BufSize);
+                    // Dummy values for first 4 arguments (Grain ID and octahedron center coordinates), 0 for diagonal
+                    // length
+                    bool DataFitsInBuffer =
+                        loadghostnodes(-1, -1.0, -1.0, -1.0, 0.0, SendSizeNorth, SendSizeSouth, MyYSlices, i,
+                                       MyYSlices - 2, k, AtNorthBoundary, AtSouthBoundary, BufferSouthSend,
+                                       BufferNorthSend, NGrainOrientations, BufSize);
                     CellType(GlobalCellCoordinateNorth) = Liquid;
                     // If data doesn't fit in the buffer after the resize, warn that buffer data may have been lost
                     if (!(DataFitsInBuffer))
-                        printf("Warning: Send/recv buffer resize failed to include all necessary data, predicted "
+                        printf("Error: Send/recv buffer resize failed to include all necessary data, predicted "
                                "results at MPI processor boundaries may be inaccurate\n");
                 }
             }

--- a/src/CAghostnodes.hpp
+++ b/src/CAghostnodes.hpp
@@ -55,36 +55,6 @@ KOKKOS_INLINE_FUNCTION bool loadghostnodes(const int GhostGID, const float Ghost
     }
     return DataFitsInBuffer;
 }
-
-// Load data for a liquid cell into the buffer - distinct from active cell buffer data as the diagonal length is zero
-// and other octahedron attributes are ignored
-KOKKOS_INLINE_FUNCTION bool loadghostnodes_liquid(ViewI SendSizeNorth, ViewI SendSizeSouth, const int MyYSlices,
-                                                  const int RankX, const int RankY, const int RankZ,
-                                                  const bool AtNorthBoundary, const bool AtSouthBoundary,
-                                                  Buffer2D BufferSouthSend, Buffer2D BufferNorthSend, int BufSize) {
-    bool DataFitsInBuffer = true;
-    if ((RankY == 1) && (!(AtSouthBoundary))) {
-        int GNPositionSouth = Kokkos::atomic_fetch_add(&SendSizeSouth(0), 1);
-        if (GNPositionSouth >= BufSize)
-            DataFitsInBuffer = false;
-        else {
-            BufferSouthSend(GNPositionSouth, 0) = static_cast<float>(RankX);
-            BufferSouthSend(GNPositionSouth, 1) = static_cast<float>(RankZ);
-            BufferSouthSend(GNPositionSouth, 7) = 0.0;
-        }
-    }
-    else if ((RankY == MyYSlices - 2) && (!(AtNorthBoundary))) {
-        int GNPositionNorth = Kokkos::atomic_fetch_add(&SendSizeNorth(0), 1);
-        if (GNPositionNorth >= BufSize)
-            DataFitsInBuffer = false;
-        else {
-            BufferNorthSend(GNPositionNorth, 0) = static_cast<float>(RankX);
-            BufferNorthSend(GNPositionNorth, 1) = static_cast<float>(RankZ);
-            BufferNorthSend(GNPositionNorth, 7) = 0.0;
-        }
-    }
-    return DataFitsInBuffer;
-}
 void ResetSendBuffers(int BufSize, Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, ViewI SendSizeNorth,
                       ViewI SendSizeSouth);
 int ResizeBuffers(Buffer2D &BufferNorthSend, Buffer2D &BufferSouthSend, Buffer2D &BufferNorthRecv,

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -96,8 +96,8 @@ void BaseplateInit_FromGrainSpacing(float SubstrateGrainSpacing, int nx, int ny,
 void PowderInit(int layernumber, int nx, int ny, int LayerHeight, double *ZMaxLayer, double ZMin, double deltax,
                 int MyYSlices, int MyYOffset, int id, ViewI GrainID, double RNGSeed,
                 int &NextLayer_FirstEpitaxialGrainID, double PowderActiveFraction);
-void CellTypeInit(int nx, int MyYSlices, int LocalActiveDomainSize, ViewI CellType, ViewI CritTimeStep, int id,
-                  int ZBound_Low);
+void CellTypeInit(int nx, int MyYSlices, int LocalActiveDomainSize, ViewI CellType, ViewI NumberOfSolidificationEvents,
+                  int id, int ZBound_Low);
 void NucleiInit(int layernumber, double RNGSeed, int MyYSlices, int MyYOffset, int nx, int ny, int nzActive,
                 int ZBound_Low, int id, double NMax, double dTN, double dTsigma, double deltax, ViewI &NucleiLocation,
                 ViewI_H &NucleationTimes_Host, ViewI &NucleiGrainID, ViewI CellType, ViewI CritTimeStep,

--- a/src/CAtypes.hpp
+++ b/src/CAtypes.hpp
@@ -17,7 +17,9 @@ enum TypeNames {
     Liquid = 5,
     TempSolid = 6,
     FutureActive = 7,
-    ActiveFailedBufferLoad = 8
+    ActiveFailedBufferLoad = 8,
+    FutureLiquid = 9,
+    LiquidFailedBufferLoad = 10
 };
 
 // Use Kokkos::DefaultExecutionSpace

--- a/src/CAupdate.cpp
+++ b/src/CAupdate.cpp
@@ -580,9 +580,11 @@ void CellCapture(int, int np, int, int, int, int nx, int MyYSlices, InterfacialR
             else if (CellType(GlobalD3D1ConvPosition) == FutureLiquid) {
                 // This type was assigned to a cell that was recently transformed from active to liquid, due to its
                 // bordering of a cell above the liquidus. This information may need to be sent to other MPI ranks
-                bool DataFitsInBuffer =
-                    loadghostnodes_liquid(SendSizeNorth, SendSizeSouth, MyYSlices, GlobalX, RankY, RankZ,
-                                          AtNorthBoundary, AtSouthBoundary, BufferSouthSend, BufferNorthSend, BufSize);
+                // Dummy values for first 4 arguments (Grain ID and octahedron center coordinates), 0 for diagonal
+                // length
+                bool DataFitsInBuffer = loadghostnodes(
+                    -1, -1.0, -1.0, -1.0, 0.0, SendSizeNorth, SendSizeSouth, MyYSlices, GlobalX, RankY, RankZ,
+                    AtNorthBoundary, AtSouthBoundary, BufferSouthSend, BufferNorthSend, NGrainOrientations, BufSize);
                 if (!(DataFitsInBuffer)) {
                     // This cell's data did not fit in the buffer with current size BufSize - mark with temporary
                     // type

--- a/src/CAupdate.cpp
+++ b/src/CAupdate.cpp
@@ -121,7 +121,9 @@ void FillSteeringVector_NoRemelt(int cycle, int LocalActiveDomainSize, int nx, i
 void FillSteeringVector_Remelt(int cycle, int LocalActiveDomainSize, int nx, int MyYSlices, NList NeighborX,
                                NList NeighborY, NList NeighborZ, ViewI CritTimeStep, ViewF UndercoolingCurrent,
                                ViewF UndercoolingChange, ViewI CellType, ViewI GrainID, int ZBound_Low, int nzActive,
-                               ViewI SteeringVector, ViewI numSteer, ViewI_H numSteer_Host, ViewI MeltTimeStep) {
+                               ViewI SteeringVector, ViewI numSteer, ViewI_H numSteer_Host, ViewI MeltTimeStep,
+                               ViewI SolidificationEventCounter, ViewI NumberOfSolidificationEvents,
+                               ViewF3D LayerTimeTempHistory) {
 
     Kokkos::parallel_for(
         "FillSV_RM", LocalActiveDomainSize, KOKKOS_LAMBDA(const int &D3D1ConvPosition) {
@@ -136,14 +138,59 @@ void FillSteeringVector_Remelt(int cycle, int LocalActiveDomainSize, int nx, int
             int cellType = CellType(GlobalD3D1ConvPosition);
             bool isNotSolid = ((cellType != TempSolid) && (cellType != Solid));
             bool atMeltTime = (cycle == MeltTimeStep(GlobalD3D1ConvPosition));
+            bool atCritTime = (cycle == CritTimeStep(GlobalD3D1ConvPosition));
             bool pastCritTime = (cycle > CritTimeStep(GlobalD3D1ConvPosition));
-            if ((atMeltTime) && ((cellType == TempSolid) || (cellType == Active))) {
-                // FIXME: Active cells that didn't finish their previous solidification event should have that
-                // solidification event skipped instead of having both this one and the previous one complete This cell
-                // should be a liquid cell
+            if (atMeltTime) {
                 CellType(GlobalD3D1ConvPosition) = Liquid;
-                // Reset current undercooling to zero
                 UndercoolingCurrent(GlobalD3D1ConvPosition) = 0.0;
+                // If this cell melts at least one more time after the melting event that just took place, replace the
+                // value for melt time step with the next time step this cell goes above the liquidus
+                if (cellType != TempSolid) {
+                    // This cell either hasn't started or hasn't finished the previous solidification event, but has
+                    // undergone melting - increment the solidification counter to move on to the next
+                    // melt-solidification event and replace CritTimeStep and UndercoolingChange with the values
+                    // corresponding to this next event
+                    SolidificationEventCounter(D3D1ConvPosition)++;
+                    CritTimeStep(GlobalD3D1ConvPosition) = static_cast<int>(
+                        LayerTimeTempHistory(D3D1ConvPosition, SolidificationEventCounter(D3D1ConvPosition), 1));
+                    UndercoolingChange(GlobalD3D1ConvPosition) =
+                        LayerTimeTempHistory(D3D1ConvPosition, SolidificationEventCounter(D3D1ConvPosition), 2);
+                    // If this cell melts at least one more time after the melting event that just took place, replace
+                    // the value for melt time step with the next time step this cell goes above the liquidus
+                    if ((SolidificationEventCounter(D3D1ConvPosition) + 1) !=
+                        NumberOfSolidificationEvents(D3D1ConvPosition)) {
+                        MeltTimeStep(GlobalD3D1ConvPosition) = static_cast<int>(LayerTimeTempHistory(
+                            D3D1ConvPosition, SolidificationEventCounter(D3D1ConvPosition) + 1, 0));
+                    }
+                }
+                else if ((SolidificationEventCounter(D3D1ConvPosition) + 1) !=
+                         NumberOfSolidificationEvents(D3D1ConvPosition)) {
+                    // If this cell melts at least one more time after the melting event that just took place, replace
+                    // the value for melt time step with the next time step this cell goes above the liquidus
+                    MeltTimeStep(GlobalD3D1ConvPosition) = static_cast<int>(
+                        LayerTimeTempHistory(D3D1ConvPosition, SolidificationEventCounter(D3D1ConvPosition) + 1, 0));
+                }
+                // Any adjacent active cells should also be remelted, as these cells are more likely heating up than
+                // cooling down These are converted to the temporary FutureLiquid state, to be later iterated over and
+                // loaded into the steering vector as necessary
+                for (int l = 0; l < 26; l++) {
+                    // "l" correpsponds to the specific neighboring cell
+                    // Local coordinates of adjacent cell center
+                    int MyNeighborX = RankX + NeighborX[l];
+                    int MyNeighborY = RankY + NeighborY[l];
+                    int MyNeighborZ = RankZ + NeighborZ[l];
+                    if ((MyNeighborX >= 0) && (MyNeighborX < nx) && (MyNeighborY >= 0) && (MyNeighborY < MyYSlices) &&
+                        (MyNeighborZ < nzActive) && (MyNeighborZ >= 0)) {
+                        int GlobalNeighborD3D1ConvPosition =
+                            (MyNeighborZ + ZBound_Low) * nx * MyYSlices + MyNeighborX * MyYSlices + MyNeighborY;
+                        if (CellType(GlobalNeighborD3D1ConvPosition) == Active) {
+                            CellType(GlobalNeighborD3D1ConvPosition) = FutureLiquid;
+                            int NeighborD3D1ConvPosition =
+                                MyNeighborZ * nx * MyYSlices + MyNeighborX * MyYSlices + MyNeighborY;
+                            SteeringVector(Kokkos::atomic_fetch_add(&numSteer(0), 1)) = NeighborD3D1ConvPosition;
+                        }
+                    }
+                }
             }
             else if ((isNotSolid) && (pastCritTime)) {
                 // Update cell undercooling
@@ -152,27 +199,28 @@ void FillSteeringVector_Remelt(int cycle, int LocalActiveDomainSize, int nx, int
                     // Add active cells below liquidus to steering vector
                     SteeringVector(Kokkos::atomic_fetch_add(&numSteer(0), 1)) = D3D1ConvPosition;
                 }
-                else if ((cellType == Liquid) && (GrainID(GlobalD3D1ConvPosition) != 0)) {
-                    // If this cell borders at least one solid/tempsolid cell and is part of a grain, it should become
-                    // active
-                    for (int l = 0; l < 26; l++) {
-                        // "l" correpsponds to the specific neighboring cell
-                        // Local coordinates of adjacent cell center
-                        int MyNeighborX = RankX + NeighborX[l];
-                        int MyNeighborY = RankY + NeighborY[l];
-                        int MyNeighborZ = RankZ + NeighborZ[l];
-                        if ((MyNeighborX >= 0) && (MyNeighborX < nx) && (MyNeighborY >= 0) &&
-                            (MyNeighborY < MyYSlices) && (MyNeighborZ < nzActive) && (MyNeighborZ >= 0)) {
-                            int GlobalNeighborD3D1ConvPosition =
-                                (MyNeighborZ + ZBound_Low) * nx * MyYSlices + MyNeighborX * MyYSlices + MyNeighborY;
-                            if ((CellType(GlobalNeighborD3D1ConvPosition) == TempSolid) ||
-                                (CellType(GlobalNeighborD3D1ConvPosition) == Solid) || (RankZ == 0)) {
-                                // Cell activation to be performed as part of steering vector
-                                l = 26;
-                                SteeringVector(Kokkos::atomic_fetch_add(&numSteer(0), 1)) = D3D1ConvPosition;
-                                CellType(GlobalD3D1ConvPosition) =
-                                    FutureActive; // this cell cannot be captured - is being activated
-                            }
+            }
+            else if ((atCritTime) && (cellType == Liquid) && (GrainID(GlobalD3D1ConvPosition) != 0)) {
+                // If this cell has cooled to the liquidus temperature, borders at least one solid/tempsolid cell, and
+                // is part of a grain, it should become active. This only needs to be checked on the time step where the
+                // cell reaches the liquidus, not every time step beyond this
+                for (int l = 0; l < 26; l++) {
+                    // "l" correpsponds to the specific neighboring cell
+                    // Local coordinates of adjacent cell center
+                    int MyNeighborX = RankX + NeighborX[l];
+                    int MyNeighborY = RankY + NeighborY[l];
+                    int MyNeighborZ = RankZ + NeighborZ[l];
+                    if ((MyNeighborX >= 0) && (MyNeighborX < nx) && (MyNeighborY >= 0) && (MyNeighborY < MyYSlices) &&
+                        (MyNeighborZ < nzActive) && (MyNeighborZ >= 0)) {
+                        int GlobalNeighborD3D1ConvPosition =
+                            (MyNeighborZ + ZBound_Low) * nx * MyYSlices + MyNeighborX * MyYSlices + MyNeighborY;
+                        if ((CellType(GlobalNeighborD3D1ConvPosition) == TempSolid) ||
+                            (CellType(GlobalNeighborD3D1ConvPosition) == Solid) || (RankZ == 0)) {
+                            // Cell activation to be performed as part of steering vector
+                            l = 26;
+                            SteeringVector(Kokkos::atomic_fetch_add(&numSteer(0), 1)) = D3D1ConvPosition;
+                            CellType(GlobalD3D1ConvPosition) =
+                                FutureActive; // this cell cannot be captured - is being activated
                         }
                     }
                 }
@@ -191,8 +239,8 @@ void CellCapture(int, int np, int, int, int, int nx, int MyYSlices, InterfacialR
                  ViewI CellType, ViewF DOCenter, ViewI GrainID, int NGrainOrientations, Buffer2D BufferNorthSend,
                  Buffer2D BufferSouthSend, ViewI SendSizeNorth, ViewI SendSizeSouth, int ZBound_Low, int nzActive, int,
                  ViewI SteeringVector, ViewI numSteer, ViewI_H numSteer_Host, bool AtNorthBoundary,
-                 bool AtSouthBoundary, ViewI SolidificationEventCounter, ViewI MeltTimeStep,
-                 ViewF3D LayerTimeTempHistory, ViewI NumberOfSolidificationEvents, int &BufSize) {
+                 bool AtSouthBoundary, ViewI SolidificationEventCounter, ViewF3D LayerTimeTempHistory,
+                 ViewI NumberOfSolidificationEvents, int &BufSize) {
 
     // Loop over list of active and soon-to-be active cells, potentially performing cell capture events and updating
     // cell types
@@ -465,7 +513,7 @@ void CellCapture(int, int np, int, int, int, int nx, int MyYSlices, InterfacialR
                     SolidificationEventCounter(D3D1ConvPosition)++;
                     // Did the cell solidify for the last time in the layer?
                     // If so, this cell is solid - ignore until next layer (if needed)
-                    // If not, update MeltTimeStep, CritTimeStep, and UndercoolingChange with values for the next
+                    // If not, update CritTimeStep, and UndercoolingChange with values for the next
                     // solidification event, and change cell type to TempSolid
                     if (SolidificationEventCounter(D3D1ConvPosition) ==
                         NumberOfSolidificationEvents(D3D1ConvPosition)) {
@@ -473,8 +521,6 @@ void CellCapture(int, int np, int, int, int, int nx, int MyYSlices, InterfacialR
                     }
                     else {
                         CellType(GlobalD3D1ConvPosition) = TempSolid;
-                        MeltTimeStep(GlobalD3D1ConvPosition) = (int)(LayerTimeTempHistory(
-                            D3D1ConvPosition, SolidificationEventCounter(D3D1ConvPosition), 0));
                         CritTimeStep(GlobalD3D1ConvPosition) = (int)(LayerTimeTempHistory(
                             D3D1ConvPosition, SolidificationEventCounter(D3D1ConvPosition), 1));
                         UndercoolingChange(GlobalD3D1ConvPosition) =
@@ -530,6 +576,22 @@ void CellCapture(int, int np, int, int, int, int nx, int MyYSlices, InterfacialR
                     // Cell activation is now finished - cell type can be changed from TemporaryUpdate to Active
                     CellType(GlobalD3D1ConvPosition) = Active;
                 } // End if statement for serial/parallel code
+            }
+            else if (CellType(GlobalD3D1ConvPosition) == FutureLiquid) {
+                // This type was assigned to a cell that was recently transformed from active to liquid, due to its
+                // bordering of a cell above the liquidus. This information may need to be sent to other MPI ranks
+                bool DataFitsInBuffer =
+                    loadghostnodes_liquid(SendSizeNorth, SendSizeSouth, MyYSlices, GlobalX, RankY, RankZ,
+                                          AtNorthBoundary, AtSouthBoundary, BufferSouthSend, BufferNorthSend, BufSize);
+                if (!(DataFitsInBuffer)) {
+                    // This cell's data did not fit in the buffer with current size BufSize - mark with temporary
+                    // type
+                    CellType(GlobalD3D1ConvPosition) = LiquidFailedBufferLoad;
+                }
+                else {
+                    // Cell activation is now finished - cell type can be changed from FutureLiquid to Active
+                    CellType(GlobalD3D1ConvPosition) = Liquid;
+                }
             }
         });
     Kokkos::fence();

--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -88,7 +88,9 @@ void FillSteeringVector_NoRemelt(int cycle, int LocalActiveDomainSize, int nx, i
 void FillSteeringVector_Remelt(int cycle, int LocalActiveDomainSize, int nx, int MyYSlices, NList NeighborX,
                                NList NeighborY, NList NeighborZ, ViewI CritTimeStep, ViewF UndercoolingCurrent,
                                ViewF UndercoolingChange, ViewI CellType, ViewI GrainID, int ZBound_Low, int nzActive,
-                               ViewI SteeringVector, ViewI numSteer, ViewI_H numSteer_Host, ViewI MeltTimeStep);
+                               ViewI SteeringVector, ViewI numSteer, ViewI_H numSteer_Host, ViewI MeltTimeStep,
+                               ViewI SolidificationEventCounter, ViewI NumberOfSolidificationEvents,
+                               ViewF3D LayerTimeTempHistory);
 void CellCapture(int id, int np, int cycle, int LocalActiveDomainSize, int LocalDomainSize, int nx, int MyYSlices,
                  InterfacialResponseFunction irf, int MyYOffset, NList NeighborX, NList NeighborY, NList NeighborZ,
                  ViewI CritTimeStep, ViewF UndercoolingCurrent, ViewF UndercoolingChange, ViewF GrainUnitVector,
@@ -96,7 +98,7 @@ void CellCapture(int id, int np, int cycle, int LocalActiveDomainSize, int Local
                  int NGrainOrientations, Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, ViewI SendSizeNorth,
                  ViewI SendSizeSouth, int ZBound_Low, int nzActive, int nz, ViewI SteeringVector, ViewI numSteer_G,
                  ViewI_H numSteer_H, bool AtNorthBoundary, bool AtSouthBoundary, ViewI SolidificationEventCounter,
-                 ViewI MeltTimeStep, ViewF3D LayerTimeTempHistory, ViewI NumberOfSolidificationEvents, int &BufSize);
+                 ViewF3D LayerTimeTempHistory, ViewI NumberOfSolidificationEvents, int &BufSize);
 void JumpTimeStep(int &cycle, unsigned long int RemainingCellsOfInterest, unsigned long int LocalTempSolidCells,
                   ViewI MeltTimeStep, int LocalActiveDomainSize, int MyYSlices, int ZBound_Low, ViewI CellType,
                   ViewI LayerID, int id, int layernumber, int np, int nx, int ny, int nz, int MyYOffset, ViewI GrainID,

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -207,7 +207,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
             PowderInit(0, nx, ny, LayerHeight, ZMaxLayer, ZMin, deltax, MyYSlices, MyYOffset, id, GrainID, RNGSeed,
                        NextLayer_FirstEpitaxialGrainID, PowderActiveFraction);
         // Separate routine for active cell data structure init for problems other than constrained solidification
-        CellTypeInit(nx, MyYSlices, LocalActiveDomainSize, CellType, CritTimeStep, id, ZBound_Low);
+        CellTypeInit(nx, MyYSlices, LocalActiveDomainSize, CellType, NumberOfSolidificationEvents, id, ZBound_Low);
     }
     MPI_Barrier(MPI_COMM_WORLD);
     if (id == 0)
@@ -296,7 +296,9 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
             if (SimulationType != "C")
                 FillSteeringVector_Remelt(cycle, LocalActiveDomainSize, nx, MyYSlices, NeighborX, NeighborY, NeighborZ,
                                           CritTimeStep, UndercoolingCurrent, UndercoolingChange, CellType, GrainID,
-                                          ZBound_Low, nzActive, SteeringVector, numSteer, numSteer_Host, MeltTimeStep);
+                                          ZBound_Low, nzActive, SteeringVector, numSteer, numSteer_Host, MeltTimeStep,
+                                          SolidificationEventCounter, NumberOfSolidificationEvents,
+                                          LayerTimeTempHistory);
             else
                 FillSteeringVector_NoRemelt(cycle, LocalActiveDomainSize, nx, MyYSlices, CritTimeStep,
                                             UndercoolingCurrent, UndercoolingChange, CellType, ZBound_Low, layernumber,
@@ -309,8 +311,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                         CritDiagonalLength, DiagonalLength, CellType, DOCenter, GrainID, NGrainOrientations,
                         BufferNorthSend, BufferSouthSend, SendSizeNorth, SendSizeSouth, ZBound_Low, nzActive, nz,
                         SteeringVector, numSteer, numSteer_Host, AtNorthBoundary, AtSouthBoundary,
-                        SolidificationEventCounter, MeltTimeStep, LayerTimeTempHistory, NumberOfSolidificationEvents,
-                        BufSize);
+                        SolidificationEventCounter, LayerTimeTempHistory, NumberOfSolidificationEvents, BufSize);
             // Count the number of cells' in halo regions where the data did not fit into the send buffers
             // Reduce across all ranks, as the same BufSize should be maintained across all ranks
             // If any rank overflowed its buffer size, resize all buffers to the new size plus 10% padding
@@ -401,7 +402,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                            GrainID, RNGSeed, NextLayer_FirstEpitaxialGrainID, PowderActiveFraction);
 
             // Initialize active cell data structures and nuclei locations for the next layer "layernumber + 1"
-            CellTypeInit(nx, MyYSlices, LocalActiveDomainSize, CellType, CritTimeStep, id, ZBound_Low);
+            CellTypeInit(nx, MyYSlices, LocalActiveDomainSize, CellType, NumberOfSolidificationEvents, id, ZBound_Low);
 
             // Initialize potential nucleation event data for next layer "layernumber + 1"
             // Views containing nucleation data will be resized to the possible number of nuclei on a given MPI rank for


### PR DESCRIPTION
Code previously would wait for a cell to become solid before moving on to the next melt-solidification event - this is corrected by allowing incomplete solidification events (i.e., cell is still undercooled liquid or active) to be terminated to allow for remelting. Additionally, the check for placement of new active cells in undercooled liquid is only performed at the liquidus time step, and active cells bordering those that just went above the liquidus are removed (as they are more likely heating up than cooling down). This simplification/reduction in the number of active cells and reduction in the number of checks for active cell placement leads to a performance improvement of up to 10% for large problems, and avoids spurious cell capture events/active interface placement when a localized region is bordered by undercooled liquid on one side and superheated liquid on the other (which may happen at a beam turnaround in laser melting problems).

Also noted is that the transformation of active cells that border superheated liquid back into liquid necessitates communication across ranks, as this new rule depends on the local cell environment. This is handled in an analogous way to the active cell/future active type logic.

Closes #192 
