### PR TITLE
New problem type for solidification of a single grain in an initially liquid domain

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -54,6 +54,7 @@ The .json files in the examples subdirectory are provided on the command line to
 |Input                   | Equivalent from old input file format | Details |
 |------------------------|---------------------------------------|---------|
 | SimulationType         | Problem Type                          |         |
+|                        |                                       | `SingleGrain` for solidification of a single grain at the domain center, continuing until it reaches a domain edge
 |                        |                                       | C for directional solidification (thermal gradient in build direction, fixed cooling rate)
 |                        |                                       | S for spot melt array problem (fixed thermal gradient/constant cooling rate for each hemispherical spot)
 |                        |                                       | R for use of temperature data provided in the appropriate format (see README file in examples/Temperatures)
@@ -87,16 +88,17 @@ The .json files in the examples subdirectory are provided on the command line to
 | Input        | Equivalent from      | Relevant problem | Details |
 |              | old input file format| type(s)          |         |    
 |--------------| ---------------------|------------------| --------|
-|Density           | Heterogeneous nucleation density             | All| Density of heterogenous nucleation sites in the liquid (evenly distributed among cells that are liquid or undergo melting), normalized by 1 x 10^12 m^-3
-|MeanUndercooling  | Mean nucleation undercooling                 | All| Mean nucleation undercooling (relative to the alloy liquidus temperature) for activation of nucleation sites (Gaussian distribution)
-|StDevUndercooling | Standard deviation of nucleation undercooling| All| Standard deviation of nucleation undercooling (Gaussian distribution), in K
+|Density           | Heterogeneous nucleation density             | C, S, R | Density of heterogenous nucleation sites in the liquid (evenly distributed among cells that are liquid or undergo melting), normalized by 1 x 10^12 m^-3
+|MeanUndercooling  | Mean nucleation undercooling                 | C, S, R | Mean nucleation undercooling (relative to the alloy liquidus temperature) for activation of nucleation sites (Gaussian distribution)
+|StDevUndercooling | Standard deviation of nucleation undercooling| C, S, R | Standard deviation of nucleation undercooling (Gaussian distribution), in K
 
 ## Temperature inputs
 | Input        | Equivalent from      | Relevant problem | Details |
 |              | old input file format| type(s)          |         |    
 |--------------| ---------------------|------------------| --------|
-|G             | Thermal gradient             | C, S | Thermal gradient in the build (+Z) directions, in K/m
-|R             | Cooling rate                 | C, S | Cooling rate (uniform across the domain), in K/s
+|G             | Thermal gradient     | SingleGrain, C, S | Thermal gradient in the build (+Z) directions, in K/m
+|R             | Cooling rate         | SingleGrain, C, S | Cooling rate (uniform across the domain), in K/s
+|InitUndercooling | N/A               | SingleGrain      | Undercooling at the location of the seeded grain 
 |HeatTransferCellSize | Heat transport data mesh size| R    | By default, equal to deltax, and cannot be used if remelting is considered. deltax must divide evenly into HTdeltax
 |LayerwiseTempRead| Discard temperature data and reread temperature files after each layer | R | If set to Y, the appropriate temperature data will be read during each layer's initialization, stored temporarily, and discarded. If set to N, temperature data for all layers will be read and stored during code initialization, and initialization of each layer will be performed using this stored temperature data. This option is only applicable to simulations with remelting; simulations without remelting (and simulations where this input is not given) default to N. Setting this to Y is only recommended if a large quantity of temperature data is read by ExaCA (for example, a 10 layer simulation where each layer's temperature data comes from a different file).
 |TemperatureFiles | N/A | R | List of files corresponding to each layer's temperature data, in the form ["filename1.csv","filename2.csv",...]. If the number of entries is less than numberOfLayers, the list is repeated. Note that if the Z coordinate of the top surface for each data set has the layer offset applied, layerOffset in the "Domain" section of the input file should be set to 0, to avoid offsetting the layers twice.
@@ -110,6 +112,7 @@ The .json files in the examples subdirectory are provided on the command line to
 |SubstrateFilename | Substrate filename       | S, R     | Path to and filename for substrate data (see note (a))
 |PowderDensity | Density of powder surface sites active | S, R | Density of sites in the powder layer to be assigned as the home of a unique grain, normalized by 1 x 10^12 m^-3 (default value is 1/(CA cell size ^3) (see note (b))
 |ExtendSubstrateThroughPower| Extend baseplate through layers | S, R | true/false value: Whether to use the baseplate microstructure as the boundary condition for the entire height of the simulation (defaults to false) (see note (b))
+|GrainOrientation | N/A               | SingleGrain      | Which orientation from the orientation's file is assigned to the grain (starts at 0). Default is 0 
 
 (a) One of these inputs must be provided, but not both
 (b) This is optional, but if this is given, "extendSubstrateThroughPower" must be set to false

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -26,7 +26,8 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
                        int &NSpotsY, int &SpotOffset, int &SpotRadius, bool &PrintTimeSeries, int &TimeSeriesInc,
                        bool &PrintIdleTimeSeriesFrames, bool &PrintDefaultRVE, double &RNGSeed,
                        bool &BaseplateThroughPowder, double &PowderActiveFraction, int &RVESize,
-                       bool &LayerwiseTempRead, bool &PrintBinary, bool &PowderFirstLayer);
+                       bool &LayerwiseTempRead, bool &PrintBinary, bool &PowderFirstLayer, double &InitUndercooling,
+                       int &SingleGrainOrientation);
 void checkPowderOverflow(int nx, int ny, int LayerHeight, int NumberOfLayers, bool BaseplateThroughPowder,
                          double PowderDensity);
 void NeighborListInit(NList &NeighborX, NList &NeighborY, NList &NeighborZ);
@@ -47,10 +48,12 @@ int calcZBound_High(std::string SimulationType, int SpotRadius, int LayerHeight,
                     double deltax, int nz, double *ZMaxLayer);
 int calcnzActive(int ZBound_Low, int ZBound_High, int id, int layernumber);
 int calcLocalActiveDomainSize(int nx, int MyYSlices, int nzActive);
-void TempInit_DirSolidification(double G, double R, int id, int &nx, int &MyYSlices, double deltax, double deltat,
-                                int nz, int LocalDomainSize, ViewI &CritTimeStep, ViewF &UndercoolingChange,
-                                ViewI &LayerID, ViewI &NumberOfSolidificationEvents, ViewI &SolidificationEventCounter,
-                                ViewI &MeltTimeStep, ViewI MaxSolidificationEvents, ViewF3D &LayerTimeTempHistory);
+void TempInit_UnidirectionalGradient(double G, double R, int, int &nx, int &MyYSlices, double deltax, double deltat,
+                                     int nz, int LocalDomainSize, ViewI &CritTimeStep, ViewF &UndercoolingChange,
+                                     ViewI &LayerID, ViewI &NumberOfSolidificationEvents,
+                                     ViewI &SolidificationEventCounter, ViewI &MeltTimeStep,
+                                     ViewI MaxSolidificationEvents, ViewF3D &LayerTimeTempHistory,
+                                     double InitUndercooling, ViewF &UndercoolingCurrent, std::string SimulationType);
 int calcMaxSolidificationEventsSpot(int nx, int MyYSlices, int NumberOfSpots, int NSpotsX, int SpotRadius,
                                     int SpotOffset, int MyYOffset);
 void OrientationInit(int id, int &NGrainOrientations, ViewF &ReadOrientationData, std::string GrainOrientationFile,
@@ -96,6 +99,10 @@ void SubstrateInit_ConstrainedGrowth(int id, double FractSurfaceSitesActive, int
                                      int MyYOffset, NList NeighborX, NList NeighborY, NList NeighborZ,
                                      ViewF GrainUnitVector, int NGrainOrientations, ViewI CellType, ViewI GrainID,
                                      ViewF DiagonalLength, ViewF DOCenter, ViewF CritDiagonalLength, double RNGSeed);
+void SubstrateInit_SingleGrain(int id, int SingleGrainOrientation, int nx, int ny, int nz, int MyYSlices, int MyYOffset,
+                               int LocalActiveDomainSize, NList NeighborX, NList NeighborY, NList NeighborZ,
+                               ViewF GrainUnitVector, ViewI CellType, ViewI GrainID, ViewF DiagonalLength,
+                               ViewF DOCenter, ViewF CritDiagonalLength);
 int getBaseplateSizeZ(int nz, double *ZMaxLayer, double ZMin, double deltax, int LayerHeight,
                       bool BaseplateThroughPowder, bool PowderFirstLayer);
 void SubstrateInit_FromFile(std::string SubstrateFileName, int nz, int nx, int MyYSlices, int MyYOffset, int pid,

--- a/src/CAtypes.hpp
+++ b/src/CAtypes.hpp
@@ -28,6 +28,7 @@ typedef Kokkos::View<int *, Kokkos::MemoryTraits<Kokkos::Atomic>> View_a;
 typedef Kokkos::View<float **> Buffer2D;
 typedef Kokkos::View<float *> TestView;
 typedef Kokkos::View<float ***> ViewF3D;
+typedef Kokkos::View<bool **> ViewB2D;
 
 using exe_space = Kokkos::DefaultExecutionSpace::execution_space;
 using device_memory_space = Kokkos::DefaultExecutionSpace::memory_space;
@@ -40,6 +41,7 @@ typedef Kokkos::View<int *, layout, Kokkos::HostSpace> ViewI_H;
 typedef Kokkos::View<int **, layout, Kokkos::HostSpace> ViewI2D_H;
 typedef Kokkos::View<int ***, layout, Kokkos::HostSpace> ViewI3D_H;
 typedef Kokkos::View<float **, layout, Kokkos::HostSpace> Buffer2D_H;
+typedef Kokkos::View<bool **, layout, Kokkos::HostSpace> ViewB2D_H;
 
 typedef Kokkos::Array<int, 26> NList;
 

--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -123,5 +123,7 @@ void IntermediateOutputAndCheck_Remelt(
     int ZBound_Low, int NGrainOrientations, ViewI LayerID, ViewF GrainUnitVector, ViewF UndercoolingChange,
     ViewF UndercoolingCurrent, std::string PathToOutput, std::string OutputFile, bool PrintIdleMovieFrames,
     int MovieFrameInc, int &IntermediateFileCounter, int NumberOfLayers, ViewI MeltTimeStep, bool PrintBinary);
+void IntermediateOutputAndCheck_SingleGrain(int id, int cycle, int MyYSlices, int MyYOffset, int LocalActiveDomainSize,
+                                            int nx, int ny, int nz, int &XSwitch, ViewI CritTimeStep, ViewI CellType);
 
 #endif

--- a/unit_test/tstInit.cpp
+++ b/unit_test/tstInit.cpp
@@ -118,10 +118,10 @@ void testInputReadFromFile(bool PrintDebugFiles) {
     // Read and parse each input file
     for (auto FileName : InputFilenames) {
         int TempFilesInSeries, NumberOfLayers, LayerHeight, nx, ny, nz, PrintDebug, NSpotsX, NSpotsY, SpotOffset,
-            SpotRadius, TimeSeriesInc, RVESize;
+            SpotRadius, TimeSeriesInc, RVESize, SingleGrainOrientation;
         float SubstrateGrainSpacing;
         double deltax, NMax, dTN, dTsigma, HT_deltax, deltat, G, R, FractSurfaceSitesActive, RNGSeed,
-            PowderActiveFraction;
+            PowderActiveFraction, InitUndercooling;
         bool RemeltingYN, PrintMisorientation, PrintFinalUndercoolingVals, PrintFullOutput, PrintTimeSeries,
             UseSubstrateFile, PrintIdleTimeSeriesFrames, PrintDefaultRVE = false, BaseplateThroughPowder,
                                                          LayerwiseTempRead, PrintBinary, PowderFirstLayer;
@@ -136,7 +136,7 @@ void testInputReadFromFile(bool PrintDebugFiles) {
                           PrintFinalUndercoolingVals, PrintFullOutput, NSpotsX, NSpotsY, SpotOffset, SpotRadius,
                           PrintTimeSeries, TimeSeriesInc, PrintIdleTimeSeriesFrames, PrintDefaultRVE, RNGSeed,
                           BaseplateThroughPowder, PowderActiveFraction, RVESize, LayerwiseTempRead, PrintBinary,
-                          PowderFirstLayer);
+                          PowderFirstLayer, InitUndercooling, SingleGrainOrientation);
         InterfacialResponseFunction irf(0, MaterialFileName, deltat, deltax);
 
         // Check the results

--- a/unit_test/tstKokkosInit.hpp
+++ b/unit_test/tstKokkosInit.hpp
@@ -79,11 +79,121 @@ void testOrientationInit_Angles() {
     }
 }
 
+// Test unidirectional solidification problem for either directional solidification or growth of a single grain seed,
+// with thermal gradient G in the domain
+void testTempInit_UnidirectionalGradient(std::string SimulationType, double G) {
+
+    int nx = 2;
+    int ny = 1;
+    int nz = 5; // (Front is at Z = 0 for directional growth, single grain seed at Z = 2 for singlegrain problem)
+    int kCenter = floorf(static_cast<float>(nz) / 2.0);
+    int LocalDomainSize = nx * ny * nz;
+    double InitUndercooling = 10; // Used only for single grain problem
+
+    // For problems with non-zero thermal gradient, 1 K difference between each cell and its neighbor in Z
+    double deltax;
+    if (G == 0)
+        deltax = 1 * pow(10, -6);
+    else
+        deltax = 1.0 / G;
+    double GNorm = G * deltax;
+    // Cells cool at rate of 1 K per time step
+    double R = 1000000;
+    double deltat = 1 * pow(10, -6);
+    double RNorm = R * deltat;
+
+    // Temperature views
+    ViewI CritTimeStep(Kokkos::ViewAllocateWithoutInitializing("CritTimeStep"), LocalDomainSize);
+    ViewF UndercoolingChange(Kokkos::ViewAllocateWithoutInitializing("UndercoolingChange"), LocalDomainSize);
+    ViewI LayerID(Kokkos::ViewAllocateWithoutInitializing("LayerID"), LocalDomainSize);
+    ViewI NumberOfSolidificationEvents(Kokkos::ViewAllocateWithoutInitializing("NumberOfSolidificationEvents"),
+                                       LocalDomainSize);
+    ViewI SolidificationEventCounter(Kokkos::ViewAllocateWithoutInitializing("SolidificationEventCounter"),
+                                     LocalDomainSize);
+    ViewI MeltTimeStep(Kokkos::ViewAllocateWithoutInitializing("MeltTimeStep"), LocalDomainSize);
+    ViewI MaxSolidificationEvents(Kokkos::ViewAllocateWithoutInitializing("MaxSolidificationEvents"), 1);
+    ViewF UndercoolingCurrent(Kokkos::ViewAllocateWithoutInitializing("UndercoolingCurrent"), LocalDomainSize);
+    ViewF3D LayerTimeTempHistory(Kokkos::ViewAllocateWithoutInitializing("LayerTimeTempHistory"), LocalDomainSize, 1,
+                                 3);
+
+    TempInit_UnidirectionalGradient(G, R, 0, nx, ny, deltax, deltat, nz, LocalDomainSize, CritTimeStep,
+                                    UndercoolingChange, LayerID, NumberOfSolidificationEvents,
+                                    SolidificationEventCounter, MeltTimeStep, MaxSolidificationEvents,
+                                    LayerTimeTempHistory, InitUndercooling, UndercoolingCurrent, SimulationType);
+
+    // Copy temperature views back to host
+    // Copy orientation data back to the host
+    ViewI_H CritTimeStep_Host = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), CritTimeStep); // Copy orientation data back to the host
+    ViewF_H UndercoolingChange_Host = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), UndercoolingChange); // Copy orientation data back to the host
+    ViewI_H LayerID_Host =
+        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), LayerID); // Copy orientation data back to the host
+    ViewI_H NumberOfSolidificationEvents_Host = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), NumberOfSolidificationEvents); // Copy orientation data back to the host
+    ViewI_H SolidificationEventCounter_Host = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), SolidificationEventCounter); // Copy orientation data back to the host
+    ViewI_H MeltTimeStep_Host = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), MeltTimeStep); // Copy orientation data back to the host
+    ViewI_H MaxSolidificationEvents_Host = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), MaxSolidificationEvents); // Copy orientation data back to the host
+    ViewF_H UndercoolingCurrent_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), UndercoolingCurrent);
+    ViewF3D_H LayerTimeTempHistory_Host =
+        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), LayerTimeTempHistory);
+
+    // Check results
+    EXPECT_EQ(MaxSolidificationEvents_Host(0), 1);
+    for (int k = 0; k < nz; k++) {
+        for (int i = 0; i < nx; i++) {
+            for (int j = 0; j < ny; j++) {
+                int D3D1ConvPosition = k * nx * ny + i * ny + j;
+                // Each cell solidifies once, and counter should start at 0, associated with the zeroth layer
+                // MeltTimeStep should be -1 for all cells
+                // Cells cool at 1 K per time step
+                EXPECT_FLOAT_EQ(MeltTimeStep_Host(D3D1ConvPosition), -1.0);
+                EXPECT_FLOAT_EQ(UndercoolingChange_Host(D3D1ConvPosition), RNorm);
+                EXPECT_EQ(NumberOfSolidificationEvents_Host(D3D1ConvPosition), 1);
+                EXPECT_EQ(SolidificationEventCounter(D3D1ConvPosition), 0);
+                EXPECT_EQ(LayerID_Host(D3D1ConvPosition), 0);
+                if (SimulationType == "C") {
+                    // Directional solidification
+                    // UndercoolingCurrent should be 0 for all cells
+                    // CritTimeStep is equivalent to the Z coordinate of the cell
+                    EXPECT_FLOAT_EQ(UndercoolingCurrent_Host(D3D1ConvPosition), 0.0);
+                    EXPECT_FLOAT_EQ(CritTimeStep_Host(D3D1ConvPosition), k);
+                }
+                else if (SimulationType == "SingleGrain") {
+                    // Single grain
+                    // UndercooliongCurrent depends on the undercooling set at the domain center and the thermal
+                    // gradient CritTimeStep depends on the distance from the liquidus (all cells are already
+                    // undercooled, so these values are negative)
+                    EXPECT_FLOAT_EQ(UndercoolingCurrent_Host(D3D1ConvPosition),
+                                    InitUndercooling - GNorm * (k - kCenter));
+                    EXPECT_FLOAT_EQ(CritTimeStep_Host(D3D1ConvPosition), -InitUndercooling + GNorm * (k - kCenter));
+                }
+                // Check that the data was copied into the time-temperature history view correctly
+                EXPECT_FLOAT_EQ(static_cast<float>(MeltTimeStep_Host(D3D1ConvPosition)),
+                                LayerTimeTempHistory_Host(D3D1ConvPosition, 0, 0));
+                EXPECT_FLOAT_EQ(static_cast<float>(CritTimeStep_Host(D3D1ConvPosition)),
+                                LayerTimeTempHistory_Host(D3D1ConvPosition, 0, 1));
+                EXPECT_FLOAT_EQ(UndercoolingChange_Host(D3D1ConvPosition),
+                                LayerTimeTempHistory_Host(D3D1ConvPosition, 0, 2));
+            }
+        }
+    }
+}
 //---------------------------------------------------------------------------//
 // RUN TESTS
 //---------------------------------------------------------------------------//
 TEST(TEST_CATEGORY, orientation_init_tests) {
     testOrientationInit_Vectors();
     testOrientationInit_Angles();
+}
+TEST(TEST_CATEGORY, temp_init_tests) {
+    // Test for directional and single grain problems, and with and without a thermal gradient for the single grain
+    // problem
+    testTempInit_UnidirectionalGradient("C", 1000000);
+    testTempInit_UnidirectionalGradient("SingleGrain", 0);
+    testTempInit_UnidirectionalGradient("SingleGrain", 1000000);
 }
 } // end namespace Test


### PR DESCRIPTION
The temperature initialization routine was repurposed to allow initialization of both the single grain problem and the directional solidification problem, as both have unidirectional thermal gradients and cooling rates in initially liquid domains. The single grain problem is also unique in the fact that it does not continue until the active layer or the simulation domain has fully solidified, but stops when the grain reaches a simulation edge - this is accounted for in a new `IntermediateOutputAndCheck` routine that is called each time step
Also includes new unit tests for the new substrate init routine, the modified temperature init routine, and the new intermediate output and check routine