### PR TITLE
CellData struct for celltype, grainid, layerid, with subviews

### DIFF
--- a/src/CAcelldata.hpp
+++ b/src/CAcelldata.hpp
@@ -86,8 +86,8 @@ struct CellData {
         }
 
         // Copy views of substrate grain locations back to the device
-        auto ActCellX_Device = Kokkos::create_mirror_view_and_copy(device_memory_space(), ActCellX_Host);
-        auto ActCellY_Device = Kokkos::create_mirror_view_and_copy(device_memory_space(), ActCellY_Host);
+        auto ActCellX_Device = Kokkos::create_mirror_view_and_copy(memory_space(), ActCellX_Host);
+        auto ActCellY_Device = Kokkos::create_mirror_view_and_copy(memory_space(), ActCellY_Host);
 
         // Start with all cells as liquid prior to locating substrate grain seeds
         // All cells have LayerID = 0 as this is not a multilayer problem
@@ -242,7 +242,7 @@ struct CellData {
         }
         Substrate.close();
         // Copy GrainIDs read from file to device
-        GrainID_AllLayers = Kokkos::create_mirror_view_and_copy(device_memory_space(), GrainID_AllLayers_Host);
+        GrainID_AllLayers = Kokkos::create_mirror_view_and_copy(memory_space(), GrainID_AllLayers_Host);
         if (id == 0)
             std::cout << "Substrate file read complete" << std::endl;
     }
@@ -304,10 +304,9 @@ struct CellData {
         }
 
         // Copy baseplate views to the device
-        auto BaseplateGrainIDs_Device =
-            Kokkos::create_mirror_view_and_copy(device_memory_space(), BaseplateGrainIDs_Host);
+        auto BaseplateGrainIDs_Device = Kokkos::create_mirror_view_and_copy(memory_space(), BaseplateGrainIDs_Host);
         auto BaseplateGrainLocations_Device =
-            Kokkos::create_mirror_view_and_copy(device_memory_space(), BaseplateGrainLocations_Host);
+            Kokkos::create_mirror_view_and_copy(memory_space(), BaseplateGrainLocations_Host);
         if (id == 0) {
             std::cout << "Baseplate spanning domain coordinates Z = 0 through " << BaseplateSizeZ - 1 << std::endl;
             std::cout << "Number of baseplate grains: " << NumberOfBaseplateGrains << std::endl;
@@ -393,7 +392,7 @@ struct CellData {
         std::shuffle(PowderGrainIDs.begin(), PowderGrainIDs.end(), gen);
         // Wrap powder layer GrainIDs into an unmanaged view, then copy to the device
         view_type_int_unmanaged PowderGrainIDs_Host(PowderGrainIDs.data(), PowderLayerCells);
-        auto PowderGrainIDs_Device = Kokkos::create_mirror_view_and_copy(device_memory_space(), PowderGrainIDs_Host);
+        auto PowderGrainIDs_Device = Kokkos::create_mirror_view_and_copy(memory_space(), PowderGrainIDs_Host);
         // Associate powder grain IDs with CA cells in the powder layer
         // Use bounds from temperature field for this layer to determine which cells are part of the powder
         int PowderTopZ = round((ZMaxLayer[layernumber] - ZMin) / deltax) + 1;

--- a/src/CAcelldata.hpp
+++ b/src/CAcelldata.hpp
@@ -1,0 +1,501 @@
+// Copyright 2021-2023 Lawrence Livermore National Security, LLC and other ExaCA Project Developers.
+// See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#ifndef EXACA_CELLDATA_HPP
+#define EXACA_CELLDATA_HPP
+
+#include "CAconfig.hpp"
+#include "CAfunctions.hpp"
+#include "CAtypes.hpp"
+#include "mpi.h"
+
+#include <Kokkos_Core.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+// Data that belongs to individual cells governing the current state and various ID values
+struct CellData {
+
+    using view_type_int_host = Kokkos::View<int *, layout, Kokkos::HostSpace>;
+    int NextLayer_FirstEpitaxialGrainID, BottomOfCurrentLayer, TopOfCurrentLayer;
+    ViewI GrainID_AllLayers, CellType_AllLayers, LayerID_AllLayers;
+
+    // Constructor for views and view bounds for current layer
+    // TODO: CellType is only needed for the current layer, and LayerID is only needed for all layers/no subview is
+    // needed. Leaving them as-is for now each with the "AllLayers" and "Current layer/subview slice" to minimize
+    // changes to the rest of the code to accomodate. GrainID is initialized to zeros, while others are not initialized
+    CellData(int LocalDomainSize, int LocalActiveDomainSize, int nx, int MyYSlices, int ZBound_Low)
+        : GrainID_AllLayers(ViewI("GrainID", LocalDomainSize))
+        , CellType_AllLayers(ViewI(Kokkos::ViewAllocateWithoutInitializing("CellType"), LocalDomainSize))
+        , LayerID_AllLayers(ViewI(Kokkos::ViewAllocateWithoutInitializing("LayerID"), LocalDomainSize)) {
+
+        BottomOfCurrentLayer = ZBound_Low * nx * MyYSlices;
+        TopOfCurrentLayer = BottomOfCurrentLayer + LocalActiveDomainSize;
+    }
+
+    // Initializes cell types and epitaxial Grain ID values where substrate grains are active cells on the bottom
+    // surface of the constrained domain. Also initialize active cell data structures associated with the substrate
+    // grains
+    void substrate_init_dirsol(int id, double FractSurfaceSitesActive, int MyYSlices, int nx, int ny, int MyYOffset,
+                               NList NeighborX, NList NeighborY, NList NeighborZ, ViewF GrainUnitVector,
+                               int NGrainOrientations, ViewF DiagonalLength, ViewF DOCenter, ViewF CritDiagonalLength,
+                               double RNGSeed) {
+
+        // Calls to Xdist(gen) and Y dist(gen) return random locations for grain seeds
+        // Since X = 0 and X = nx-1 are the cell centers of the last cells in X, locations are evenly scattered between
+        // X = -0.49999 and X = nx - 0.5, as the cells have a half width of 0.5
+        std::mt19937_64 gen(RNGSeed);
+        std::uniform_real_distribution<double> Xdist(-0.49999, nx - 0.5);
+        std::uniform_real_distribution<double> Ydist(-0.49999, ny - 0.5);
+
+        // Determine number of active cells from the fraction of sites active and the number of sites on the bottom
+        // domain surface
+        int SubstrateActCells = std::round(FractSurfaceSitesActive * nx * ny);
+
+        // On all ranks, generate active site locations - same list on every rank
+        // TODO: Generate random numbers on GPU, instead of using host view and copying over - ensure that locations are
+        // in the same order every time based on the RNGSeed
+        ViewI_H ActCellX_Host(Kokkos::ViewAllocateWithoutInitializing("ActCellX_Host"), SubstrateActCells);
+        ViewI_H ActCellY_Host(Kokkos::ViewAllocateWithoutInitializing("ActCellY_Host"), SubstrateActCells);
+
+        // Randomly locate substrate grain seeds for cells in the interior of this subdomain (at the k = 0 bottom
+        // surface)
+        for (int n = 0; n < SubstrateActCells; n++) {
+            double XLocation = Xdist(gen);
+            double YLocation = Ydist(gen);
+            // Randomly select integer coordinates between 0 and nx-1 or ny-1
+            ActCellX_Host(n) = round(XLocation);
+            ActCellY_Host(n) = round(YLocation);
+        }
+
+        // Copy views of substrate grain locations back to the device
+        ViewI ActCellX_Device = Kokkos::create_mirror_view_and_copy(device_memory_space(), ActCellX_Host);
+        ViewI ActCellY_Device = Kokkos::create_mirror_view_and_copy(device_memory_space(), ActCellY_Host);
+
+        // Start with all cells as liquid prior to locating substrate grain seeds
+        // All cells have LayerID = 0 as this is not a multilayer problem
+        Kokkos::deep_copy(CellType_AllLayers, Liquid);
+        Kokkos::deep_copy(LayerID_AllLayers, 0);
+        auto CellType_AllLayers_local = CellType_AllLayers;
+        auto GrainID_AllLayers_local = GrainID_AllLayers;
+
+        // Determine which grains/active cells belong to which MPI ranks
+        Kokkos::parallel_for(
+            "ConstrainedGrainInit", SubstrateActCells, KOKKOS_LAMBDA(const int &n) {
+                // What are the X and Y coordinates of this active cell relative to the X and Y bounds of this rank?
+                if ((ActCellY_Device(n) >= MyYOffset) && (ActCellY_Device(n) < MyYOffset + MyYSlices)) {
+                    // Convert X and Y coordinates to values relative to this MPI rank's grid (Z = 0 for these active
+                    // cells, at bottom surface) GrainIDs come from the position on the list of substrate active cells
+                    // to avoid reusing the same value
+                    int GlobalX = ActCellX_Device(n);
+                    int LocalY = ActCellY_Device(n) - MyYOffset;
+                    int D3D1ConvPosition = GlobalX * MyYSlices + LocalY;
+                    CellType_AllLayers_local(D3D1ConvPosition) = Active;
+                    GrainID_AllLayers_local(D3D1ConvPosition) = n + 1; // assign GrainID > 0 to epitaxial seeds
+                    // Initialize active cell data structures
+                    int GlobalY = LocalY + MyYOffset;
+                    int GlobalZ = 0;
+                    // Initialize new octahedron
+                    createNewOctahedron(D3D1ConvPosition, DiagonalLength, DOCenter, GlobalX, GlobalY, GlobalZ);
+
+                    // The orientation for the new grain will depend on its Grain ID
+                    int MyOrientation = getGrainOrientation(n + 1, NGrainOrientations);
+                    float cx = GlobalX + 0.5;
+                    float cy = GlobalY + 0.5;
+                    float cz = GlobalZ + 0.5;
+                    // Calculate critical values at which this active cell leads to the activation of a neighboring
+                    // liquid cell. Octahedron center and cell center overlap for octahedra created as part of a new
+                    // grain
+                    calcCritDiagonalLength(D3D1ConvPosition, cx, cy, cz, cx, cy, cz, NeighborX, NeighborY, NeighborZ,
+                                           MyOrientation, GrainUnitVector, CritDiagonalLength);
+                }
+            });
+        if (id == 0)
+            std::cout << "Number of substrate active cells across all ranks: " << SubstrateActCells << std::endl;
+    }
+
+    void substrate_init(std::string SubstrateFileName, bool UseSubstrateFile, bool BaseplateThroughPowder,
+                        bool PowderFirstLayer, int nx, int ny, int nz, int LayerHeight, int LocalActiveDomainSize,
+                        double *ZMaxLayer, double ZMin, double deltax, int MyYSlices, int MyYOffset, int ZBound_Low,
+                        int id, double RNGSeed, double SubstrateGrainSpacing, double PowderActiveFraction,
+                        ViewI NumberOfSolidificationEvents) {
+
+        // Generate the baseplate microstructure, or read it from a file, to initialize the grain ID values
+        if (UseSubstrateFile)
+            init_baseplate_grainid_fromfile(SubstrateFileName, nz, nx, MyYSlices, MyYOffset, id, ZMin, ZMaxLayer,
+                                            BaseplateThroughPowder, PowderFirstLayer, LayerHeight, deltax);
+        else
+            init_baseplate_grainid_fromspacing(SubstrateGrainSpacing, nx, ny, ZMin, ZMaxLayer, MyYSlices, MyYOffset, id,
+                                               deltax, RNGSeed, nz, BaseplateThroughPowder, PowderFirstLayer,
+                                               LayerHeight);
+
+        // Optionally generate powder grain structure grain IDs for top of layer 0
+        if (PowderFirstLayer)
+            init_powder_grainid(0, nx, ny, LayerHeight, ZMaxLayer, ZMin, deltax, MyYSlices, MyYOffset, id, RNGSeed,
+                                PowderActiveFraction);
+
+        // LayerID starts at -1 for all cells
+        Kokkos::deep_copy(LayerID_AllLayers, -1);
+
+        // Initialize cell types and layer IDs based on whether cells will solidify in layer 0 or not
+        init_celltype_layerid(0, nx, MyYSlices, LocalActiveDomainSize, NumberOfSolidificationEvents, id, ZBound_Low);
+    }
+
+    // Determine the height of the baseplate, in CA cells
+    // The baseplate always starts at the simulation bottom (Z coordinate corresponding to ZMin), regardless of whether
+    // the first layer melts the cells at the bottom or not If BaseplateThroughPowder is true, the baseplate
+    // microstructure extends through the entire simulation domain in Z If BaseplateThroughPowder is false and
+    // PowderFirstLayer is true, the baseplate extends to the Z coordinate that is LayerHeight cells short of the top of
+    // the first layer (the final LayerHeight cells of the first layer will be initialized using the powder options
+    // specified)) If BaseplateThroughPowder is false and PowderFirstLayer is false, the baseplate extends to the top of
+    // the first layer
+    int get_baseplate_size_z(int nz, double *ZMaxLayer, double ZMin, double deltax, int LayerHeight,
+                             bool BaseplateThroughPowder, bool PowderFirstLayer) {
+        int BaseplateSizeZ;
+        if (BaseplateThroughPowder)
+            BaseplateSizeZ = nz;
+        else {
+            if (PowderFirstLayer)
+                BaseplateSizeZ = round((ZMaxLayer[0] - ZMin) / deltax) + 1 - LayerHeight;
+
+            else
+                BaseplateSizeZ = round((ZMaxLayer[0] - ZMin) / deltax) + 1;
+        }
+        return BaseplateSizeZ;
+    }
+
+    // Initializes Grain ID values where the substrate comes from a file
+    void init_baseplate_grainid_fromfile(std::string SubstrateFileName, int nz, int nx, int MyYSlices, int MyYOffset,
+                                         int id, double ZMin, double *ZMaxLayer, bool BaseplateThroughPowder,
+                                         bool PowderFirstLayer, int LayerHeight, double deltax) {
+
+        // Assign GrainID values to cells that are part of the substrate - read values from file and initialize using
+        // temporary host view
+        view_type_int_host GrainID_AllLayers_Host(Kokkos::ViewAllocateWithoutInitializing("GrainID_Host"),
+                                                  nx * MyYSlices * nz);
+        std::ifstream Substrate;
+        Substrate.open(SubstrateFileName);
+        int Substrate_LowY = MyYOffset;
+        int Substrate_HighY = MyYOffset + MyYSlices;
+        int nxS, nyS, nzS;
+        int BaseplateSizeZ = get_baseplate_size_z(nz, ZMaxLayer, ZMin, deltax, LayerHeight, BaseplateThroughPowder,
+                                                  PowderFirstLayer); // in CA cells
+        if ((id == 0) && (BaseplateSizeZ < 1))
+            std::cout
+                << "Warning: No substrate data from the file be used, as the powder layer extends further in the Z "
+                   "direction than the first layer's temperature data"
+                << std::endl;
+        std::string s;
+        getline(Substrate, s);
+        std::size_t found = s.find("=");
+        std::string str = s.substr(found + 1, s.length() - 1);
+        nzS = stoi(str, nullptr, 10);
+        getline(Substrate, s);
+        found = s.find("=");
+        str = s.substr(found + 1, s.length() - 1);
+        nyS = stoi(str, nullptr, 10);
+        getline(Substrate, s);
+        found = s.find("=");
+        str = s.substr(found + 1, s.length() - 1);
+        nxS = stoi(str, nullptr, 10);
+        if ((id == 0) && (nzS < BaseplateSizeZ)) {
+            // Do not allow simulation if there is inssufficient substrate data in the specified file
+            std::string error =
+                "Error: only " + std::to_string(nzS) + " layers of substrate data are present in the file " +
+                SubstrateFileName + " ; at least " + std::to_string(BaseplateSizeZ) +
+                " layers of substrate data are required to simulate the specified solidification problem";
+            throw std::runtime_error(error);
+        }
+
+        // Assign GrainID values to all cells - cells that will be part of the melt pool footprint may still need their
+        // initial GrainID
+        for (int k = 0; k < nzS; k++) {
+            if (k == BaseplateSizeZ)
+                break;
+            for (int j = 0; j < nyS; j++) {
+                for (int i = 0; i < nxS; i++) {
+                    std::string GIDVal;
+                    getline(Substrate, GIDVal);
+                    if ((j >= Substrate_LowY) && (j < Substrate_HighY)) {
+                        int CAGridLocation;
+                        CAGridLocation = k * nx * MyYSlices + i * MyYSlices + (j - MyYOffset);
+                        GrainID_AllLayers_Host(CAGridLocation) = stoi(GIDVal, nullptr, 10);
+                    }
+                }
+            }
+        }
+        Substrate.close();
+        // Copy GrainIDs read from file to device
+        GrainID_AllLayers = Kokkos::create_mirror_view_and_copy(device_memory_space(), GrainID_AllLayers_Host);
+        if (id == 0)
+            std::cout << "Substrate file read complete" << std::endl;
+    }
+
+    // Initializes Grain ID values where the baseplate is generated using an input grain spacing and a Voronoi
+    // Tessellation
+    void init_baseplate_grainid_fromspacing(float SubstrateGrainSpacing, int nx, int ny, double ZMin, double *ZMaxLayer,
+                                            int MyYSlices, int MyYOffset, int id, double deltax, double RNGSeed, int nz,
+                                            bool BaseplateThroughPowder, bool PowderFirstLayer, int LayerHeight) {
+
+        // Number of cells to assign GrainID
+        int BaseplateSizeZ = get_baseplate_size_z(nz, ZMaxLayer, ZMin, deltax, LayerHeight, BaseplateThroughPowder,
+                                                  PowderFirstLayer); // in CA cells
+        if ((id == 0) && (BaseplateSizeZ < 1))
+            std::cout
+                << "Warning: no baseplate microstructure will be used, as the powder layer extends further in the Z "
+                   "direction than the first layer's temperature data"
+                << std::endl;
+        std::mt19937_64 gen(RNGSeed);
+
+        // Based on the baseplate volume (convert to cubic microns to match units) and the substrate grain spacing,
+        // determine the number of baseplate grains
+        int BaseplateVolume = nx * ny * BaseplateSizeZ;
+        double BaseplateVolume_microns = BaseplateVolume * pow(deltax, 3) * pow(10, 18);
+        double SubstrateMeanGrainVolume_microns = pow(SubstrateGrainSpacing, 3);
+        int NumberOfBaseplateGrains = round(BaseplateVolume_microns / SubstrateMeanGrainVolume_microns);
+        // Need at least 1 baseplate grain, cannot have more baseplate grains than cells in the baseplate
+        NumberOfBaseplateGrains = std::max(NumberOfBaseplateGrains, 1);
+        NumberOfBaseplateGrains = std::min(NumberOfBaseplateGrains, nx * ny * BaseplateSizeZ);
+        // TODO: Use device RNG to generate baseplate grain locations, instead of host with copy
+        // List of potential grain IDs (starting at 1) - index corresponds to the associated CA cell location
+        // Assign positive values for indices 0 through NumberOfBaseplateGrains-1, assign zeros to the remaining indices
+        std::vector<int> BaseplateGrainLocations(BaseplateVolume);
+        std::vector<int> BaseplateGrainIDs(BaseplateVolume);
+        for (int i = 0; i < BaseplateVolume; i++) {
+            BaseplateGrainLocations[i] = i;
+            if (i < NumberOfBaseplateGrains)
+                BaseplateGrainIDs[i] = i + 1;
+            else
+                BaseplateGrainIDs[i] = 0;
+        }
+        // Shuffle list of grain IDs
+        std::shuffle(BaseplateGrainIDs.begin(), BaseplateGrainIDs.end(), gen);
+
+        // Create views of baseplate grain IDs and locations - copying BaseplateGrainIDs and BaseplateGrainLocations
+        // values only for indices where BaseplateGrainIDs(i) != 0 (cells with BaseplateGrainIDs(i) = 0 were not
+        // assigned baseplate center locations)
+        view_type_int_host BaseplateGrainLocations_Host(
+            Kokkos::ViewAllocateWithoutInitializing("BaseplateGrainLocations_Host"), NumberOfBaseplateGrains);
+        view_type_int_host BaseplateGrainIDs_Host(Kokkos::ViewAllocateWithoutInitializing("BaseplateGrainIDs_Host"),
+                                                  NumberOfBaseplateGrains);
+        int count = 0;
+        for (int i = 0; i < BaseplateVolume; i++) {
+            if (BaseplateGrainIDs[i] != 0) {
+                BaseplateGrainLocations_Host(count) = BaseplateGrainLocations[i];
+                BaseplateGrainIDs_Host(count) = BaseplateGrainIDs[i];
+                count++;
+            }
+        }
+
+        // Copy baseplate views to the device
+        ViewI BaseplateGrainIDs_Device =
+            Kokkos::create_mirror_view_and_copy(device_memory_space(), BaseplateGrainIDs_Host);
+        ViewI BaseplateGrainLocations_Device =
+            Kokkos::create_mirror_view_and_copy(device_memory_space(), BaseplateGrainLocations_Host);
+        if (id == 0) {
+            std::cout << "Baseplate spanning domain coordinates Z = 0 through " << BaseplateSizeZ - 1 << std::endl;
+            std::cout << "Number of baseplate grains: " << NumberOfBaseplateGrains << std::endl;
+        }
+
+        // First, assign cells that are associated with grain centers the appropriate non-zero GrainID values (assumes
+        // GrainID values were initialized to zeros)
+        auto GrainID_AllLayers_local = GrainID_AllLayers;
+        Kokkos::parallel_for(
+            "BaseplateInit", NumberOfBaseplateGrains, KOKKOS_LAMBDA(const int &n) {
+                int BaseplateGrainLoc = BaseplateGrainLocations_Device(n);
+                // x, y, z associated with baseplate grain "n", at 1D coordinate "BaseplateGrainLoc"
+                int z_n = BaseplateGrainLoc / (nx * ny);
+                int Rem = BaseplateGrainLoc % (nx * ny);
+                int x_n = Rem / ny;
+                int y_n = Rem % ny;
+                if ((y_n >= MyYOffset) && (y_n < MyYOffset + MyYSlices)) {
+                    // This grain is associated with a cell on this MPI rank
+                    int CAGridLocation = z_n * nx * MyYSlices + x_n * MyYSlices + (y_n - MyYOffset);
+                    GrainID_AllLayers_local(CAGridLocation) = BaseplateGrainIDs_Device(n);
+                }
+            });
+        Kokkos::fence();
+        // For cells that are not associated with grain centers, assign them the GrainID of the nearest grain center
+        Kokkos::parallel_for(
+            "BaseplateGen",
+            Kokkos::MDRangePolicy<Kokkos::Rank<3, Kokkos::Iterate::Right, Kokkos::Iterate::Right>>(
+                {0, 0, 0}, {BaseplateSizeZ, nx, MyYSlices}),
+            KOKKOS_LAMBDA(const int k, const int i, const int j) {
+                int CAGridLocation = k * nx * MyYSlices + i * MyYSlices + j;
+                if (GrainID_AllLayers_local(CAGridLocation) == 0) {
+                    // This cell needs to be assigned a GrainID value
+                    // Check each possible baseplate grain center to find the closest one
+                    float MinDistanceToThisGrain = nx * ny * BaseplateSizeZ;
+                    int MinDistanceToThisGrain_GrainID = 0;
+                    for (int n = 0; n < NumberOfBaseplateGrains; n++) {
+                        // Baseplate grain center at x_n, y_n, z_n - how far is the cell at i, j+MyYOffset, k?
+                        int z_n = BaseplateGrainLocations_Device(n) / (nx * ny);
+                        int Rem = BaseplateGrainLocations_Device(n) % (nx * ny);
+                        int x_n = Rem / ny;
+                        int y_n = Rem % ny;
+                        float DistanceToThisGrainX = i - x_n;
+                        float DistanceToThisGrainY = (j + MyYOffset) - y_n;
+                        float DistanceToThisGrainZ = k - z_n;
+                        float DistanceToThisGrain = sqrtf(DistanceToThisGrainX * DistanceToThisGrainX +
+                                                          DistanceToThisGrainY * DistanceToThisGrainY +
+                                                          DistanceToThisGrainZ * DistanceToThisGrainZ);
+                        if (DistanceToThisGrain < MinDistanceToThisGrain) {
+                            // This is the closest grain center to cell at "CAGridLocation" - update values
+                            MinDistanceToThisGrain = DistanceToThisGrain;
+                            MinDistanceToThisGrain_GrainID = BaseplateGrainIDs_Device(n);
+                        }
+                    }
+                    // GrainID associated with the closest baseplate grain center
+                    GrainID_AllLayers_local(CAGridLocation) = MinDistanceToThisGrain_GrainID;
+                }
+            });
+
+        NextLayer_FirstEpitaxialGrainID =
+            NumberOfBaseplateGrains + 1; // avoid reusing GrainID in next layer's powder grain structure
+        if (id == 0)
+            std::cout << "Baseplate grain structure initialized" << std::endl;
+    }
+
+    // Each layer's top Z coordinates are seeded with CA-cell sized substrate grains (emulating bulk nucleation
+    // alongside the edges of partially melted powder particles)
+    void init_powder_grainid(int layernumber, int nx, int ny, int LayerHeight, double *ZMaxLayer, double ZMin,
+                             double deltax, int MyYSlices, int MyYOffset, int id, double RNGSeed,
+                             double PowderActiveFraction) {
+
+        // On all ranks, generate list of powder grain IDs (starting with NextLayer_FirstEpitaxialGrainID, and shuffle
+        // them so that their locations aren't sequential and depend on the RNGSeed (different for each layer)
+        std::mt19937_64 gen(RNGSeed + layernumber);
+        std::uniform_real_distribution<double> dis(0.0, 1.0);
+
+        // TODO: This should be performed on the device, rather than the host
+        int PowderLayerCells = nx * ny * LayerHeight;
+        int PowderLayerAssignedCells = round(static_cast<double>(PowderLayerCells) * PowderActiveFraction);
+        std::vector<int> PowderGrainIDs(PowderLayerCells, 0);
+        for (int n = 0; n < PowderLayerAssignedCells; n++) {
+            PowderGrainIDs[n] = n + NextLayer_FirstEpitaxialGrainID; // assigned a nonzero GrainID
+        }
+        std::shuffle(PowderGrainIDs.begin(), PowderGrainIDs.end(), gen);
+        // Copy powder layer GrainIDs into a host view, then a device view
+        view_type_int_host PowderGrainIDs_Host(Kokkos::ViewAllocateWithoutInitializing("PowderGrainIDs_Host"),
+                                               PowderLayerCells);
+        for (int n = 0; n < PowderLayerCells; n++) {
+            PowderGrainIDs_Host(n) = PowderGrainIDs[n];
+        }
+        ViewI PowderGrainIDs_Device = Kokkos::create_mirror_view_and_copy(device_memory_space(), PowderGrainIDs_Host);
+        // Associate powder grain IDs with CA cells in the powder layer
+        // Use bounds from temperature field for this layer to determine which cells are part of the powder
+        int PowderTopZ = round((ZMaxLayer[layernumber] - ZMin) / deltax) + 1;
+        int PowderBottomZ = PowderTopZ - LayerHeight;
+        MPI_Barrier(MPI_COMM_WORLD);
+        if (id == 0)
+            std::cout << "Initializing powder layer for Z = " << PowderBottomZ << " through " << PowderTopZ - 1 << " ("
+                      << nx * ny * (PowderTopZ - PowderBottomZ) << " cells)" << std::endl;
+
+        int PowderStart = nx * ny * PowderBottomZ;
+        int PowderEnd = nx * ny * PowderTopZ;
+        if (id == 0)
+            std::cout << "Powder layer has " << PowderLayerAssignedCells
+                      << " cells assigned new grain ID values, ranging from " << NextLayer_FirstEpitaxialGrainID
+                      << " through " << NextLayer_FirstEpitaxialGrainID + PowderLayerAssignedCells - 1 << std::endl;
+        auto GrainID_AllLayers_local = GrainID_AllLayers;
+        Kokkos::parallel_for(
+            "PowderGrainInit", Kokkos::RangePolicy<>(PowderStart, PowderEnd), KOKKOS_LAMBDA(const int &n) {
+                int GlobalZ = n / (nx * ny);
+                int Rem = n % (nx * ny);
+                int GlobalX = Rem / ny;
+                int GlobalY = Rem % ny;
+                // Is this powder coordinate in X and Y in bounds for this rank? Is the grain id of this site unassigned
+                // (wasn't captured during solidification of the previous layer)?
+                int GlobalD3D1ConvPosition = GlobalZ * nx * MyYSlices + GlobalX * MyYSlices + (GlobalY - MyYOffset);
+                if ((GlobalY >= MyYOffset) && (GlobalY < MyYOffset + MyYSlices) &&
+                    (GrainID_AllLayers_local(GlobalD3D1ConvPosition) == 0))
+                    GrainID_AllLayers_local(GlobalD3D1ConvPosition) = PowderGrainIDs_Device(n - PowderStart);
+            });
+        Kokkos::fence();
+
+        // Update NextLayer_FirstEpitaxialGrainID for next layer
+        NextLayer_FirstEpitaxialGrainID += PowderLayerAssignedCells;
+        MPI_Barrier(MPI_COMM_WORLD);
+        if (id == 0)
+            std::cout << "Initialized powder grain structure for layer " << layernumber << std::endl;
+    }
+
+    // Sets up views, powder layer (if necessary), and cell types for the next layer of a multilayer problem
+    //*****************************************************************************/
+    void init_next_layer(int nextlayernumber, int id, int nx, int ny, int MyYSlices, int MyYOffset, int ZBound_Low,
+                         int LayerHeight, int LocalActiveDomainSize, bool UseSubstrateFile, bool BaseplateThroughPowder,
+                         double ZMin, double *ZMaxLayer, double deltax, double RNGSeed, double PowderActiveFraction,
+                         ViewI NumberOfSolidificationEvents) {
+
+        // Subviews for the next layer's grain id, layer id, cell type are constructed based on updated layer bound
+        // ZBound_Low
+        BottomOfCurrentLayer = ZBound_Low * nx * MyYSlices;
+        TopOfCurrentLayer = BottomOfCurrentLayer + LocalActiveDomainSize;
+
+        // If the baseplate was initialized from a substrate grain spacing, initialize powder layer grain structure
+        // for the next layer "layernumber + 1" Otherwise, the entire substrate (baseplate + powder) was read from a
+        // file, and the powder layers have already been initialized
+        if ((!(UseSubstrateFile)) && (!(BaseplateThroughPowder)))
+            init_powder_grainid(nextlayernumber, nx, ny, LayerHeight, ZMaxLayer, ZMin, deltax, MyYSlices, MyYOffset, id,
+                                RNGSeed, PowderActiveFraction);
+
+        // Initialize active cell data structures and nuclei locations for the next layer "layernumber + 1"
+        init_celltype_layerid(nextlayernumber, nx, MyYSlices, LocalActiveDomainSize, NumberOfSolidificationEvents, id,
+                              ZBound_Low);
+    }
+
+    //*****************************************************************************/
+    // Initializes cells for the current layer as either solid (don't resolidify) or tempsolid (will melt and
+    // resolidify)
+    void init_celltype_layerid(int layernumber, int nx, int MyYSlices, int LocalActiveDomainSize,
+                               ViewI NumberOfSolidificationEvents, int id, int ZBound_Low) {
+
+        int MeltPoolCellCount;
+        auto CellType_AllLayers_local = CellType_AllLayers;
+        auto LayerID_AllLayers_local = LayerID_AllLayers;
+        Kokkos::parallel_reduce(
+            "CellTypeInitSolidRM", LocalActiveDomainSize,
+            KOKKOS_LAMBDA(const int &D3D1ConvPosition, int &local_count) {
+                int GlobalD3D1ConvPosition = D3D1ConvPosition + ZBound_Low * nx * MyYSlices;
+                if (NumberOfSolidificationEvents(D3D1ConvPosition) > 0) {
+                    CellType_AllLayers_local(GlobalD3D1ConvPosition) = TempSolid;
+                    LayerID_AllLayers_local(GlobalD3D1ConvPosition) = layernumber;
+                    local_count++;
+                }
+                else
+                    CellType_AllLayers_local(GlobalD3D1ConvPosition) = Solid;
+            },
+            MeltPoolCellCount);
+        int TotalMeltPoolCellCount;
+        MPI_Reduce(&MeltPoolCellCount, &TotalMeltPoolCellCount, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+        if (id == 0)
+            std::cout << "Number of cells across all ranks to undergo solidification at least once: "
+                      << TotalMeltPoolCellCount << std::endl;
+    }
+
+    // Take a view consisting of data for all layers, and return a subview of the same type consisting of just the cells
+    // corresponding to the current layer of a multilayer problem
+    ViewI getGrainIDSubview() {
+        ViewI GrainID = Kokkos::subview(GrainID_AllLayers, std::make_pair(BottomOfCurrentLayer, TopOfCurrentLayer));
+        return GrainID;
+    }
+    ViewI getLayerIDSubview() {
+        ViewI LayerID = Kokkos::subview(LayerID_AllLayers, std::make_pair(BottomOfCurrentLayer, TopOfCurrentLayer));
+        return LayerID;
+    }
+    ViewI getCellTypeSubview() {
+        ViewI CellType = Kokkos::subview(CellType_AllLayers, std::make_pair(BottomOfCurrentLayer, TopOfCurrentLayer));
+        return CellType;
+    }
+};
+
+#endif

--- a/src/CAcelldata.hpp
+++ b/src/CAcelldata.hpp
@@ -33,6 +33,7 @@ struct CellData {
     using view_type_float = Kokkos::View<float *, memory_space>;
 
     int NextLayer_FirstEpitaxialGrainID, BottomOfCurrentLayer, TopOfCurrentLayer;
+    std::pair<int, int> LayerRange;
     view_type_int GrainID_AllLayers, CellType_AllLayers, LayerID_AllLayers;
 
     // Constructor for views and view bounds for current layer
@@ -46,6 +47,7 @@ struct CellData {
 
         BottomOfCurrentLayer = ZBound_Low * nx * MyYSlices;
         TopOfCurrentLayer = BottomOfCurrentLayer + LocalActiveDomainSize;
+        LayerRange = std::make_pair(BottomOfCurrentLayer, TopOfCurrentLayer);
     }
 
     // Initializes cell types and epitaxial Grain ID values where substrate grains are active cells on the bottom
@@ -441,6 +443,7 @@ struct CellData {
         // ZBound_Low
         BottomOfCurrentLayer = ZBound_Low * nx * MyYSlices;
         TopOfCurrentLayer = BottomOfCurrentLayer + LocalActiveDomainSize;
+        LayerRange = std::make_pair(BottomOfCurrentLayer, TopOfCurrentLayer);
 
         // If the baseplate was initialized from a substrate grain spacing, initialize powder layer grain structure
         // for the next layer "layernumber + 1" Otherwise, the entire substrate (baseplate + powder) was read from a
@@ -485,21 +488,9 @@ struct CellData {
 
     // Take a view consisting of data for all layers, and return a subview of the same type consisting of just the cells
     // corresponding to the current layer of a multilayer problem
-    view_type_int getGrainIDSubview() {
-        view_type_int GrainID =
-            Kokkos::subview(GrainID_AllLayers, std::make_pair(BottomOfCurrentLayer, TopOfCurrentLayer));
-        return GrainID;
-    }
-    view_type_int getLayerIDSubview() {
-        view_type_int LayerID =
-            Kokkos::subview(LayerID_AllLayers, std::make_pair(BottomOfCurrentLayer, TopOfCurrentLayer));
-        return LayerID;
-    }
-    view_type_int getCellTypeSubview() {
-        view_type_int CellType =
-            Kokkos::subview(CellType_AllLayers, std::make_pair(BottomOfCurrentLayer, TopOfCurrentLayer));
-        return CellType;
-    }
+    auto getGrainIDSubview() { return Kokkos::subview(GrainID_AllLayers, LayerRange); }
+    auto getLayerIDSubview() { return Kokkos::subview(LayerID_AllLayers, LayerRange); }
+    auto getCellTypeSubview() { return Kokkos::subview(CellType_AllLayers, LayerRange); }
 };
 
 #endif

--- a/src/CAcelldata.hpp
+++ b/src/CAcelldata.hpp
@@ -13,8 +13,6 @@
 
 #include <Kokkos_Core.hpp>
 
-#include <nlohmann/json.hpp>
-
 #include <algorithm>
 #include <fstream>
 #include <iostream>

--- a/src/CAcelldata.hpp
+++ b/src/CAcelldata.hpp
@@ -28,7 +28,7 @@ struct CellData {
 
     using memory_space = MemorySpace;
     using view_type_int = Kokkos::View<int *, memory_space>;
-    using view_type_int_host = Kokkos::View<int *, layout, Kokkos::HostSpace>;
+    using view_type_int_host = typename view_type_int::HostMirror;
     using view_type_float = Kokkos::View<float *, memory_space>;
 
     int NextLayer_FirstEpitaxialGrainID, BottomOfCurrentLayer, TopOfCurrentLayer;
@@ -83,8 +83,8 @@ struct CellData {
         }
 
         // Copy views of substrate grain locations back to the device
-        view_type_int ActCellX_Device = Kokkos::create_mirror_view_and_copy(device_memory_space(), ActCellX_Host);
-        view_type_int ActCellY_Device = Kokkos::create_mirror_view_and_copy(device_memory_space(), ActCellY_Host);
+        auto ActCellX_Device = Kokkos::create_mirror_view_and_copy(device_memory_space(), ActCellX_Host);
+        auto ActCellY_Device = Kokkos::create_mirror_view_and_copy(device_memory_space(), ActCellY_Host);
 
         // Start with all cells as liquid prior to locating substrate grain seeds
         // All cells have LayerID = 0 as this is not a multilayer problem
@@ -301,9 +301,9 @@ struct CellData {
         }
 
         // Copy baseplate views to the device
-        view_type_int BaseplateGrainIDs_Device =
+        auto BaseplateGrainIDs_Device =
             Kokkos::create_mirror_view_and_copy(device_memory_space(), BaseplateGrainIDs_Host);
-        view_type_int BaseplateGrainLocations_Device =
+        auto BaseplateGrainLocations_Device =
             Kokkos::create_mirror_view_and_copy(device_memory_space(), BaseplateGrainLocations_Host);
         if (id == 0) {
             std::cout << "Baseplate spanning domain coordinates Z = 0 through " << BaseplateSizeZ - 1 << std::endl;

--- a/src/CAfunctions.hpp
+++ b/src/CAfunctions.hpp
@@ -10,6 +10,70 @@
 #include <Kokkos_Core.hpp>
 //*****************************************************************************/
 // Inline functions
+// Assign octahedron a small initial size, and a center location
+template <typename ViewType>
+KOKKOS_INLINE_FUNCTION void createNewOctahedron(int D3D1ConvPosition, ViewType DiagonalLength, ViewType DOCenter,
+                                                int GlobalX, int GlobalY, int GlobalZ) {
+    DiagonalLength(D3D1ConvPosition) = 0.01;
+    DOCenter(3 * D3D1ConvPosition) = GlobalX + 0.5;
+    DOCenter(3 * D3D1ConvPosition + 1) = GlobalY + 0.5;
+    DOCenter(3 * D3D1ConvPosition + 2) = GlobalZ + 0.5;
+}
+
+// For the newly active cell located at 1D array position D3D1ConvPosition (3D center coordinate of xp, yp, zp), update
+// CritDiagonalLength values for cell capture of neighboring cells. The octahedron has a center located at (cx, cy, cz)
+template <typename ViewType>
+KOKKOS_INLINE_FUNCTION void calcCritDiagonalLength(int D3D1ConvPosition, float xp, float yp, float zp, float cx,
+                                                   float cy, float cz, NList NeighborX, NList NeighborY,
+                                                   NList NeighborZ, int MyOrientation, ViewType GrainUnitVector,
+                                                   ViewType CritDiagonalLength) {
+    // Calculate critical octahedron diagonal length to activate nearest neighbor.
+    // First, calculate the unique planes (4) associated with all octahedron faces (8)
+    // Then just look at distance between face and the point of interest (cell center of
+    // neighbor). The critical diagonal length will be the maximum of these (since all other
+    // planes will have passed over the point by then
+    // ... meaning it must be in the octahedron)
+    double Fx[4], Fy[4], Fz[4];
+
+    Fx[0] = GrainUnitVector(9 * MyOrientation) + GrainUnitVector(9 * MyOrientation + 3) +
+            GrainUnitVector(9 * MyOrientation + 6);
+    Fx[1] = GrainUnitVector(9 * MyOrientation) - GrainUnitVector(9 * MyOrientation + 3) +
+            GrainUnitVector(9 * MyOrientation + 6);
+    Fx[2] = GrainUnitVector(9 * MyOrientation) + GrainUnitVector(9 * MyOrientation + 3) -
+            GrainUnitVector(9 * MyOrientation + 6);
+    Fx[3] = GrainUnitVector(9 * MyOrientation) - GrainUnitVector(9 * MyOrientation + 3) -
+            GrainUnitVector(9 * MyOrientation + 6);
+
+    Fy[0] = GrainUnitVector(9 * MyOrientation + 1) + GrainUnitVector(9 * MyOrientation + 4) +
+            GrainUnitVector(9 * MyOrientation + 7);
+    Fy[1] = GrainUnitVector(9 * MyOrientation + 1) - GrainUnitVector(9 * MyOrientation + 4) +
+            GrainUnitVector(9 * MyOrientation + 7);
+    Fy[2] = GrainUnitVector(9 * MyOrientation + 1) + GrainUnitVector(9 * MyOrientation + 4) -
+            GrainUnitVector(9 * MyOrientation + 7);
+    Fy[3] = GrainUnitVector(9 * MyOrientation + 1) - GrainUnitVector(9 * MyOrientation + 4) -
+            GrainUnitVector(9 * MyOrientation + 7);
+
+    Fz[0] = GrainUnitVector(9 * MyOrientation + 2) + GrainUnitVector(9 * MyOrientation + 5) +
+            GrainUnitVector(9 * MyOrientation + 8);
+    Fz[1] = GrainUnitVector(9 * MyOrientation + 2) - GrainUnitVector(9 * MyOrientation + 5) +
+            GrainUnitVector(9 * MyOrientation + 8);
+    Fz[2] = GrainUnitVector(9 * MyOrientation + 2) + GrainUnitVector(9 * MyOrientation + 5) -
+            GrainUnitVector(9 * MyOrientation + 8);
+    Fz[3] = GrainUnitVector(9 * MyOrientation + 2) - GrainUnitVector(9 * MyOrientation + 5) -
+            GrainUnitVector(9 * MyOrientation + 8);
+
+    for (int n = 0; n < 26; n++) {
+        float x0 = xp + NeighborX[n] - cx;
+        float y0 = yp + NeighborY[n] - cy;
+        float z0 = zp + NeighborZ[n] - cz;
+        float D0 = x0 * Fx[0] + y0 * Fy[0] + z0 * Fz[0];
+        float D1 = x0 * Fx[1] + y0 * Fy[1] + z0 * Fz[1];
+        float D2 = x0 * Fx[2] + y0 * Fy[2] + z0 * Fz[2];
+        float D3 = x0 * Fx[3] + y0 * Fy[3] + z0 * Fz[3];
+        float Dfabs = fmax(fmax(fabs(D0), fabs(D1)), fmax(fabs(D2), fabs(D3)));
+        CritDiagonalLength((long int)(26) * D3D1ConvPosition + (long int)(n)) = Dfabs;
+    }
+}
 
 // Get the orientation of a grain from a given grain ID and the number of possible orientations
 // By default, start indexing at 0 (GrainID of 1 has Orientation number 0), optionally starting at 1

--- a/src/CAghostnodes.cpp
+++ b/src/CAghostnodes.cpp
@@ -72,9 +72,10 @@ void ResetBufferCapacity(Buffer2D &BufferNorthSend, Buffer2D &BufferSouthSend, B
 
 // Refill the buffers as necessary starting from the old count size, using the data from cells marked with type
 // ActiveFailedBufferLoad
-void RefillBuffers(int nx, int nzActive, int MyYSlices, int, CellData &cellData, Buffer2D BufferNorthSend,
-                   Buffer2D BufferSouthSend, ViewI SendSizeNorth, ViewI SendSizeSouth, bool AtNorthBoundary,
-                   bool AtSouthBoundary, ViewF DOCenter, ViewF DiagonalLength, int NGrainOrientations, int BufSize) {
+void RefillBuffers(int nx, int nzActive, int MyYSlices, int, CellData<device_memory_space> &cellData,
+                   Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, ViewI SendSizeNorth, ViewI SendSizeSouth,
+                   bool AtNorthBoundary, bool AtSouthBoundary, ViewF DOCenter, ViewF DiagonalLength,
+                   int NGrainOrientations, int BufSize) {
 
     ViewI CellType = cellData.getCellTypeSubview();
     ViewI GrainID = cellData.getGrainIDSubview();
@@ -152,9 +153,9 @@ void RefillBuffers(int nx, int nzActive, int MyYSlices, int, CellData &cellData,
 //*****************************************************************************/
 // 1D domain decomposition: update ghost nodes with new cell data from Nucleation and CellCapture routines
 void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int nx, int MyYSlices, int MyYOffset,
-                  NList NeighborX, NList NeighborY, NList NeighborZ, CellData &cellData, ViewF DOCenter,
-                  ViewF GrainUnitVector, ViewF DiagonalLength, ViewF CritDiagonalLength, int NGrainOrientations,
-                  Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, Buffer2D BufferNorthRecv,
+                  NList NeighborX, NList NeighborY, NList NeighborZ, CellData<device_memory_space> &cellData,
+                  ViewF DOCenter, ViewF GrainUnitVector, ViewF DiagonalLength, ViewF CritDiagonalLength,
+                  int NGrainOrientations, Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, Buffer2D BufferNorthRecv,
                   Buffer2D BufferSouthRecv, int BufSize, int ZBound_Low, ViewI SendSizeNorth, ViewI SendSizeSouth) {
 
     std::vector<MPI_Request> SendRequests(2, MPI_REQUEST_NULL);

--- a/src/CAghostnodes.cpp
+++ b/src/CAghostnodes.cpp
@@ -77,8 +77,8 @@ void RefillBuffers(int nx, int nzActive, int MyYSlices, int, CellData<device_mem
                    bool AtNorthBoundary, bool AtSouthBoundary, ViewF DOCenter, ViewF DiagonalLength,
                    int NGrainOrientations, int BufSize) {
 
-    ViewI CellType = cellData.getCellTypeSubview();
-    ViewI GrainID = cellData.getGrainIDSubview();
+    auto CellType = cellData.getCellTypeSubview();
+    auto GrainID = cellData.getGrainIDSubview();
     Kokkos::parallel_for(
         "FillSendBuffersOverflow", nx, KOKKOS_LAMBDA(const int &i) {
             for (int k = 0; k < nzActive; k++) {
@@ -171,8 +171,8 @@ void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int 
 
     // unpack in any order
     bool unpack_complete = false;
-    ViewI CellType = cellData.getCellTypeSubview();
-    ViewI GrainID = cellData.getGrainIDSubview();
+    auto CellType = cellData.getCellTypeSubview();
+    auto GrainID = cellData.getGrainIDSubview();
     while (!unpack_complete) {
         // Get the next buffer to unpack from rank "unpack_index"
         int unpack_index = MPI_UNDEFINED;

--- a/src/CAghostnodes.cpp
+++ b/src/CAghostnodes.cpp
@@ -72,74 +72,73 @@ void ResetBufferCapacity(Buffer2D &BufferNorthSend, Buffer2D &BufferSouthSend, B
 
 // Refill the buffers as necessary starting from the old count size, using the data from cells marked with type
 // ActiveFailedBufferLoad
-void RefillBuffers(int nx, int nzActive, int MyYSlices, int ZBound_Low, ViewI CellType, Buffer2D BufferNorthSend,
+void RefillBuffers(int nx, int nzActive, int MyYSlices, int, CellData &cellData, Buffer2D BufferNorthSend,
                    Buffer2D BufferSouthSend, ViewI SendSizeNorth, ViewI SendSizeSouth, bool AtNorthBoundary,
-                   bool AtSouthBoundary, ViewI GrainID, ViewF DOCenter, ViewF DiagonalLength, int NGrainOrientations,
-                   int BufSize) {
+                   bool AtSouthBoundary, ViewF DOCenter, ViewF DiagonalLength, int NGrainOrientations, int BufSize) {
 
+    ViewI CellType = cellData.getCellTypeSubview();
+    ViewI GrainID = cellData.getGrainIDSubview();
     Kokkos::parallel_for(
         "FillSendBuffersOverflow", nx, KOKKOS_LAMBDA(const int &i) {
             for (int k = 0; k < nzActive; k++) {
-                int GlobalCellCoordinateSouth = (k + ZBound_Low) * nx * MyYSlices + i * MyYSlices + 1;
-                int GlobalCellCoordinateNorth = (k + ZBound_Low) * nx * MyYSlices + i * MyYSlices + MyYSlices - 2;
-                if (CellType(GlobalCellCoordinateSouth) == ActiveFailedBufferLoad) {
-                    int ActiveLayerCoordinateSouth = k * nx * MyYSlices + i * MyYSlices + 1;
-                    int GhostGID = GrainID(GlobalCellCoordinateSouth);
-                    float GhostDOCX = DOCenter(3 * ActiveLayerCoordinateSouth);
-                    float GhostDOCY = DOCenter(3 * ActiveLayerCoordinateSouth + 1);
-                    float GhostDOCZ = DOCenter(3 * ActiveLayerCoordinateSouth + 2);
-                    float GhostDL = DiagonalLength(ActiveLayerCoordinateSouth);
+                int CellCoordinateSouth = k * nx * MyYSlices + i * MyYSlices + 1;
+                int CellCoordinateNorth = k * nx * MyYSlices + i * MyYSlices + MyYSlices - 2;
+                if (CellType(CellCoordinateSouth) == ActiveFailedBufferLoad) {
+                    int GhostGID = GrainID(CellCoordinateSouth);
+                    float GhostDOCX = DOCenter(3 * CellCoordinateSouth);
+                    float GhostDOCY = DOCenter(3 * CellCoordinateSouth + 1);
+                    float GhostDOCZ = DOCenter(3 * CellCoordinateSouth + 2);
+                    float GhostDL = DiagonalLength(CellCoordinateSouth);
                     // Collect data for the ghost nodes, if necessary
                     // Data loaded into the ghost nodes is for the cell that was just captured
                     bool DataFitsInBuffer =
                         loadghostnodes(GhostGID, GhostDOCX, GhostDOCY, GhostDOCZ, GhostDL, SendSizeNorth, SendSizeSouth,
                                        MyYSlices, i, 1, k, AtNorthBoundary, AtSouthBoundary, BufferSouthSend,
                                        BufferNorthSend, NGrainOrientations, BufSize);
-                    CellType(GlobalCellCoordinateSouth) = Active;
+                    CellType(CellCoordinateSouth) = Active;
                     // If data doesn't fit in the buffer after the resize, warn that buffer data may have been lost
                     if (!(DataFitsInBuffer))
                         printf("Error: Send/recv buffer resize failed to include all necessary data, predicted "
                                "results at MPI processor boundaries may be inaccurate\n");
                 }
-                else if (CellType(GlobalCellCoordinateSouth) == LiquidFailedBufferLoad) {
+                else if (CellType(CellCoordinateSouth) == LiquidFailedBufferLoad) {
                     // Dummy values for first 4 arguments (Grain ID and octahedron center coordinates), 0 for diagonal
                     // length
                     bool DataFitsInBuffer = loadghostnodes(
                         -1, -1.0, -1.0, -1.0, 0.0, SendSizeNorth, SendSizeSouth, MyYSlices, i, 1, k, AtNorthBoundary,
                         AtSouthBoundary, BufferSouthSend, BufferNorthSend, NGrainOrientations, BufSize);
-                    CellType(GlobalCellCoordinateSouth) = Liquid;
+                    CellType(CellCoordinateSouth) = Liquid;
                     // If data doesn't fit in the buffer after the resize, warn that buffer data may have been lost
                     if (!(DataFitsInBuffer))
                         printf("Error: Send/recv buffer resize failed to include all necessary data, predicted "
                                "results at MPI processor boundaries may be inaccurate\n");
                 }
-                if (CellType(GlobalCellCoordinateNorth) == ActiveFailedBufferLoad) {
-                    int ActiveLayerCoordinateNorth = k * nx * MyYSlices + i * MyYSlices + MyYSlices - 2;
-                    int GhostGID = GrainID(GlobalCellCoordinateNorth);
-                    float GhostDOCX = DOCenter(3 * ActiveLayerCoordinateNorth);
-                    float GhostDOCY = DOCenter(3 * ActiveLayerCoordinateNorth + 1);
-                    float GhostDOCZ = DOCenter(3 * ActiveLayerCoordinateNorth + 2);
-                    float GhostDL = DiagonalLength(ActiveLayerCoordinateNorth);
+                if (CellType(CellCoordinateNorth) == ActiveFailedBufferLoad) {
+                    int GhostGID = GrainID(CellCoordinateNorth);
+                    float GhostDOCX = DOCenter(3 * CellCoordinateNorth);
+                    float GhostDOCY = DOCenter(3 * CellCoordinateNorth + 1);
+                    float GhostDOCZ = DOCenter(3 * CellCoordinateNorth + 2);
+                    float GhostDL = DiagonalLength(CellCoordinateNorth);
                     // Collect data for the ghost nodes, if necessary
                     // Data loaded into the ghost nodes is for the cell that was just captured
                     bool DataFitsInBuffer =
                         loadghostnodes(GhostGID, GhostDOCX, GhostDOCY, GhostDOCZ, GhostDL, SendSizeNorth, SendSizeSouth,
                                        MyYSlices, i, MyYSlices - 2, k, AtNorthBoundary, AtSouthBoundary,
                                        BufferSouthSend, BufferNorthSend, NGrainOrientations, BufSize);
-                    CellType(GlobalCellCoordinateNorth) = Active;
+                    CellType(CellCoordinateNorth) = Active;
                     // If data doesn't fit in the buffer after the resize, warn that buffer data may have been lost
                     if (!(DataFitsInBuffer))
                         printf("Error: Send/recv buffer resize failed to include all necessary data, predicted "
                                "results at MPI processor boundaries may be inaccurate\n");
                 }
-                else if (CellType(GlobalCellCoordinateNorth) == LiquidFailedBufferLoad) {
+                else if (CellType(CellCoordinateNorth) == LiquidFailedBufferLoad) {
                     // Dummy values for first 4 arguments (Grain ID and octahedron center coordinates), 0 for diagonal
                     // length
                     bool DataFitsInBuffer =
                         loadghostnodes(-1, -1.0, -1.0, -1.0, 0.0, SendSizeNorth, SendSizeSouth, MyYSlices, i,
                                        MyYSlices - 2, k, AtNorthBoundary, AtSouthBoundary, BufferSouthSend,
                                        BufferNorthSend, NGrainOrientations, BufSize);
-                    CellType(GlobalCellCoordinateNorth) = Liquid;
+                    CellType(CellCoordinateNorth) = Liquid;
                     // If data doesn't fit in the buffer after the resize, warn that buffer data may have been lost
                     if (!(DataFitsInBuffer))
                         printf("Error: Send/recv buffer resize failed to include all necessary data, predicted "
@@ -153,7 +152,7 @@ void RefillBuffers(int nx, int nzActive, int MyYSlices, int ZBound_Low, ViewI Ce
 //*****************************************************************************/
 // 1D domain decomposition: update ghost nodes with new cell data from Nucleation and CellCapture routines
 void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int nx, int MyYSlices, int MyYOffset,
-                  NList NeighborX, NList NeighborY, NList NeighborZ, ViewI CellType, ViewF DOCenter, ViewI GrainID,
+                  NList NeighborX, NList NeighborY, NList NeighborZ, CellData &cellData, ViewF DOCenter,
                   ViewF GrainUnitVector, ViewF DiagonalLength, ViewF CritDiagonalLength, int NGrainOrientations,
                   Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, Buffer2D BufferNorthRecv,
                   Buffer2D BufferSouthRecv, int BufSize, int ZBound_Low, ViewI SendSizeNorth, ViewI SendSizeSouth) {
@@ -171,6 +170,8 @@ void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int 
 
     // unpack in any order
     bool unpack_complete = false;
+    ViewI CellType = cellData.getCellTypeSubview();
+    ViewI GrainID = cellData.getGrainIDSubview();
     while (!unpack_complete) {
         // Get the next buffer to unpack from rank "unpack_index"
         int unpack_index = MPI_UNDEFINED;
@@ -196,11 +197,10 @@ void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int 
                         RankY = 0;
                         RankZ = static_cast<int>(BufferSouthRecv(BufPosition, 1));
                         CellLocation = RankZ * nx * MyYSlices + MyYSlices * RankX + RankY;
-                        int GlobalCellLocation = CellLocation + ZBound_Low * nx * MyYSlices;
                         // Two possibilities: buffer data with non-zero diagonal length was loaded, and a liquid cell
                         // may have to be updated to active - or zero diagonal length data was loaded, and an active
                         // cell may have to be updated to liquid
-                        if (CellType(GlobalCellLocation) == Liquid) {
+                        if (CellType(CellLocation) == Liquid) {
                             Place = true;
                             int MyGrainOrientation = static_cast<int>(BufferSouthRecv(BufPosition, 2));
                             int MyGrainNumber = static_cast<int>(BufferSouthRecv(BufPosition, 3));
@@ -210,8 +210,8 @@ void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int 
                             DOCenterZ = BufferSouthRecv(BufPosition, 6);
                             NewDiagonalLength = BufferSouthRecv(BufPosition, 7);
                         }
-                        else if ((CellType(GlobalCellLocation) == Active) && (BufferSouthRecv(BufPosition, 7) == 0.0)) {
-                            CellType(GlobalCellLocation) = Liquid;
+                        else if ((CellType(CellLocation) == Active) && (BufferSouthRecv(BufPosition, 7) == 0.0)) {
+                            CellType(CellLocation) = Liquid;
                         }
                     }
                     else if ((unpack_index == 1) && (BufferNorthRecv(BufPosition, 0) != -1.0) &&
@@ -221,11 +221,10 @@ void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int 
                         RankY = MyYSlices - 1;
                         RankZ = static_cast<int>(BufferNorthRecv(BufPosition, 1));
                         CellLocation = RankZ * nx * MyYSlices + MyYSlices * RankX + RankY;
-                        int GlobalCellLocation = CellLocation + ZBound_Low * nx * MyYSlices;
                         // Two possibilities: buffer data with non-zero diagonal length was loaded, and a liquid cell
                         // may have to be updated to active - or zero diagonal length data was loaded, and an active
                         // cell may have to be updated to liquid
-                        if (CellType(GlobalCellLocation) == Liquid) {
+                        if (CellType(CellLocation) == Liquid) {
                             Place = true;
                             int MyGrainOrientation = static_cast<int>(BufferNorthRecv(BufPosition, 2));
                             int MyGrainNumber = static_cast<int>(BufferNorthRecv(BufPosition, 3));
@@ -235,19 +234,18 @@ void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int 
                             DOCenterZ = BufferNorthRecv(BufPosition, 6);
                             NewDiagonalLength = BufferNorthRecv(BufPosition, 7);
                         }
-                        else if ((CellType(GlobalCellLocation) == Active) && (BufferNorthRecv(BufPosition, 7) == 0.0)) {
-                            CellType(GlobalCellLocation) = Liquid;
+                        else if ((CellType(CellLocation) == Active) && (BufferNorthRecv(BufPosition, 7) == 0.0)) {
+                            CellType(CellLocation) = Liquid;
                         }
                     }
                     if (Place) {
                         int GlobalZ = RankZ + ZBound_Low;
-                        int GlobalCellLocation = GlobalZ * nx * MyYSlices + RankX * MyYSlices + RankY;
                         // Update this ghost node cell's information with data from other rank
-                        GrainID(GlobalCellLocation) = NewGrainID;
+                        GrainID(CellLocation) = NewGrainID;
                         DOCenter((long int)(3) * CellLocation) = DOCenterX;
                         DOCenter((long int)(3) * CellLocation + (long int)(1)) = DOCenterY;
                         DOCenter((long int)(3) * CellLocation + (long int)(2)) = DOCenterZ;
-                        int MyOrientation = getGrainOrientation(GrainID(GlobalCellLocation), NGrainOrientations);
+                        int MyOrientation = getGrainOrientation(GrainID(CellLocation), NGrainOrientations);
                         DiagonalLength(CellLocation) = static_cast<float>(NewDiagonalLength);
                         // Global coordinates of cell center
                         double xp = RankX + 0.5;
@@ -258,7 +256,7 @@ void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int 
                         calcCritDiagonalLength(CellLocation, xp, yp, zp, DOCenterX, DOCenterY, DOCenterZ, NeighborX,
                                                NeighborY, NeighborZ, MyOrientation, GrainUnitVector,
                                                CritDiagonalLength);
-                        CellType(GlobalCellLocation) = Active;
+                        CellType(CellLocation) = Active;
                     }
                 });
         }

--- a/src/CAghostnodes.hpp
+++ b/src/CAghostnodes.hpp
@@ -63,13 +63,14 @@ int ResizeBuffers(Buffer2D &BufferNorthSend, Buffer2D &BufferSouthSend, Buffer2D
                   ViewI_H SendSizeSouth_Host, int OldBufSize, int NumCellsBufferPadding = 25);
 void ResetBufferCapacity(Buffer2D &BufferNorthSend, Buffer2D &BufferSouthSend, Buffer2D &BufferNorthRecv,
                          Buffer2D &BufferSouthRecv, int NewBufSize);
-void RefillBuffers(int nx, int nzActive, int MyYSlices, int ZBound_Low, CellData &cellData, Buffer2D BufferNorthSend,
-                   Buffer2D BufferSouthSend, ViewI SendSizeNorth, ViewI SendSizeSouth, bool AtNorthBoundary,
-                   bool AtSouthBoundary, ViewF DOCenter, ViewF DiagonalLength, int NGrainOrientations, int BufSize);
+void RefillBuffers(int nx, int nzActive, int MyYSlices, int ZBound_Low, CellData<device_memory_space> &cellData,
+                   Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, ViewI SendSizeNorth, ViewI SendSizeSouth,
+                   bool AtNorthBoundary, bool AtSouthBoundary, ViewF DOCenter, ViewF DiagonalLength,
+                   int NGrainOrientations, int BufSize);
 void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int nx, int MyYSlices, int MyYOffset,
-                  NList NeighborX, NList NeighborY, NList NeighborZ, CellData &cellData, ViewF DOCenter,
-                  ViewF GrainUnitVector, ViewF DiagonalLength, ViewF CritDiagonalLength, int NGrainOrientations,
-                  Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, Buffer2D BufferNorthRecv,
+                  NList NeighborX, NList NeighborY, NList NeighborZ, CellData<device_memory_space> &cellData,
+                  ViewF DOCenter, ViewF GrainUnitVector, ViewF DiagonalLength, ViewF CritDiagonalLength,
+                  int NGrainOrientations, Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, Buffer2D BufferNorthRecv,
                   Buffer2D BufferSouthRecv, int BufSize, int ZBound_Low, ViewI SendSizeNorth, ViewI SendSizeSouth);
 
 #endif

--- a/src/CAghostnodes.hpp
+++ b/src/CAghostnodes.hpp
@@ -6,6 +6,7 @@
 #ifndef EXACA_GHOST_HPP
 #define EXACA_GHOST_HPP
 
+#include "CAcelldata.hpp"
 #include "CAfunctions.hpp"
 #include "CAtypes.hpp"
 
@@ -62,12 +63,11 @@ int ResizeBuffers(Buffer2D &BufferNorthSend, Buffer2D &BufferSouthSend, Buffer2D
                   ViewI_H SendSizeSouth_Host, int OldBufSize, int NumCellsBufferPadding = 25);
 void ResetBufferCapacity(Buffer2D &BufferNorthSend, Buffer2D &BufferSouthSend, Buffer2D &BufferNorthRecv,
                          Buffer2D &BufferSouthRecv, int NewBufSize);
-void RefillBuffers(int nx, int nzActive, int MyYSlices, int ZBound_Low, ViewI CellType, Buffer2D BufferNorthSend,
+void RefillBuffers(int nx, int nzActive, int MyYSlices, int ZBound_Low, CellData &cellData, Buffer2D BufferNorthSend,
                    Buffer2D BufferSouthSend, ViewI SendSizeNorth, ViewI SendSizeSouth, bool AtNorthBoundary,
-                   bool AtSouthBoundary, ViewI GrainID, ViewF DOCenter, ViewF DiagonalLength, int NGrainOrientations,
-                   int BufSize);
+                   bool AtSouthBoundary, ViewF DOCenter, ViewF DiagonalLength, int NGrainOrientations, int BufSize);
 void GhostNodes1D(int, int, int NeighborRank_North, int NeighborRank_South, int nx, int MyYSlices, int MyYOffset,
-                  NList NeighborX, NList NeighborY, NList NeighborZ, ViewI CellType, ViewF DOCenter, ViewI GrainID,
+                  NList NeighborX, NList NeighborY, NList NeighborZ, CellData &cellData, ViewF DOCenter,
                   ViewF GrainUnitVector, ViewF DiagonalLength, ViewF CritDiagonalLength, int NGrainOrientations,
                   Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, Buffer2D BufferNorthRecv,
                   Buffer2D BufferSouthRecv, int BufSize, int ZBound_Low, ViewI SendSizeNorth, ViewI SendSizeSouth);

--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -1035,42 +1035,6 @@ void TempInit_ReadData(int layernumber, int id, int nx, int MyYSlices, int, int 
 }
 
 //*****************************************************************************/
-// Initialize grain orientations and unit vectors
-void OrientationInit(int, int &NGrainOrientations, ViewF &GrainOrientationData, std::string GrainOrientationFile,
-                     int ValsPerLine) {
-
-    // Read file of grain orientations
-    std::ifstream O;
-    O.open(GrainOrientationFile);
-
-    // Line 1 is the number of orientation values to read (if not specified already)
-    std::string ValueRead;
-    getline(O, ValueRead);
-    NGrainOrientations = getInputInt(ValueRead);
-
-    // Temporary host view for storing grain orientations read from file
-    ViewF_H GrainOrientationData_Host(Kokkos::ViewAllocateWithoutInitializing("GrainOrientationData_H"),
-                                      ValsPerLine * NGrainOrientations);
-    // Populate data structure for grain orientation data
-    for (int i = 0; i < NGrainOrientations; i++) {
-        std::vector<std::string> ParsedLine(ValsPerLine);
-        std::string ReadLine;
-        if (!getline(O, ReadLine))
-            break;
-        splitString(ReadLine, ParsedLine, ValsPerLine);
-        // Place the 3 grain orientation angles or 9 rotation matrix components into the orientation data view
-        for (int Comp = 0; Comp < ValsPerLine; Comp++) {
-            GrainOrientationData_Host(ValsPerLine * i + Comp) = getInputFloat(ParsedLine[Comp]);
-        }
-    }
-    O.close();
-
-    // Resize device view and orientation data to device
-    Kokkos::realloc(GrainOrientationData, ValsPerLine * NGrainOrientations);
-    GrainOrientationData = Kokkos::create_mirror_view_and_copy(device_memory_space(), GrainOrientationData_Host);
-}
-
-//*****************************************************************************/
 void ZeroResetViews(int LocalActiveDomainSize, ViewF &DiagonalLength, ViewF &CritDiagonalLength, ViewF &DOCenter,
                     ViewI &SteeringVector) {
 

--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -580,7 +580,7 @@ int calcLocalActiveDomainSize(int nx, int MyYSlices, int nzActive) {
 //*****************************************************************************/
 // Initialize temperature data for a constrained solidification test problem
 void TempInit_DirSolidification(double G, double R, int, int &nx, int &MyYSlices, double deltax, double deltat, int,
-                                int LocalDomainSize, ViewI &CritTimeStep, ViewF &UndercoolingChange, ViewI &LayerID,
+                                int LocalDomainSize, ViewI &CritTimeStep, ViewF &UndercoolingChange,
                                 ViewI &NumberOfSolidificationEvents, ViewI &SolidificationEventCounter,
                                 ViewI &MeltTimeStep, ViewI MaxSolidificationEvents, ViewF3D &LayerTimeTempHistory) {
 
@@ -604,8 +604,6 @@ void TempInit_DirSolidification(double G, double R, int, int &nx, int &MyYSlices
             // Cells cool at a constant rate
             LayerTimeTempHistory(Coordinate1D, 0, 2) = R * deltat;
             UndercoolingChange(Coordinate1D) = R * deltat;
-            // DirS not a multilayer problem
-            LayerID(Coordinate1D) = 0;
             // All cells solidify once
             MaxSolidificationEvents(0) = 1;
             SolidificationEventCounter(Coordinate1D) = 0;
@@ -653,7 +651,7 @@ int calcMaxSolidificationEventsSpot(int nx, int MyYSlices, int NumberOfSpots, in
 void TempInit_Spot(int layernumber, double G, double R, std::string, int id, int &nx, int &MyYSlices, int &MyYOffset,
                    double deltax, double deltat, int ZBound_Low, int, int LocalActiveDomainSize, int LocalDomainSize,
                    ViewI &CritTimeStep, ViewF &UndercoolingChange, ViewF &UndercoolingCurrent, int,
-                   double FreezingRange, ViewI &LayerID, int NSpotsX, int NSpotsY, int SpotRadius, int SpotOffset,
+                   double FreezingRange, int NSpotsX, int NSpotsY, int SpotRadius, int SpotOffset,
                    ViewF3D &LayerTimeTempHistory, ViewI &NumberOfSolidificationEvents, ViewI &MeltTimeStep,
                    ViewI &MaxSolidificationEvents, ViewI &SolidificationEventCounter) {
 
@@ -683,14 +681,9 @@ void TempInit_Spot(int layernumber, double G, double R, std::string, int id, int
     // Temporary host views for storing initialized temperature data for active region data structures
     // No resize of device views necessary, as multilayer spot melt simulations have the same active domain size for all
     // layers These views are copied to the host, updated for layer "layernumber", and later copied back to the device
-    ViewI_H LayerID_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), LayerID);
     ViewI_H MeltTimeStep_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), MeltTimeStep);
     ViewI_H CritTimeStep_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), CritTimeStep);
     ViewF_H UndercoolingChange_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), UndercoolingChange);
-
-    // First layer - all LayerID values are -1, to later be populated with other values
-    if (layernumber == 0)
-        Kokkos::deep_copy(LayerID_Host, -1);
 
     // Outer edges of spots are initialized at the liquidus temperature
     // Spots cool at constant rate R, spot thermal gradient = G
@@ -748,7 +741,6 @@ void TempInit_Spot(int layernumber, double G, double R, std::string, int id, int
                     MeltTimeStep_Host(GlobalD3D1ConvPosition) = LayerTimeTempHistory_Host(D3D1ConvPosition, 0, 0);
                     CritTimeStep_Host(GlobalD3D1ConvPosition) = LayerTimeTempHistory_Host(D3D1ConvPosition, 0, 1);
                     UndercoolingChange_Host(GlobalD3D1ConvPosition) = LayerTimeTempHistory_Host(D3D1ConvPosition, 0, 2);
-                    LayerID_Host(GlobalD3D1ConvPosition) = layernumber;
                 }
                 else {
                     MeltTimeStep_Host(GlobalD3D1ConvPosition) = 0;
@@ -765,7 +757,6 @@ void TempInit_Spot(int layernumber, double G, double R, std::string, int id, int
 
     // Copy host view data back to device
     MaxSolidificationEvents = Kokkos::create_mirror_view_and_copy(device_memory_space(), MaxSolidificationEvents_Host);
-    LayerID = Kokkos::create_mirror_view_and_copy(device_memory_space(), LayerID_Host);
     MeltTimeStep = Kokkos::create_mirror_view_and_copy(device_memory_space(), MeltTimeStep_Host);
     CritTimeStep = Kokkos::create_mirror_view_and_copy(device_memory_space(), CritTimeStep_Host);
     UndercoolingChange = Kokkos::create_mirror_view_and_copy(device_memory_space(), UndercoolingChange_Host);
@@ -867,8 +858,8 @@ void TempInit_ReadData(int layernumber, int id, int nx, int MyYSlices, int, int 
                        ViewI &MaxSolidificationEvents, ViewI &MeltTimeStep, ViewI &CritTimeStep,
                        ViewF &UndercoolingChange, ViewF &UndercoolingCurrent, double XMin, double YMin,
                        double *ZMinLayer, int LayerHeight, int nzActive, int ZBound_Low, int *FinishTimeStep,
-                       ViewI &LayerID, int *FirstValue, int *LastValue, ViewD_H RawTemperatureData,
-                       ViewI &SolidificationEventCounter, int TempFilesInSeries) {
+                       int *FirstValue, int *LastValue, ViewD_H RawTemperatureData, ViewI &SolidificationEventCounter,
+                       int TempFilesInSeries) {
 
     // Data was already read into the "RawData" temporary data structure
     // Determine which section of "RawData" is relevant for this layer of the overall domain
@@ -896,7 +887,6 @@ void TempInit_ReadData(int layernumber, int id, int nx, int MyYSlices, int, int 
     }
 
     // These views are copied to the host, updated for layer "layernumber", and later copied back to the device
-    ViewI_H LayerID_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), LayerID);
     ViewI_H MeltTimeStep_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), MeltTimeStep);
     ViewI_H CritTimeStep_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), CritTimeStep);
     ViewF_H UndercoolingChange_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), UndercoolingChange);
@@ -906,10 +896,6 @@ void TempInit_ReadData(int layernumber, int id, int nx, int MyYSlices, int, int 
     ViewF3D_H LayerTimeTempHistory_Host("TimeTempHistory_H", LocalActiveDomainSize,
                                         MaxSolidificationEvents_Host(layernumber), 3);
     ViewI_H NumberOfSolidificationEvents_Host("NumSEvents_H", LocalActiveDomainSize);
-
-    // First layer - all LayerID values are -1, to later be populated with other values
-    if (layernumber == 0)
-        Kokkos::deep_copy(LayerID_Host, -1);
 
     double LargestTime = 0;
     double LargestTime_Global = 0;
@@ -1012,7 +998,6 @@ void TempInit_ReadData(int layernumber, int id, int nx, int MyYSlices, int, int 
                 int GlobalD3D1ConvPosition = GlobalZ * nx * MyYSlices + i * MyYSlices + j;
                 if (LayerTimeTempHistory_Host(D3D1ConvPosition, 0, 0) > 0) {
                     // This cell undergoes solidification in layer "layernumber" at least once
-                    LayerID_Host(GlobalD3D1ConvPosition) = layernumber;
                     MeltTimeStep_Host(GlobalD3D1ConvPosition) =
                         (int)(LayerTimeTempHistory_Host(D3D1ConvPosition, 0, 0));
                     CritTimeStep_Host(GlobalD3D1ConvPosition) =
@@ -1037,7 +1022,6 @@ void TempInit_ReadData(int layernumber, int id, int nx, int MyYSlices, int, int 
 
     // Copy host view data back to device
     MaxSolidificationEvents = Kokkos::create_mirror_view_and_copy(device_memory_space(), MaxSolidificationEvents_Host);
-    LayerID = Kokkos::create_mirror_view_and_copy(device_memory_space(), LayerID_Host);
     MeltTimeStep = Kokkos::create_mirror_view_and_copy(device_memory_space(), MeltTimeStep_Host);
     CritTimeStep = Kokkos::create_mirror_view_and_copy(device_memory_space(), CritTimeStep_Host);
     UndercoolingChange = Kokkos::create_mirror_view_and_copy(device_memory_space(), UndercoolingChange_Host);
@@ -1084,375 +1068,6 @@ void OrientationInit(int, int &NGrainOrientations, ViewF &GrainOrientationData, 
     // Resize device view and orientation data to device
     Kokkos::realloc(GrainOrientationData, ValsPerLine * NGrainOrientations);
     GrainOrientationData = Kokkos::create_mirror_view_and_copy(device_memory_space(), GrainOrientationData_Host);
-}
-
-// Initializes cell types and epitaxial Grain ID values where substrate grains are active cells on the bottom surface of
-// the constrained domain. Also initialize active cell data structures associated with the substrate grains
-void SubstrateInit_ConstrainedGrowth(int id, double FractSurfaceSitesActive, int MyYSlices, int nx, int ny,
-                                     int MyYOffset, NList NeighborX, NList NeighborY, NList NeighborZ,
-                                     ViewF GrainUnitVector, int NGrainOrientations, ViewI CellType, ViewI GrainID,
-                                     ViewF DiagonalLength, ViewF DOCenter, ViewF CritDiagonalLength, double RNGSeed) {
-
-    // Calls to Xdist(gen) and Y dist(gen) return random locations for grain seeds
-    // Since X = 0 and X = nx-1 are the cell centers of the last cells in X, locations are evenly scattered between X =
-    // -0.49999 and X = nx - 0.5, as the cells have a half width of 0.5
-    std::mt19937_64 gen(RNGSeed);
-    std::uniform_real_distribution<double> Xdist(-0.49999, nx - 0.5);
-    std::uniform_real_distribution<double> Ydist(-0.49999, ny - 0.5);
-
-    // Determine number of active cells from the fraction of sites active and the number of sites on the bottom domain
-    // surface
-    int SubstrateActCells = std::round(FractSurfaceSitesActive * nx * ny);
-
-    // On all ranks, generate active site locations - same list on every rank
-    // TODO: Generate random numbers on GPU, instead of using host view and copying over - ensure that locations are in
-    // the same order every time based on the RNGSeed
-    ViewI_H ActCellX_Host(Kokkos::ViewAllocateWithoutInitializing("ActCellX_Host"), SubstrateActCells);
-    ViewI_H ActCellY_Host(Kokkos::ViewAllocateWithoutInitializing("ActCellY_Host"), SubstrateActCells);
-
-    // Randomly locate substrate grain seeds for cells in the interior of this subdomain (at the k = 0 bottom surface)
-    for (int n = 0; n < SubstrateActCells; n++) {
-        double XLocation = Xdist(gen);
-        double YLocation = Ydist(gen);
-        // Randomly select integer coordinates between 0 and nx-1 or ny-1
-        ActCellX_Host(n) = round(XLocation);
-        ActCellY_Host(n) = round(YLocation);
-    }
-
-    // Copy views of substrate grain locations back to the device
-    ViewI ActCellX_Device = Kokkos::create_mirror_view_and_copy(device_memory_space(), ActCellX_Host);
-    ViewI ActCellY_Device = Kokkos::create_mirror_view_and_copy(device_memory_space(), ActCellY_Host);
-
-    // Start with all cells as liquid prior to locating substrate grain seeds
-    Kokkos::deep_copy(CellType, Liquid);
-
-    // Determine which grains/active cells belong to which MPI ranks
-    Kokkos::parallel_for(
-        "ConstrainedGrainInit", SubstrateActCells, KOKKOS_LAMBDA(const int &n) {
-            // What are the X and Y coordinates of this active cell relative to the X and Y bounds of this rank?
-            if ((ActCellY_Device(n) >= MyYOffset) && (ActCellY_Device(n) < MyYOffset + MyYSlices)) {
-                // Convert X and Y coordinates to values relative to this MPI rank's grid (Z = 0 for these active cells,
-                // at bottom surface) GrainIDs come from the position on the list of substrate active cells to avoid
-                // reusing the same value
-                int GlobalX = ActCellX_Device(n);
-                int LocalY = ActCellY_Device(n) - MyYOffset;
-                int D3D1ConvPosition = GlobalX * MyYSlices + LocalY;
-                CellType(D3D1ConvPosition) = Active;
-                GrainID(D3D1ConvPosition) = n + 1; // assign GrainID > 0 to epitaxial seeds
-                // Initialize active cell data structures
-                int GlobalY = LocalY + MyYOffset;
-                int GlobalZ = 0;
-                // Initialize new octahedron
-                createNewOctahedron(D3D1ConvPosition, DiagonalLength, DOCenter, GlobalX, GlobalY, GlobalZ);
-
-                // The orientation for the new grain will depend on its Grain ID
-                int MyOrientation = getGrainOrientation(n + 1, NGrainOrientations);
-                float cx = GlobalX + 0.5;
-                float cy = GlobalY + 0.5;
-                float cz = GlobalZ + 0.5;
-                // Calculate critical values at which this active cell leads to the activation of a neighboring liquid
-                // cell. Octahedron center and cell center overlap for octahedra created as part of a new grain
-                calcCritDiagonalLength(D3D1ConvPosition, cx, cy, cz, cx, cy, cz, NeighborX, NeighborY, NeighborZ,
-                                       MyOrientation, GrainUnitVector, CritDiagonalLength);
-            }
-        });
-    if (id == 0)
-        std::cout << "Number of substrate active cells across all ranks: " << SubstrateActCells << std::endl;
-}
-
-// Determine the height of the baseplate, in CA cells
-// The baseplate always starts at the simulation bottom (Z coordinate corresponding to ZMin), regardless of whether the
-// first layer melts the cells at the bottom or not If BaseplateThroughPowder is true, the baseplate microstructure
-// extends through the entire simulation domain in Z If BaseplateThroughPowder is false and PowderFirstLayer is true,
-// the baseplate extends to the Z coordinate that is LayerHeight cells short of the top of the first layer (the final
-// LayerHeight cells of the first layer will be initialized using the powder options specified)) If
-// BaseplateThroughPowder is false and PowderFirstLayer is false, the baseplate extends to the top of the first layer
-int getBaseplateSizeZ(int nz, double *ZMaxLayer, double ZMin, double deltax, int LayerHeight,
-                      bool BaseplateThroughPowder, bool PowderFirstLayer) {
-    int BaseplateSizeZ;
-    if (BaseplateThroughPowder)
-        BaseplateSizeZ = nz;
-    else {
-        if (PowderFirstLayer)
-            BaseplateSizeZ = round((ZMaxLayer[0] - ZMin) / deltax) + 1 - LayerHeight;
-
-        else
-            BaseplateSizeZ = round((ZMaxLayer[0] - ZMin) / deltax) + 1;
-    }
-    return BaseplateSizeZ;
-}
-
-// Initializes Grain ID values where the substrate comes from a file
-void SubstrateInit_FromFile(std::string SubstrateFileName, int nz, int nx, int MyYSlices, int MyYOffset, int id,
-                            ViewI &GrainID_Device, double ZMin, double *ZMaxLayer, bool BaseplateThroughPowder,
-                            bool PowderFirstLayer, int LayerHeight, double deltax) {
-
-    // Assign GrainID values to cells that are part of the substrate - read values from file and initialize using
-    // temporary host view
-    ViewI_H GrainID_Host(Kokkos::ViewAllocateWithoutInitializing("GrainID_Host"), nx * MyYSlices * nz);
-    std::ifstream Substrate;
-    Substrate.open(SubstrateFileName);
-    int Substrate_LowY = MyYOffset;
-    int Substrate_HighY = MyYOffset + MyYSlices;
-    int nxS, nyS, nzS;
-    int BaseplateSizeZ = getBaseplateSizeZ(nz, ZMaxLayer, ZMin, deltax, LayerHeight, BaseplateThroughPowder,
-                                           PowderFirstLayer); // in CA cells
-    if ((id == 0) && (BaseplateSizeZ < 1))
-        std::cout << "Warning: No substrate data from the file be used, as the powder layer extends further in the Z "
-                     "direction than the first layer's temperature data"
-                  << std::endl;
-    std::string s;
-    getline(Substrate, s);
-    std::size_t found = s.find("=");
-    std::string str = s.substr(found + 1, s.length() - 1);
-    nzS = stoi(str, nullptr, 10);
-    getline(Substrate, s);
-    found = s.find("=");
-    str = s.substr(found + 1, s.length() - 1);
-    nyS = stoi(str, nullptr, 10);
-    getline(Substrate, s);
-    found = s.find("=");
-    str = s.substr(found + 1, s.length() - 1);
-    nxS = stoi(str, nullptr, 10);
-    if ((id == 0) && (nzS < BaseplateSizeZ)) {
-        // Do not allow simulation if there is inssufficient substrate data in the specified file
-        std::string error = "Error: only " + std::to_string(nzS) +
-                            " layers of substrate data are present in the file " + SubstrateFileName + " ; at least " +
-                            std::to_string(BaseplateSizeZ) +
-                            " layers of substrate data are required to simulate the specified solidification problem";
-        throw std::runtime_error(error);
-    }
-
-    // Assign GrainID values to all cells - cells that will be part of the melt pool footprint may still need their
-    // initial GrainID
-    for (int k = 0; k < nzS; k++) {
-        if (k == BaseplateSizeZ)
-            break;
-        for (int j = 0; j < nyS; j++) {
-            for (int i = 0; i < nxS; i++) {
-                std::string GIDVal;
-                getline(Substrate, GIDVal);
-                if ((j >= Substrate_LowY) && (j < Substrate_HighY)) {
-                    int CAGridLocation;
-                    CAGridLocation = k * nx * MyYSlices + i * MyYSlices + (j - MyYOffset);
-                    GrainID_Host(CAGridLocation) = stoi(GIDVal, nullptr, 10);
-                }
-            }
-        }
-    }
-    Substrate.close();
-    // Copy GrainIDs read from file to device
-    GrainID_Device = Kokkos::create_mirror_view_and_copy(device_memory_space(), GrainID_Host);
-    if (id == 0)
-        std::cout << "Substrate file read complete" << std::endl;
-}
-
-// Initializes Grain ID values where the baseplate is generated using an input grain spacing and a Voronoi Tessellation
-void BaseplateInit_FromGrainSpacing(float SubstrateGrainSpacing, int nx, int ny, double ZMin, double *ZMaxLayer,
-                                    int MyYSlices, int MyYOffset, int id, double deltax, ViewI GrainID, double RNGSeed,
-                                    int &NextLayer_FirstEpitaxialGrainID, int nz, double BaseplateThroughPowder,
-                                    bool PowderFirstLayer, int LayerHeight) {
-
-    // Number of cells to assign GrainID
-    int BaseplateSizeZ = getBaseplateSizeZ(nz, ZMaxLayer, ZMin, deltax, LayerHeight, BaseplateThroughPowder,
-                                           PowderFirstLayer); // in CA cells
-    if ((id == 0) && (BaseplateSizeZ < 1))
-        std::cout << "Warning: no baseplate microstructure will be used, as the powder layer extends further in the Z "
-                     "direction than the first layer's temperature data"
-                  << std::endl;
-    std::mt19937_64 gen(RNGSeed);
-
-    // Based on the baseplate volume (convert to cubic microns to match units) and the substrate grain spacing,
-    // determine the number of baseplate grains
-    int BaseplateVolume = nx * ny * BaseplateSizeZ;
-    double BaseplateVolume_microns = BaseplateVolume * pow(deltax, 3) * pow(10, 18);
-    double SubstrateMeanGrainVolume_microns = pow(SubstrateGrainSpacing, 3);
-    int NumberOfBaseplateGrains = round(BaseplateVolume_microns / SubstrateMeanGrainVolume_microns);
-    // Need at least 1 baseplate grain, cannot have more baseplate grains than cells in the baseplate
-    NumberOfBaseplateGrains = std::max(NumberOfBaseplateGrains, 1);
-    NumberOfBaseplateGrains = std::min(NumberOfBaseplateGrains, nx * ny * BaseplateSizeZ);
-    // TODO: Use device RNG to generate baseplate grain locations, instead of host with copy
-    // List of potential grain IDs (starting at 1) - index corresponds to the associated CA cell location
-    // Assign positive values for indices 0 through NumberOfBaseplateGrains-1, assign zeros to the remaining indices
-    std::vector<int> BaseplateGrainLocations(BaseplateVolume);
-    std::vector<int> BaseplateGrainIDs(BaseplateVolume);
-    for (int i = 0; i < BaseplateVolume; i++) {
-        BaseplateGrainLocations[i] = i;
-        if (i < NumberOfBaseplateGrains)
-            BaseplateGrainIDs[i] = i + 1;
-        else
-            BaseplateGrainIDs[i] = 0;
-    }
-    // Shuffle list of grain IDs
-    std::shuffle(BaseplateGrainIDs.begin(), BaseplateGrainIDs.end(), gen);
-
-    // Create views of baseplate grain IDs and locations - copying BaseplateGrainIDs and BaseplateGrainLocations values
-    // only for indices where BaseplateGrainIDs(i) != 0 (cells with BaseplateGrainIDs(i) = 0 were not assigned baseplate
-    // center locations)
-    ViewI_H BaseplateGrainLocations_Host(Kokkos::ViewAllocateWithoutInitializing("BaseplateGrainLocations_Host"),
-                                         NumberOfBaseplateGrains);
-    ViewI_H BaseplateGrainIDs_Host(Kokkos::ViewAllocateWithoutInitializing("BaseplateGrainIDs_Host"),
-                                   NumberOfBaseplateGrains);
-    int count = 0;
-    for (int i = 0; i < BaseplateVolume; i++) {
-        if (BaseplateGrainIDs[i] != 0) {
-            BaseplateGrainLocations_Host(count) = BaseplateGrainLocations[i];
-            BaseplateGrainIDs_Host(count) = BaseplateGrainIDs[i];
-            count++;
-        }
-    }
-
-    // Copy baseplate views to the device
-    ViewI BaseplateGrainIDs_Device = Kokkos::create_mirror_view_and_copy(device_memory_space(), BaseplateGrainIDs_Host);
-    ViewI BaseplateGrainLocations_Device =
-        Kokkos::create_mirror_view_and_copy(device_memory_space(), BaseplateGrainLocations_Host);
-    if (id == 0) {
-        std::cout << "Baseplate spanning domain coordinates Z = 0 through " << BaseplateSizeZ - 1 << std::endl;
-        std::cout << "Number of baseplate grains: " << NumberOfBaseplateGrains << std::endl;
-    }
-
-    // First, assign cells that are associated with grain centers the appropriate non-zero GrainID values (assumes
-    // GrainID values were initialized to zeros)
-    Kokkos::parallel_for(
-        "BaseplateInit", NumberOfBaseplateGrains, KOKKOS_LAMBDA(const int &n) {
-            int BaseplateGrainLoc = BaseplateGrainLocations_Device(n);
-            // x, y, z associated with baseplate grain "n", at 1D coordinate "BaseplateGrainLoc"
-            int z_n = BaseplateGrainLoc / (nx * ny);
-            int Rem = BaseplateGrainLoc % (nx * ny);
-            int x_n = Rem / ny;
-            int y_n = Rem % ny;
-            if ((y_n >= MyYOffset) && (y_n < MyYOffset + MyYSlices)) {
-                // This grain is associated with a cell on this MPI rank
-                int CAGridLocation = z_n * nx * MyYSlices + x_n * MyYSlices + (y_n - MyYOffset);
-                GrainID(CAGridLocation) = BaseplateGrainIDs_Device(n);
-            }
-        });
-    Kokkos::fence();
-    // For cells that are not associated with grain centers, assign them the GrainID of the nearest grain center
-    Kokkos::parallel_for(
-        "BaseplateGen",
-        Kokkos::MDRangePolicy<Kokkos::Rank<3, Kokkos::Iterate::Right, Kokkos::Iterate::Right>>(
-            {0, 0, 0}, {BaseplateSizeZ, nx, MyYSlices}),
-        KOKKOS_LAMBDA(const int k, const int i, const int j) {
-            int CAGridLocation = k * nx * MyYSlices + i * MyYSlices + j;
-            if (GrainID(CAGridLocation) == 0) {
-                // This cell needs to be assigned a GrainID value
-                // Check each possible baseplate grain center to find the closest one
-                float MinDistanceToThisGrain = nx * ny * BaseplateSizeZ;
-                int MinDistanceToThisGrain_GrainID = 0;
-                for (int n = 0; n < NumberOfBaseplateGrains; n++) {
-                    // Baseplate grain center at x_n, y_n, z_n - how far is the cell at i, j+MyYOffset, k?
-                    int z_n = BaseplateGrainLocations_Device(n) / (nx * ny);
-                    int Rem = BaseplateGrainLocations_Device(n) % (nx * ny);
-                    int x_n = Rem / ny;
-                    int y_n = Rem % ny;
-                    float DistanceToThisGrainX = i - x_n;
-                    float DistanceToThisGrainY = (j + MyYOffset) - y_n;
-                    float DistanceToThisGrainZ = k - z_n;
-                    float DistanceToThisGrain = sqrtf(DistanceToThisGrainX * DistanceToThisGrainX +
-                                                      DistanceToThisGrainY * DistanceToThisGrainY +
-                                                      DistanceToThisGrainZ * DistanceToThisGrainZ);
-                    if (DistanceToThisGrain < MinDistanceToThisGrain) {
-                        // This is the closest grain center to cell at "CAGridLocation" - update values
-                        MinDistanceToThisGrain = DistanceToThisGrain;
-                        MinDistanceToThisGrain_GrainID = BaseplateGrainIDs_Device(n);
-                    }
-                }
-                // GrainID associated with the closest baseplate grain center
-                GrainID(CAGridLocation) = MinDistanceToThisGrain_GrainID;
-            }
-        });
-
-    NextLayer_FirstEpitaxialGrainID =
-        NumberOfBaseplateGrains + 2; // avoid reusing GrainID in next layer's powder grain structure
-    if (id == 0)
-        std::cout << "Baseplate grain structure initialized" << std::endl;
-}
-
-// Each layer's top Z coordinates are seeded with CA-cell sized substrate grains (emulating bulk nucleation alongside
-// the edges of partially melted powder particles)
-void PowderInit(int layernumber, int nx, int ny, int LayerHeight, double *ZMaxLayer, double ZMin, double deltax,
-                int MyYSlices, int MyYOffset, int id, ViewI GrainID, double RNGSeed,
-                int &NextLayer_FirstEpitaxialGrainID, double PowderActiveFraction) {
-
-    // On all ranks, generate list of powder grain IDs (starting with NextLayer_FirstEpitaxialGrainID, and shuffle them
-    // so that their locations aren't sequential and depend on the RNGSeed (different for each layer)
-    std::mt19937_64 gen(RNGSeed + layernumber);
-    std::uniform_real_distribution<double> dis(0.0, 1.0);
-
-    // TODO: This should be performed on the device, rather than the host
-    int PowderLayerCells = nx * ny * LayerHeight;
-    int PowderLayerAssignedCells = round(static_cast<double>(PowderLayerCells) * PowderActiveFraction);
-    std::vector<int> PowderGrainIDs(PowderLayerCells, 0);
-    for (int n = 0; n < PowderLayerAssignedCells; n++) {
-        PowderGrainIDs[n] = n + NextLayer_FirstEpitaxialGrainID; // assigned a nonzero GrainID
-    }
-    std::shuffle(PowderGrainIDs.begin(), PowderGrainIDs.end(), gen);
-    // Copy powder layer GrainIDs into a host view, then a device view
-    ViewI_H PowderGrainIDs_Host(Kokkos::ViewAllocateWithoutInitializing("PowderGrainIDs_Host"), PowderLayerCells);
-    for (int n = 0; n < PowderLayerCells; n++) {
-        PowderGrainIDs_Host(n) = PowderGrainIDs[n];
-    }
-    ViewI PowderGrainIDs_Device = Kokkos::create_mirror_view_and_copy(device_memory_space(), PowderGrainIDs_Host);
-    // Associate powder grain IDs with CA cells in the powder layer
-    // Use bounds from temperature field for this layer to determine which cells are part of the powder
-    int PowderTopZ = round((ZMaxLayer[layernumber] - ZMin) / deltax) + 1;
-    int PowderBottomZ = PowderTopZ - LayerHeight;
-    MPI_Barrier(MPI_COMM_WORLD);
-    if (id == 0)
-        std::cout << "Initializing powder layer for Z = " << PowderBottomZ << " through " << PowderTopZ - 1 << " ("
-                  << nx * ny * (PowderTopZ - PowderBottomZ) << " cells)" << std::endl;
-
-    int PowderStart = nx * ny * PowderBottomZ;
-    int PowderEnd = nx * ny * PowderTopZ;
-    if (id == 0)
-        std::cout << "Powder layer has " << PowderLayerAssignedCells
-                  << " cells assigned new grain ID values, ranging from " << NextLayer_FirstEpitaxialGrainID
-                  << " through " << NextLayer_FirstEpitaxialGrainID + PowderLayerAssignedCells - 1 << std::endl;
-    Kokkos::parallel_for(
-        "PowderGrainInit", Kokkos::RangePolicy<>(PowderStart, PowderEnd), KOKKOS_LAMBDA(const int &n) {
-            int GlobalZ = n / (nx * ny);
-            int Rem = n % (nx * ny);
-            int GlobalX = Rem / ny;
-            int GlobalY = Rem % ny;
-            // Is this powder coordinate in X and Y in bounds for this rank? Is the grain id of this site unassigned
-            // (wasn't captured during solidification of the previous layer)?
-            int GlobalD3D1ConvPosition = GlobalZ * nx * MyYSlices + GlobalX * MyYSlices + (GlobalY - MyYOffset);
-            if ((GlobalY >= MyYOffset) && (GlobalY < MyYOffset + MyYSlices) && (GrainID(GlobalD3D1ConvPosition) == 0))
-                GrainID(GlobalD3D1ConvPosition) = PowderGrainIDs_Device(n - PowderStart);
-        });
-    Kokkos::fence();
-
-    // Update NextLayer_FirstEpitaxialGrainID for next layer
-    NextLayer_FirstEpitaxialGrainID += PowderLayerAssignedCells;
-    MPI_Barrier(MPI_COMM_WORLD);
-    if (id == 0)
-        std::cout << "Initialized powder grain structure for layer " << layernumber << std::endl;
-}
-
-//*****************************************************************************/
-// Initializes cells for the current layer as either solid (don't resolidify) or tempsolid (will melt and resolidify)
-void CellTypeInit(int nx, int MyYSlices, int LocalActiveDomainSize, ViewI CellType, ViewI NumberOfSolidificationEvents,
-                  int id, int ZBound_Low) {
-
-    int MeltPoolCellCount;
-    Kokkos::parallel_reduce(
-        "CellTypeInitSolidRM", LocalActiveDomainSize,
-        KOKKOS_LAMBDA(const int &D3D1ConvPosition, int &local_count) {
-            int GlobalD3D1ConvPosition = D3D1ConvPosition + ZBound_Low * nx * MyYSlices;
-            if (NumberOfSolidificationEvents(D3D1ConvPosition) > 0) {
-                CellType(GlobalD3D1ConvPosition) = TempSolid;
-                local_count++;
-            }
-            else
-                CellType(GlobalD3D1ConvPosition) = Solid;
-        },
-        MeltPoolCellCount);
-    int TotalMeltPoolCellCount;
-    MPI_Reduce(&MeltPoolCellCount, &TotalMeltPoolCellCount, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
-    if (id == 0)
-        std::cout << "Number of cells across all ranks to undergo solidification at least once: "
-                  << TotalMeltPoolCellCount << std::endl;
 }
 
 //*****************************************************************************/

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -45,7 +45,7 @@ int calcnzActive(int ZBound_Low, int ZBound_High, int id, int layernumber);
 int calcLocalActiveDomainSize(int nx, int MyYSlices, int nzActive);
 void TempInit_DirSolidification(double G, double R, int id, int &nx, int &MyYSlices, double deltax, double deltat,
                                 int nz, int LocalDomainSize, ViewI &CritTimeStep, ViewF &UndercoolingChange,
-                                ViewI &LayerID, ViewI &NumberOfSolidificationEvents, ViewI &SolidificationEventCounter,
+                                ViewI &NumberOfSolidificationEvents, ViewI &SolidificationEventCounter,
                                 ViewI &MeltTimeStep, ViewI MaxSolidificationEvents, ViewF3D &LayerTimeTempHistory);
 int calcMaxSolidificationEventsSpot(int nx, int MyYSlices, int NumberOfSpots, int NSpotsX, int SpotRadius,
                                     int SpotOffset, int MyYOffset);
@@ -54,7 +54,7 @@ void OrientationInit(int id, int &NGrainOrientations, ViewF &ReadOrientationData
 void TempInit_Spot(int layernumber, double G, double R, std::string, int id, int &nx, int &MyYSlices, int &MyYOffset,
                    double deltax, double deltat, int ZBound_Low, int nz, int LocalActiveDomainSize, int LocalDomainSize,
                    ViewI &CritTimeStep, ViewF &UndercoolingChange, ViewF &UndercoolingCurrent, int LayerHeight,
-                   double FreezingRange, ViewI &LayerID, int NSpotsX, int NSpotsY, int SpotRadius, int SpotOffset,
+                   double FreezingRange, int NSpotsX, int NSpotsY, int SpotRadius, int SpotOffset,
                    ViewF3D &LayerTimeTempHistory, ViewI &NumberOfSolidificationEvents, ViewI &MeltTimeStep,
                    ViewI &MaxSolidificationEvents, ViewI &SolidificationEventCounter);
 int getTempCoordX(int i, double XMin, double deltax, const ViewD_H RawTemperatureData);
@@ -74,26 +74,8 @@ void TempInit_ReadData(int layernumber, int id, int nx, int MyYSlices, int nz, i
                        ViewI &MaxSolidificationEvents, ViewI &MeltTimeStep, ViewI &CritTimeStep,
                        ViewF &UndercoolingChange, ViewF &UndercoolingCurrent, double XMin, double YMin,
                        double *ZMinLayer, int LayerHeight, int nzActive, int ZBound_Low, int *FinishTimeStep,
-                       ViewI &LayerID, int *FirstValue, int *LastValue, ViewD_H RawTemperatureData,
-                       ViewI &SolidificationEventCounter, int TempFilesInSeries);
-void SubstrateInit_ConstrainedGrowth(int id, double FractSurfaceSitesActive, int MyYSlices, int nx, int ny,
-                                     int MyYOffset, NList NeighborX, NList NeighborY, NList NeighborZ,
-                                     ViewF GrainUnitVector, int NGrainOrientations, ViewI CellType, ViewI GrainID,
-                                     ViewF DiagonalLength, ViewF DOCenter, ViewF CritDiagonalLength, double RNGSeed);
-int getBaseplateSizeZ(int nz, double *ZMaxLayer, double ZMin, double deltax, int LayerHeight,
-                      bool BaseplateThroughPowder, bool PowderFirstLayer);
-void SubstrateInit_FromFile(std::string SubstrateFileName, int nz, int nx, int MyYSlices, int MyYOffset, int pid,
-                            ViewI &GrainID, double ZMin, double *ZMaxLayer, bool BaseplateThroughPowder,
-                            bool PowderFirstLayer, int LayerHeight, double deltax);
-void BaseplateInit_FromGrainSpacing(float SubstrateGrainSpacing, int nx, int ny, double ZMin, double *ZMaxLayer,
-                                    int MyYSlices, int MyYOffset, int id, double deltax, ViewI GrainID, double RNGSeed,
-                                    int &NextLayer_FirstEpitaxialGrainID, int nz, double BaseplateThroughPowder,
-                                    bool PowderFirstLayer, int LayerHeight);
-void PowderInit(int layernumber, int nx, int ny, int LayerHeight, double *ZMaxLayer, double ZMin, double deltax,
-                int MyYSlices, int MyYOffset, int id, ViewI GrainID, double RNGSeed,
-                int &NextLayer_FirstEpitaxialGrainID, double PowderActiveFraction);
-void CellTypeInit(int nx, int MyYSlices, int LocalActiveDomainSize, ViewI CellType, ViewI NumberOfSolidificationEvents,
-                  int id, int ZBound_Low);
+                       int *FirstValue, int *LastValue, ViewD_H RawTemperatureData, ViewI &SolidificationEventCounter,
+                       int TempFilesInSeries);
 void ZeroResetViews(int LocalActiveDomainSize, ViewF &DiagonalLength, ViewF &CritDiagonalLength, ViewF &DOCenter,
                     ViewI &SteeringVector);
 

--- a/src/CAnucleation.hpp
+++ b/src/CAnucleation.hpp
@@ -230,7 +230,7 @@ struct Nucleation {
 
     // Compute velocity from local undercooling.
     // functional form is assumed to be cubic if not explicitly given in input file
-    void nucleate_grain(int cycle, CellData<device_memory_space> &cellData, int, int, int, view_type_int SteeringVector,
+    void nucleate_grain(int cycle, CellData<memory_space> &cellData, int, int, int, view_type_int SteeringVector,
                         view_type_int numSteer_G) {
 
         auto CellType = cellData.getCellTypeSubview();

--- a/src/CAnucleation.hpp
+++ b/src/CAnucleation.hpp
@@ -76,8 +76,8 @@ struct Nucleation {
     // accounting for multiple possible nucleation events in cells that melt and solidify multiple times
     template <class... Params>
     void placeNuclei(view_type_int MaxSolidificationEvents, view_type_int NumberOfSolidificationEvents,
-                     Kokkos::View<float ***, Params...> LayerTimeTempHistory, double RNGSeed, int layernumber, int nx, int ny,
-                     int nzActive, double dTN, double dTsigma, int MyYSlices, int MyYOffset, int, int id,
+                     Kokkos::View<float ***, Params...> LayerTimeTempHistory, double RNGSeed, int layernumber, int nx,
+                     int ny, int nzActive, double dTN, double dTsigma, int MyYSlices, int MyYOffset, int, int id,
                      bool AtNorthBoundary, bool AtSouthBoundary) {
 
         // TODO: convert this subroutine into kokkos kernels, rather than copying data back to the host, and nucleation

--- a/src/CAnucleation.hpp
+++ b/src/CAnucleation.hpp
@@ -6,6 +6,7 @@
 #ifndef EXACA_NUCLEATION_HPP
 #define EXACA_NUCLEATION_HPP
 
+#include "CAcelldata.hpp"
 #include "CAconfig.hpp"
 #include "CAtypes.hpp"
 #include "mpi.h"
@@ -75,9 +76,9 @@ struct Nucleation {
     // accounting for multiple possible nucleation events in cells that melt and solidify multiple times
     template <class... Params>
     void placeNuclei(view_type_int MaxSolidificationEvents, view_type_int NumberOfSolidificationEvents,
-                     Kokkos::View<float ***, Params...> LayerTimeTempHistory, double RNGSeed, int layernumber, int nx,
-                     int ny, int nzActive, double dTN, double dTsigma, int MyYSlices, int MyYOffset, int ZBound_Low,
-                     int id, bool AtNorthBoundary, bool AtSouthBoundary) {
+                     Kokkos::View<float ***, Params...> LayerTimeTempHistory, double RNGSeed, int layernumber, int nx, int ny,
+                     int nzActive, double dTN, double dTsigma, int MyYSlices, int MyYOffset, int, int id,
+                     bool AtNorthBoundary, bool AtSouthBoundary) {
 
         // TODO: convert this subroutine into kokkos kernels, rather than copying data back to the host, and nucleation
         // data back to the device again. This is currently performed on the device due to heavy usage of standard
@@ -151,19 +152,16 @@ struct Nucleation {
                 if (((NucleiY(NEvent) > MyYOffset) || (AtSouthBoundary)) &&
                     ((NucleiY(NEvent) < MyYOffset + MyYSlices - 1) || (AtNorthBoundary))) {
                     // Convert 3D location (using global X and Y coordinates) into a 1D location (using local X and Y
-                    // coordinates) for the possible nucleation event, both as relative to the bottom of this layer as
-                    // well as relative to the bottom of the overall domain
+                    // coordinates) for the possible nucleation event, both as relative to the bottom of this layer
                     int NucleiLocation_ThisLayer =
                         NucleiZ(NEvent) * nx * MyYSlices + NucleiX(NEvent) * MyYSlices + (NucleiY(NEvent) - MyYOffset);
-                    int NucleiLocation_AllLayers = (NucleiZ(NEvent) + ZBound_Low) * nx * MyYSlices +
-                                                   NucleiX(NEvent) * MyYSlices + (NucleiY(NEvent) - MyYOffset);
                     // Criteria for placing a nucleus - whether or not this nuclei is associated with a solidification
                     // event
                     if (meltevent < NumberOfSolidificationEvents_Host(NucleiLocation_ThisLayer)) {
                         // Nucleation event is possible - cell undergoes solidification at least once, this nucleation
                         // event is associated with one of the time periods during which the associated cell undergoes
                         // solidification
-                        NucleiLocation_MyRank_V[PossibleNuclei] = NucleiLocation_AllLayers;
+                        NucleiLocation_MyRank_V[PossibleNuclei] = NucleiLocation_ThisLayer;
 
                         int CritTimeStep_ThisEvent = LayerTimeTempHistory_Host(NucleiLocation_ThisLayer, meltevent, 1);
                         float UndercoolingChange_ThisEvent =
@@ -232,8 +230,11 @@ struct Nucleation {
 
     // Compute velocity from local undercooling.
     // functional form is assumed to be cubic if not explicitly given in input file
-    void nucleate_grain(int cycle, view_type_int CellType, view_type_int GrainID, int ZBound_Low, int nx, int MyYSlices,
-                        view_type_int SteeringVector, view_type_int numSteer_G) {
+    void nucleate_grain(int cycle, CellData &cellData, int, int, int, view_type_int SteeringVector,
+                        view_type_int numSteer_G) {
+
+        ViewI CellType = cellData.getCellTypeSubview();
+        ViewI GrainID = cellData.getGrainIDSubview();
 
         // Is there nucleation left in this layer to check?
         if (NucleationCounter < PossibleNuclei) {
@@ -261,25 +262,18 @@ struct Nucleation {
                 Kokkos::parallel_reduce(
                     "NucleiUpdateLoop", Kokkos::RangePolicy<>(FirstEvent, LastEvent),
                     KOKKOS_LAMBDA(const int NucleationCounter_Device, int &update) {
-                        int NucleationEventLocation_GlobalGrid = NucleiLocations_local(NucleationCounter_Device);
+                        int NucleationEventLocation = NucleiLocations_local(NucleationCounter_Device);
                         int update_val =
                             FutureActive; // added to steering vector to become a new active cell as part of cellcapture
                         int old_val = Liquid;
-                        int OldCellTypeValue = Kokkos::atomic_compare_exchange(
-                            &CellType(NucleationEventLocation_GlobalGrid), old_val, update_val);
+                        int OldCellTypeValue =
+                            Kokkos::atomic_compare_exchange(&CellType(NucleationEventLocation), old_val, update_val);
                         if (OldCellTypeValue == Liquid) {
                             // Successful nucleation event - atomic update of cell type, proceeded if the atomic
                             // exchange is successful (cell was liquid) Add future active cell location to steering
                             // vector and change cell type, assign new Grain ID
-                            GrainID(NucleationEventLocation_GlobalGrid) = NucleiGrainID_local(NucleationCounter_Device);
-                            int GlobalZ = NucleationEventLocation_GlobalGrid / (nx * MyYSlices);
-                            int Rem = NucleationEventLocation_GlobalGrid % (nx * MyYSlices);
-                            int RankX = Rem / MyYSlices;
-                            int RankY = Rem % MyYSlices;
-                            int RankZ = GlobalZ - ZBound_Low;
-                            int NucleationEventLocation_LocalGrid = RankZ * nx * MyYSlices + RankX * MyYSlices + RankY;
-                            SteeringVector(Kokkos::atomic_fetch_add(&numSteer_G(0), 1)) =
-                                NucleationEventLocation_LocalGrid;
+                            GrainID(NucleationEventLocation) = NucleiGrainID_local(NucleationCounter_Device);
+                            SteeringVector(Kokkos::atomic_fetch_add(&numSteer_G(0), 1)) = NucleationEventLocation;
                             // This undercooled liquid cell is now a nuclei (no nuclei are in the ghost nodes - halo
                             // exchange routine GhostNodes1D or GhostNodes2D is used to fill these)
                             update++;

--- a/src/CAnucleation.hpp
+++ b/src/CAnucleation.hpp
@@ -233,8 +233,8 @@ struct Nucleation {
     void nucleate_grain(int cycle, CellData<device_memory_space> &cellData, int, int, int, view_type_int SteeringVector,
                         view_type_int numSteer_G) {
 
-        ViewI CellType = cellData.getCellTypeSubview();
-        ViewI GrainID = cellData.getGrainIDSubview();
+        auto CellType = cellData.getCellTypeSubview();
+        auto GrainID = cellData.getGrainIDSubview();
 
         // Is there nucleation left in this layer to check?
         if (NucleationCounter < PossibleNuclei) {

--- a/src/CAnucleation.hpp
+++ b/src/CAnucleation.hpp
@@ -230,7 +230,7 @@ struct Nucleation {
 
     // Compute velocity from local undercooling.
     // functional form is assumed to be cubic if not explicitly given in input file
-    void nucleate_grain(int cycle, CellData &cellData, int, int, int, view_type_int SteeringVector,
+    void nucleate_grain(int cycle, CellData<device_memory_space> &cellData, int, int, int, view_type_int SteeringVector,
                         view_type_int numSteer_G) {
 
         ViewI CellType = cellData.getCellTypeSubview();

--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -214,10 +214,12 @@ struct Print {
     }
 
     // Called on rank 0, prints initial values of selected data structures to Paraview files for the first layer
-    template <typename ViewTypeInt, typename ViewTypeFloat>
+    template <typename ViewTypeGrainID, typename ViewTypeLayerID, typename ViewTypeMeltTimeStep,
+              typename ViewTypeCritTimeStep, typename ViewTypeUndercoolingChange>
     void printInitExaCAData(int id, int np, int nx, int ny, int MyYSlices, int nzActive, double deltax, double XMin,
-                            double YMin, double ZMin, ViewTypeInt GrainID, ViewTypeInt LayerID,
-                            ViewTypeInt MeltTimeStep, ViewTypeInt CritTimeStep, ViewTypeFloat UndercoolingChange) {
+                            double YMin, double ZMin, ViewTypeGrainID GrainID, ViewTypeLayerID LayerID,
+                            ViewTypeMeltTimeStep MeltTimeStep, ViewTypeCritTimeStep CritTimeStep,
+                            ViewTypeUndercoolingChange UndercoolingChange) {
 
         if ((PrintInitGrainID) || (PrintInitLayerID) || (PrintInitMeltTimeStep) || (PrintInitCritTimeStep) ||
             (PrintInitUndercoolingChange)) {
@@ -258,12 +260,13 @@ struct Print {
 
     // Called on rank 0, prints intermediate values of grain misorientation for all layers up to current layer, also
     // marking which cells are liquid
-    template <typename ViewTypeInt, typename ViewTypeFloat>
+    template <typename ViewTypeGrainID, typename ViewTypeLayerID, typename ViewTypeCellType,
+              typename ViewTypeGrainUnitVector>
     void printIntermediateGrainMisorientation(int id, int np, int cycle, int nx, int ny, int nz, int MyYSlices,
                                               int nzActive, double deltax, double XMin, double YMin, double ZMin,
-                                              ViewTypeInt GrainID, ViewTypeInt LayerID, ViewTypeInt CellType,
-                                              ViewTypeFloat GrainUnitVector, int NGrainOrientations, int layernumber,
-                                              int ZBound_Low) {
+                                              ViewTypeGrainID GrainID, ViewTypeLayerID LayerID,
+                                              ViewTypeCellType CellType, ViewTypeGrainUnitVector GrainUnitVector,
+                                              int NGrainOrientations, int layernumber, int ZBound_Low) {
 
         IntermediateFileCounter++;
         auto GrainID_WholeDomain = collectViewData(id, np, nx, ny, nz, MyYSlices, MPI_INT, GrainID);
@@ -279,11 +282,14 @@ struct Print {
     }
 
     // Prints final values of selected data structures to Paraview files
-    template <typename ViewTypeInt, typename ViewTypeFloat>
+    template <typename ViewTypeGrainID, typename ViewTypeLayerID, typename ViewTypeCell, typename ViewTypeGrainUnit,
+              typename ViewTypeUndercoolingCurrent, typename ViewTypeUndercoolingChange, typename ViewTypeMeltTimeStep,
+              typename ViewTypeCritTimeStep>
     void printFinalExaCAData(int id, int np, int nx, int ny, int nz, int MyYSlices, int NumberOfLayers,
-                             ViewTypeInt LayerID, ViewTypeInt CellType, ViewTypeInt GrainID,
-                             ViewTypeFloat UndercoolingCurrent, ViewTypeFloat UndercoolingChange,
-                             ViewTypeInt MeltTimeStep, ViewTypeInt CritTimeStep, ViewTypeFloat GrainUnitVector,
+                             ViewTypeLayerID LayerID, ViewTypeCell CellType, ViewTypeGrainID GrainID,
+                             ViewTypeUndercoolingCurrent UndercoolingCurrent,
+                             ViewTypeUndercoolingChange UndercoolingChange, ViewTypeMeltTimeStep MeltTimeStep,
+                             ViewTypeCritTimeStep CritTimeStep, ViewTypeGrainUnit GrainUnitVector,
                              int NGrainOrientations, double deltax, double XMin, double YMin, double ZMin) {
 
         if (id == 0)

--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -259,19 +259,20 @@ struct Print {
     // Called on rank 0, prints intermediate values of grain misorientation for all layers up to current layer, also
     // marking which cells are liquid
     template <typename ViewTypeInt, typename ViewTypeFloat>
-    void printIntermediateGrainMisorientation(int id, int np, int cycle, int nx, int ny, int MyYSlices, int nzActive,
-                                              double deltax, double XMin, double YMin, double ZMin, ViewTypeInt GrainID,
-                                              ViewTypeInt LayerID, ViewTypeInt CellType, ViewTypeFloat GrainUnitVector,
-                                              int NGrainOrientations, int layernumber, int ZBound_Low) {
+    void printIntermediateGrainMisorientation(int id, int np, int cycle, int nx, int ny, int nz, int MyYSlices,
+                                              int nzActive, double deltax, double XMin, double YMin, double ZMin,
+                                              ViewTypeInt GrainID, ViewTypeInt LayerID, ViewTypeInt CellType,
+                                              ViewTypeFloat GrainUnitVector, int NGrainOrientations, int layernumber,
+                                              int ZBound_Low) {
 
         IntermediateFileCounter++;
-        auto GrainID_WholeDomain = collectViewData(id, np, nx, ny, nzActive, MyYSlices, MPI_INT, GrainID);
-        auto LayerID_WholeDomain = collectViewData(id, np, nx, ny, nzActive, MyYSlices, MPI_INT, LayerID);
-        auto CellType_WholeDomain = collectViewData(id, np, nx, ny, nzActive, MyYSlices, MPI_INT, CellType);
+        auto GrainID_WholeDomain = collectViewData(id, np, nx, ny, nz, MyYSlices, MPI_INT, GrainID);
+        auto LayerID_WholeDomain = collectViewData(id, np, nx, ny, nz, MyYSlices, MPI_INT, LayerID);
+        auto CellType_WholeDomain = collectViewData(id, np, nx, ny, nz, MyYSlices, MPI_INT, CellType);
         if (id == 0) {
             std::cout << "Intermediate output on time step " << cycle << std::endl;
             auto GrainUnitVector_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), GrainUnitVector);
-            printGrainMisorientations(nx, ny, nzActive, LayerID_WholeDomain, GrainID_WholeDomain, CellType_WholeDomain,
+            printGrainMisorientations(nx, ny, nz, LayerID_WholeDomain, GrainID_WholeDomain, CellType_WholeDomain,
                                       GrainUnitVector_Host, NGrainOrientations, deltax, XMin, YMin, ZMin, true,
                                       layernumber, ZBound_Low, nzActive);
         }

--- a/src/CAupdate.cpp
+++ b/src/CAupdate.cpp
@@ -548,7 +548,7 @@ void CellCapture(int, int np, int, int, int, int nx, int MyYSlices, InterfacialR
 void JumpTimeStep(int &cycle, unsigned long int RemainingCellsOfInterest, unsigned long int LocalTempSolidCells,
                   ViewI MeltTimeStep, int LocalActiveDomainSize, int MyYSlices, int ZBound_Low, ViewI CellType,
                   ViewI LayerID, int id, int layernumber, int np, int nx, int ny, ViewI GrainID, ViewF GrainUnitVector,
-                  Print print, int NGrainOrientations, int nzActive, double deltax, double XMin, double YMin,
+                  Print print, int NGrainOrientations, int nzActive, int nz, double deltax, double XMin, double YMin,
                   double ZMin) {
 
     MPI_Bcast(&RemainingCellsOfInterest, 1, MPI_UNSIGNED_LONG, 0, MPI_COMM_WORLD);
@@ -589,7 +589,7 @@ void JumpTimeStep(int &cycle, unsigned long int RemainingCellsOfInterest, unsign
                     if (cycle_jump % print.TimeSeriesInc == 0) {
                         // Print current state of ExaCA simulation (up to and including the current layer's data)
                         print.printIntermediateGrainMisorientation(
-                            id, np, cycle, nx, ny, MyYSlices, nzActive, deltax, XMin, YMin, ZMin, GrainID, LayerID,
+                            id, np, cycle, nx, ny, nz, MyYSlices, nzActive, deltax, XMin, YMin, ZMin, GrainID, LayerID,
                             CellType, GrainUnitVector, NGrainOrientations, layernumber, ZBound_Low);
                     }
                 }
@@ -606,7 +606,7 @@ void JumpTimeStep(int &cycle, unsigned long int RemainingCellsOfInterest, unsign
 // Prints intermediate code output to stdout (intermediate output collected and printed is different than without
 // remelting) and checks to see if solidification is complete in the case where cells can solidify multiple times
 void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyYSlices, int LocalActiveDomainSize, int nx, int ny,
-                                int nzActive, double deltax, double XMin, double YMin, double ZMin,
+                                int nz, int nzActive, double deltax, double XMin, double YMin, double ZMin,
                                 int SuccessfulNucEvents_ThisRank, int &XSwitch, CellData<device_memory_space> &cellData,
                                 ViewI CritTimeStep, std::string TemperatureDataType, int layernumber, int,
                                 int ZBound_Low, int NGrainOrientations, ViewF GrainUnitVector, Print print,
@@ -668,5 +668,5 @@ void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyYSlices, int L
     if ((XSwitch == 0) && ((TemperatureDataType == "R") || (TemperatureDataType == "S")))
         JumpTimeStep(cycle, RemainingCellsOfInterest, LocalTempSolidCells, MeltTimeStep, LocalActiveDomainSize,
                      MyYSlices, ZBound_Low, CellType, LayerID, id, layernumber, np, nx, ny, GrainID, GrainUnitVector,
-                     print, NGrainOrientations, nzActive, deltax, XMin, YMin, ZMin);
+                     print, NGrainOrientations, nzActive, nz, deltax, XMin, YMin, ZMin);
 }

--- a/src/CAupdate.cpp
+++ b/src/CAupdate.cpp
@@ -19,9 +19,9 @@ using std::min;
 // Determine which cells are associated with the "steering vector" of cells that are either active, or becoming active
 // this time step
 void FillSteeringVector_NoRemelt(int cycle, int LocalActiveDomainSize, int nx, int MyYSlices, ViewI CritTimeStep,
-                                 ViewF UndercoolingCurrent, ViewF UndercoolingChange, CellData &cellData,
-                                 int ZBound_Low, int layernumber, ViewI SteeringVector, ViewI numSteer,
-                                 ViewI_H numSteer_Host) {
+                                 ViewF UndercoolingCurrent, ViewF UndercoolingChange,
+                                 CellData<device_memory_space> &cellData, int ZBound_Low, int layernumber,
+                                 ViewI SteeringVector, ViewI numSteer, ViewI_H numSteer_Host) {
 
     // Cells associated with this layer that are not solid type but have passed the liquidus (crit time step) have their
     // undercooling values updated Cells that meet the aforementioned criteria and are active type should be added to
@@ -62,9 +62,9 @@ void FillSteeringVector_NoRemelt(int cycle, int LocalActiveDomainSize, int nx, i
 // this time step - version with remelting
 void FillSteeringVector_Remelt(int cycle, int LocalActiveDomainSize, int nx, int MyYSlices, NList NeighborX,
                                NList NeighborY, NList NeighborZ, ViewI CritTimeStep, ViewF UndercoolingCurrent,
-                               ViewF UndercoolingChange, CellData &cellData, int ZBound_Low, int nzActive,
-                               ViewI SteeringVector, ViewI numSteer, ViewI_H numSteer_Host, ViewI MeltTimeStep,
-                               ViewI SolidificationEventCounter, ViewI NumberOfSolidificationEvents,
+                               ViewF UndercoolingChange, CellData<device_memory_space> &cellData, int ZBound_Low,
+                               int nzActive, ViewI SteeringVector, ViewI numSteer, ViewI_H numSteer_Host,
+                               ViewI MeltTimeStep, ViewI SolidificationEventCounter, ViewI NumberOfSolidificationEvents,
                                ViewF3D LayerTimeTempHistory) {
 
     ViewI CellType = cellData.getCellTypeSubview();
@@ -178,11 +178,11 @@ void FillSteeringVector_Remelt(int cycle, int LocalActiveDomainSize, int nx, int
 void CellCapture(int, int np, int, int, int, int nx, int MyYSlices, InterfacialResponseFunction irf, int MyYOffset,
                  NList NeighborX, NList NeighborY, NList NeighborZ, ViewI CritTimeStep, ViewF UndercoolingCurrent,
                  ViewF UndercoolingChange, ViewF GrainUnitVector, ViewF CritDiagonalLength, ViewF DiagonalLength,
-                 CellData &cellData, ViewF DOCenter, int NGrainOrientations, Buffer2D BufferNorthSend,
-                 Buffer2D BufferSouthSend, ViewI SendSizeNorth, ViewI SendSizeSouth, int ZBound_Low, int nzActive, int,
-                 ViewI SteeringVector, ViewI numSteer, ViewI_H numSteer_Host, bool AtNorthBoundary,
-                 bool AtSouthBoundary, ViewI SolidificationEventCounter, ViewF3D LayerTimeTempHistory,
-                 ViewI NumberOfSolidificationEvents, int &BufSize) {
+                 CellData<device_memory_space> &cellData, ViewF DOCenter, int NGrainOrientations,
+                 Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, ViewI SendSizeNorth, ViewI SendSizeSouth,
+                 int ZBound_Low, int nzActive, int, ViewI SteeringVector, ViewI numSteer, ViewI_H numSteer_Host,
+                 bool AtNorthBoundary, bool AtSouthBoundary, ViewI SolidificationEventCounter,
+                 ViewF3D LayerTimeTempHistory, ViewI NumberOfSolidificationEvents, int &BufSize) {
 
     // Loop over list of active and soon-to-be active cells, potentially performing cell capture events and updating
     // cell types
@@ -607,9 +607,10 @@ void JumpTimeStep(int &cycle, unsigned long int RemainingCellsOfInterest, unsign
 // remelting) and checks to see if solidification is complete in the case where cells can solidify multiple times
 void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyYSlices, int LocalActiveDomainSize, int nx, int ny,
                                 int nzActive, double deltax, double XMin, double YMin, double ZMin,
-                                int SuccessfulNucEvents_ThisRank, int &XSwitch, CellData &cellData, ViewI CritTimeStep,
-                                std::string TemperatureDataType, int layernumber, int, int ZBound_Low,
-                                int NGrainOrientations, ViewF GrainUnitVector, Print print, ViewI MeltTimeStep) {
+                                int SuccessfulNucEvents_ThisRank, int &XSwitch, CellData<device_memory_space> &cellData,
+                                ViewI CritTimeStep, std::string TemperatureDataType, int layernumber, int,
+                                int ZBound_Low, int NGrainOrientations, ViewF GrainUnitVector, Print print,
+                                ViewI MeltTimeStep) {
 
     ViewI CellType = cellData.getCellTypeSubview();
     ViewI GrainID = cellData.getGrainIDSubview();

--- a/src/CAupdate.cpp
+++ b/src/CAupdate.cpp
@@ -26,8 +26,8 @@ void FillSteeringVector_NoRemelt(int cycle, int LocalActiveDomainSize, int nx, i
     // Cells associated with this layer that are not solid type but have passed the liquidus (crit time step) have their
     // undercooling values updated Cells that meet the aforementioned criteria and are active type should be added to
     // the steering vector
-    ViewI CellType = cellData.getCellTypeSubview();
-    ViewI LayerID = cellData.getLayerIDSubview();
+    auto CellType = cellData.getCellTypeSubview();
+    auto LayerID = cellData.getLayerIDSubview();
     Kokkos::parallel_for(
         "FillSV", LocalActiveDomainSize, KOKKOS_LAMBDA(const int &D3D1ConvPosition) {
             // Cells of interest for the CA
@@ -67,8 +67,8 @@ void FillSteeringVector_Remelt(int cycle, int LocalActiveDomainSize, int nx, int
                                ViewI MeltTimeStep, ViewI SolidificationEventCounter, ViewI NumberOfSolidificationEvents,
                                ViewF3D LayerTimeTempHistory) {
 
-    ViewI CellType = cellData.getCellTypeSubview();
-    ViewI GrainID = cellData.getGrainIDSubview();
+    auto CellType = cellData.getCellTypeSubview();
+    auto GrainID = cellData.getGrainIDSubview();
     Kokkos::parallel_for(
         "FillSV_RM", LocalActiveDomainSize, KOKKOS_LAMBDA(const int &D3D1ConvPosition) {
             // Coordinate of this cell on the "global" (all cells in the Z direction) grid
@@ -186,8 +186,8 @@ void CellCapture(int, int np, int, int, int, int nx, int MyYSlices, InterfacialR
 
     // Loop over list of active and soon-to-be active cells, potentially performing cell capture events and updating
     // cell types
-    ViewI CellType = cellData.getCellTypeSubview();
-    ViewI GrainID = cellData.getGrainIDSubview();
+    auto CellType = cellData.getCellTypeSubview();
+    auto GrainID = cellData.getGrainIDSubview();
     Kokkos::parallel_for(
         "CellCapture", numSteer_Host(0), KOKKOS_LAMBDA(const int &num) {
             numSteer(0) = 0;
@@ -612,9 +612,9 @@ void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyYSlices, int L
                                 int ZBound_Low, int NGrainOrientations, ViewF GrainUnitVector, Print print,
                                 ViewI MeltTimeStep) {
 
-    ViewI CellType = cellData.getCellTypeSubview();
-    ViewI GrainID = cellData.getGrainIDSubview();
-    ViewI LayerID = cellData.getLayerIDSubview();
+    auto CellType = cellData.getCellTypeSubview();
+    auto GrainID = cellData.getGrainIDSubview();
+    auto LayerID = cellData.getLayerIDSubview();
     unsigned long int LocalSuperheatedCells;
     unsigned long int LocalUndercooledCells;
     unsigned long int LocalActiveCells;

--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -6,6 +6,7 @@
 #ifndef EXACA_UPDATE_HPP
 #define EXACA_UPDATE_HPP
 
+#include "CAcelldata.hpp"
 #include "CAinterfacialresponse.hpp"
 #include "CAprint.hpp"
 #include "CAtypes.hpp"
@@ -14,99 +15,32 @@
 
 #include <string>
 
-// Assign octahedron a small initial size, and a center location
-template <typename ViewType>
-KOKKOS_INLINE_FUNCTION void createNewOctahedron(int D3D1ConvPosition, ViewType DiagonalLength, ViewType DOCenter,
-                                                int GlobalX, int GlobalY, int GlobalZ) {
-    DiagonalLength(D3D1ConvPosition) = 0.01;
-    DOCenter(3 * D3D1ConvPosition) = GlobalX + 0.5;
-    DOCenter(3 * D3D1ConvPosition + 1) = GlobalY + 0.5;
-    DOCenter(3 * D3D1ConvPosition + 2) = GlobalZ + 0.5;
-}
-
-// For the newly active cell located at 1D array position D3D1ConvPosition (3D center coordinate of xp, yp, zp), update
-// CritDiagonalLength values for cell capture of neighboring cells. The octahedron has a center located at (cx, cy, cz)
-template <typename ViewType>
-KOKKOS_INLINE_FUNCTION void calcCritDiagonalLength(int D3D1ConvPosition, float xp, float yp, float zp, float cx,
-                                                   float cy, float cz, NList NeighborX, NList NeighborY,
-                                                   NList NeighborZ, int MyOrientation, ViewType GrainUnitVector,
-                                                   ViewType CritDiagonalLength) {
-    // Calculate critical octahedron diagonal length to activate nearest neighbor.
-    // First, calculate the unique planes (4) associated with all octahedron faces (8)
-    // Then just look at distance between face and the point of interest (cell center of
-    // neighbor). The critical diagonal length will be the maximum of these (since all other
-    // planes will have passed over the point by then
-    // ... meaning it must be in the octahedron)
-    double Fx[4], Fy[4], Fz[4];
-
-    Fx[0] = GrainUnitVector(9 * MyOrientation) + GrainUnitVector(9 * MyOrientation + 3) +
-            GrainUnitVector(9 * MyOrientation + 6);
-    Fx[1] = GrainUnitVector(9 * MyOrientation) - GrainUnitVector(9 * MyOrientation + 3) +
-            GrainUnitVector(9 * MyOrientation + 6);
-    Fx[2] = GrainUnitVector(9 * MyOrientation) + GrainUnitVector(9 * MyOrientation + 3) -
-            GrainUnitVector(9 * MyOrientation + 6);
-    Fx[3] = GrainUnitVector(9 * MyOrientation) - GrainUnitVector(9 * MyOrientation + 3) -
-            GrainUnitVector(9 * MyOrientation + 6);
-
-    Fy[0] = GrainUnitVector(9 * MyOrientation + 1) + GrainUnitVector(9 * MyOrientation + 4) +
-            GrainUnitVector(9 * MyOrientation + 7);
-    Fy[1] = GrainUnitVector(9 * MyOrientation + 1) - GrainUnitVector(9 * MyOrientation + 4) +
-            GrainUnitVector(9 * MyOrientation + 7);
-    Fy[2] = GrainUnitVector(9 * MyOrientation + 1) + GrainUnitVector(9 * MyOrientation + 4) -
-            GrainUnitVector(9 * MyOrientation + 7);
-    Fy[3] = GrainUnitVector(9 * MyOrientation + 1) - GrainUnitVector(9 * MyOrientation + 4) -
-            GrainUnitVector(9 * MyOrientation + 7);
-
-    Fz[0] = GrainUnitVector(9 * MyOrientation + 2) + GrainUnitVector(9 * MyOrientation + 5) +
-            GrainUnitVector(9 * MyOrientation + 8);
-    Fz[1] = GrainUnitVector(9 * MyOrientation + 2) - GrainUnitVector(9 * MyOrientation + 5) +
-            GrainUnitVector(9 * MyOrientation + 8);
-    Fz[2] = GrainUnitVector(9 * MyOrientation + 2) + GrainUnitVector(9 * MyOrientation + 5) -
-            GrainUnitVector(9 * MyOrientation + 8);
-    Fz[3] = GrainUnitVector(9 * MyOrientation + 2) - GrainUnitVector(9 * MyOrientation + 5) -
-            GrainUnitVector(9 * MyOrientation + 8);
-
-    for (int n = 0; n < 26; n++) {
-        float x0 = xp + NeighborX[n] - cx;
-        float y0 = yp + NeighborY[n] - cy;
-        float z0 = zp + NeighborZ[n] - cz;
-        float D0 = x0 * Fx[0] + y0 * Fy[0] + z0 * Fz[0];
-        float D1 = x0 * Fx[1] + y0 * Fy[1] + z0 * Fz[1];
-        float D2 = x0 * Fx[2] + y0 * Fy[2] + z0 * Fz[2];
-        float D3 = x0 * Fx[3] + y0 * Fy[3] + z0 * Fz[3];
-        float Dfabs = fmax(fmax(fabs(D0), fabs(D1)), fmax(fabs(D2), fabs(D3)));
-        CritDiagonalLength((long int)(26) * D3D1ConvPosition + (long int)(n)) = Dfabs;
-    }
-}
-
 void FillSteeringVector_NoRemelt(int cycle, int LocalActiveDomainSize, int nx, int MyYSlices, ViewI CritTimeStep,
-                                 ViewF UndercoolingCurrent, ViewF UndercoolingChange, ViewI CellType, int ZBound_Low,
-                                 int layernumber, ViewI LayerID, ViewI SteeringVector, ViewI numSteer_G,
+                                 ViewF UndercoolingCurrent, ViewF UndercoolingChange, CellData &cellData,
+                                 int ZBound_Low, int layernumber, ViewI SteeringVector, ViewI numSteer_G,
                                  ViewI_H numSteer_H);
 void FillSteeringVector_Remelt(int cycle, int LocalActiveDomainSize, int nx, int MyYSlices, NList NeighborX,
                                NList NeighborY, NList NeighborZ, ViewI CritTimeStep, ViewF UndercoolingCurrent,
-                               ViewF UndercoolingChange, ViewI CellType, ViewI GrainID, int ZBound_Low, int nzActive,
+                               ViewF UndercoolingChange, CellData &cellData, int ZBound_Low, int nzActive,
                                ViewI SteeringVector, ViewI numSteer, ViewI_H numSteer_Host, ViewI MeltTimeStep,
                                ViewI SolidificationEventCounter, ViewI NumberOfSolidificationEvents,
                                ViewF3D LayerTimeTempHistory);
 void CellCapture(int id, int np, int cycle, int LocalActiveDomainSize, int LocalDomainSize, int nx, int MyYSlices,
                  InterfacialResponseFunction irf, int MyYOffset, NList NeighborX, NList NeighborY, NList NeighborZ,
                  ViewI CritTimeStep, ViewF UndercoolingCurrent, ViewF UndercoolingChange, ViewF GrainUnitVector,
-                 ViewF CritDiagonalLength, ViewF DiagonalLength, ViewI CellType, ViewF DOCenter, ViewI GrainID,
+                 ViewF CritDiagonalLength, ViewF DiagonalLength, CellData &cellData, ViewF DOCenter,
                  int NGrainOrientations, Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, ViewI SendSizeNorth,
                  ViewI SendSizeSouth, int ZBound_Low, int nzActive, int nz, ViewI SteeringVector, ViewI numSteer_G,
                  ViewI_H numSteer_H, bool AtNorthBoundary, bool AtSouthBoundary, ViewI SolidificationEventCounter,
                  ViewF3D LayerTimeTempHistory, ViewI NumberOfSolidificationEvents, int &BufSize);
 void JumpTimeStep(int &cycle, unsigned long int RemainingCellsOfInterest, unsigned long int LocalTempSolidCells,
-                  ViewI MeltTimeStep, int LocalActiveDomainSize, int MyYSlices, int ZBound_Low, ViewI CellType,
-                  ViewI LayerID, int id, int layernumber, int np, int nx, int ny, ViewI GrainID, ViewF GrainUnitVector,
-                  Print print, int NGrainOrientations, int nzActive, double deltax, double XMin, double YMin,
-                  double ZMin);
+                  ViewI MeltTimeStep, int LocalActiveDomainSize, int MyYSlices, int ZBound_Low, CellData &cellData,
+                  int id, int layernumber, int np, int nx, int ny, ViewF GrainUnitVector, Print print,
+                  int NGrainOrientations, int nzActive, double deltax, double XMin, double YMin, double ZMin);
 void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyYSlices, int LocalActiveDomainSize, int nx, int ny,
                                 int nzActive, double deltax, double XMin, double YMin, double ZMin,
-                                int SuccessfulNucEvents_ThisRank, int &XSwitch, ViewI CellType, ViewI CritTimeStep,
-                                ViewI GrainID, std::string TemperatureDataType, int layernumber, int, int ZBound_Low,
-                                int NGrainOrientations, ViewI LayerID, ViewF GrainUnitVector, Print print,
-                                ViewI MeltTimeStep);
+                                int SuccessfulNucEvents_ThisRank, int &XSwitch, CellData &cellData, ViewI CritTimeStep,
+                                std::string TemperatureDataType, int layernumber, int, int ZBound_Low,
+                                int NGrainOrientations, ViewF GrainUnitVector, Print print, ViewI MeltTimeStep);
 
 #endif

--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -16,31 +16,34 @@
 #include <string>
 
 void FillSteeringVector_NoRemelt(int cycle, int LocalActiveDomainSize, int nx, int MyYSlices, ViewI CritTimeStep,
-                                 ViewF UndercoolingCurrent, ViewF UndercoolingChange, CellData &cellData,
-                                 int ZBound_Low, int layernumber, ViewI SteeringVector, ViewI numSteer_G,
-                                 ViewI_H numSteer_H);
+                                 ViewF UndercoolingCurrent, ViewF UndercoolingChange,
+                                 CellData<device_memory_space> &cellData, int ZBound_Low, int layernumber,
+                                 ViewI SteeringVector, ViewI numSteer_G, ViewI_H numSteer_H);
 void FillSteeringVector_Remelt(int cycle, int LocalActiveDomainSize, int nx, int MyYSlices, NList NeighborX,
                                NList NeighborY, NList NeighborZ, ViewI CritTimeStep, ViewF UndercoolingCurrent,
-                               ViewF UndercoolingChange, CellData &cellData, int ZBound_Low, int nzActive,
-                               ViewI SteeringVector, ViewI numSteer, ViewI_H numSteer_Host, ViewI MeltTimeStep,
-                               ViewI SolidificationEventCounter, ViewI NumberOfSolidificationEvents,
+                               ViewF UndercoolingChange, CellData<device_memory_space> &cellData, int ZBound_Low,
+                               int nzActive, ViewI SteeringVector, ViewI numSteer, ViewI_H numSteer_Host,
+                               ViewI MeltTimeStep, ViewI SolidificationEventCounter, ViewI NumberOfSolidificationEvents,
                                ViewF3D LayerTimeTempHistory);
 void CellCapture(int id, int np, int cycle, int LocalActiveDomainSize, int LocalDomainSize, int nx, int MyYSlices,
                  InterfacialResponseFunction irf, int MyYOffset, NList NeighborX, NList NeighborY, NList NeighborZ,
                  ViewI CritTimeStep, ViewF UndercoolingCurrent, ViewF UndercoolingChange, ViewF GrainUnitVector,
-                 ViewF CritDiagonalLength, ViewF DiagonalLength, CellData &cellData, ViewF DOCenter,
-                 int NGrainOrientations, Buffer2D BufferNorthSend, Buffer2D BufferSouthSend, ViewI SendSizeNorth,
-                 ViewI SendSizeSouth, int ZBound_Low, int nzActive, int nz, ViewI SteeringVector, ViewI numSteer_G,
-                 ViewI_H numSteer_H, bool AtNorthBoundary, bool AtSouthBoundary, ViewI SolidificationEventCounter,
-                 ViewF3D LayerTimeTempHistory, ViewI NumberOfSolidificationEvents, int &BufSize);
+                 ViewF CritDiagonalLength, ViewF DiagonalLength, CellData<device_memory_space> &cellData,
+                 ViewF DOCenter, int NGrainOrientations, Buffer2D BufferNorthSend, Buffer2D BufferSouthSend,
+                 ViewI SendSizeNorth, ViewI SendSizeSouth, int ZBound_Low, int nzActive, int nz, ViewI SteeringVector,
+                 ViewI numSteer_G, ViewI_H numSteer_H, bool AtNorthBoundary, bool AtSouthBoundary,
+                 ViewI SolidificationEventCounter, ViewF3D LayerTimeTempHistory, ViewI NumberOfSolidificationEvents,
+                 int &BufSize);
 void JumpTimeStep(int &cycle, unsigned long int RemainingCellsOfInterest, unsigned long int LocalTempSolidCells,
-                  ViewI MeltTimeStep, int LocalActiveDomainSize, int MyYSlices, int ZBound_Low, CellData &cellData,
-                  int id, int layernumber, int np, int nx, int ny, ViewF GrainUnitVector, Print print,
-                  int NGrainOrientations, int nzActive, double deltax, double XMin, double YMin, double ZMin);
+                  ViewI MeltTimeStep, int LocalActiveDomainSize, int MyYSlices, int ZBound_Low,
+                  CellData<device_memory_space> &cellData, int id, int layernumber, int np, int nx, int ny,
+                  ViewF GrainUnitVector, Print print, int NGrainOrientations, int nzActive, double deltax, double XMin,
+                  double YMin, double ZMin);
 void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyYSlices, int LocalActiveDomainSize, int nx, int ny,
                                 int nzActive, double deltax, double XMin, double YMin, double ZMin,
-                                int SuccessfulNucEvents_ThisRank, int &XSwitch, CellData &cellData, ViewI CritTimeStep,
-                                std::string TemperatureDataType, int layernumber, int, int ZBound_Low,
-                                int NGrainOrientations, ViewF GrainUnitVector, Print print, ViewI MeltTimeStep);
+                                int SuccessfulNucEvents_ThisRank, int &XSwitch, CellData<device_memory_space> &cellData,
+                                ViewI CritTimeStep, std::string TemperatureDataType, int layernumber, int,
+                                int ZBound_Low, int NGrainOrientations, ViewF GrainUnitVector, Print print,
+                                ViewI MeltTimeStep);
 
 #endif

--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -37,10 +37,10 @@ void CellCapture(int id, int np, int cycle, int LocalActiveDomainSize, int Local
 void JumpTimeStep(int &cycle, unsigned long int RemainingCellsOfInterest, unsigned long int LocalTempSolidCells,
                   ViewI MeltTimeStep, int LocalActiveDomainSize, int MyYSlices, int ZBound_Low,
                   CellData<device_memory_space> &cellData, int id, int layernumber, int np, int nx, int ny,
-                  ViewF GrainUnitVector, Print print, int NGrainOrientations, int nzActive, double deltax, double XMin,
-                  double YMin, double ZMin);
+                  ViewF GrainUnitVector, Print print, int NGrainOrientations, int nzActive, int nz, double deltax,
+                  double XMin, double YMin, double ZMin);
 void IntermediateOutputAndCheck(int id, int np, int &cycle, int MyYSlices, int LocalActiveDomainSize, int nx, int ny,
-                                int nzActive, double deltax, double XMin, double YMin, double ZMin,
+                                int nz, int nzActive, double deltax, double XMin, double YMin, double ZMin,
                                 int SuccessfulNucEvents_ThisRank, int &XSwitch, CellData<device_memory_space> &cellData,
                                 ViewI CritTimeStep, std::string TemperatureDataType, int layernumber, int,
                                 int ZBound_Low, int NGrainOrientations, ViewF GrainUnitVector, Print print,

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -219,9 +219,8 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     double InitTime = MPI_Wtime() - StartInitTime;
     if (id == 0)
         std::cout << "Data initialized: Time spent: " << InitTime << " s" << std::endl;
-    print.printInitExaCAData<ViewI, ViewF>(id, np, nx, ny, MyYSlices, nzActive, deltax, XMin, YMin, ZMin,
-                                           cellData.GrainID_AllLayers, cellData.LayerID_AllLayers, MeltTimeStep,
-                                           CritTimeStep, UndercoolingChange);
+    print.printInitExaCAData(id, np, nx, ny, MyYSlices, nzActive, deltax, XMin, YMin, ZMin, cellData.GrainID_AllLayers,
+                             cellData.LayerID_AllLayers, MeltTimeStep, CritTimeStep, UndercoolingChange);
     MPI_Barrier(MPI_COMM_WORLD);
     int cycle = 0;
     double StartRunTime = MPI_Wtime();
@@ -391,10 +390,10 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
 
     MPI_Barrier(MPI_COMM_WORLD);
     // Collect and print specified final fields to output files
-    print.printFinalExaCAData<ViewI, ViewF>(id, np, nx, ny, nz, MyYSlices, NumberOfLayers, cellData.LayerID_AllLayers,
-                                            cellData.CellType_AllLayers, cellData.GrainID_AllLayers,
-                                            UndercoolingCurrent, UndercoolingChange, MeltTimeStep, CritTimeStep,
-                                            GrainUnitVector, NGrainOrientations, deltax, XMin, YMin, ZMin);
+    print.printFinalExaCAData(id, np, nx, ny, nz, MyYSlices, NumberOfLayers, cellData.LayerID_AllLayers,
+                              cellData.CellType_AllLayers, cellData.GrainID_AllLayers, UndercoolingCurrent,
+                              UndercoolingChange, MeltTimeStep, CritTimeStep, GrainUnitVector, NGrainOrientations,
+                              deltax, XMin, YMin, ZMin);
 
     // Calculate volume fraction of solidified domain consisting of nucleated grains
     float VolFractionNucleated =

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -180,13 +180,13 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     ResetSendBuffers(BufSize, BufferNorthSend, BufferSouthSend, SendSizeNorth, SendSizeSouth);
 
     // Initialize cell types, grain IDs, and layer IDs
-    CellData cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
+    CellData<device_memory_space> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
     if (SimulationType == "C")
-        cellData.substrate_init_dirsol(id, FractSurfaceSitesActive, MyYSlices, nx, ny, MyYOffset, NeighborX, NeighborY,
-                                       NeighborZ, GrainUnitVector, NGrainOrientations, DiagonalLength, DOCenter,
-                                       CritDiagonalLength, RNGSeed);
+        cellData.init_substrate(id, FractSurfaceSitesActive, MyYSlices, nx, ny, MyYOffset, NeighborX, NeighborY,
+                                NeighborZ, GrainUnitVector, NGrainOrientations, DiagonalLength, DOCenter,
+                                CritDiagonalLength, RNGSeed);
     else
-        cellData.substrate_init(SubstrateFileName, UseSubstrateFile, BaseplateThroughPowder, PowderFirstLayer, nx, ny,
+        cellData.init_substrate(SubstrateFileName, UseSubstrateFile, BaseplateThroughPowder, PowderFirstLayer, nx, ny,
                                 nz, LayerHeight, LocalActiveDomainSize, ZMaxLayer, ZMin, deltax, MyYSlices, MyYOffset,
                                 ZBound_Low, id, RNGSeed, SubstrateGrainSpacing, PowderActiveFraction,
                                 NumberOfSolidificationEvents);

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -237,9 +237,9 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
             if ((print.PrintTimeSeries) && (cycle % print.TimeSeriesInc == 0)) {
                 // Print current state of ExaCA simulation (up to and including the current layer's data)
                 print.printIntermediateGrainMisorientation(
-                    id, np, cycle, nx, ny, MyYSlices, nzActive, deltax, XMin, YMin, ZMin, cellData.GrainID_AllLayers,
-                    cellData.LayerID_AllLayers, cellData.CellType_AllLayers, GrainUnitVector, NGrainOrientations,
-                    layernumber, ZBound_Low);
+                    id, np, cycle, nx, ny, nz, MyYSlices, nzActive, deltax, XMin, YMin, ZMin,
+                    cellData.GrainID_AllLayers, cellData.LayerID_AllLayers, cellData.CellType_AllLayers,
+                    GrainUnitVector, NGrainOrientations, layernumber, ZBound_Low);
             }
             cycle++;
 
@@ -304,10 +304,10 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
             }
 
             if (cycle % 1000 == 0) {
-                IntermediateOutputAndCheck(id, np, cycle, MyYSlices, LocalActiveDomainSize, nx, ny, nzActive, deltax,
-                                           XMin, YMin, ZMin, nucleation.SuccessfulNucleationCounter, XSwitch, cellData,
-                                           CritTimeStep, SimulationType, layernumber, NumberOfLayers, ZBound_Low,
-                                           NGrainOrientations, GrainUnitVector, print, MeltTimeStep);
+                IntermediateOutputAndCheck(id, np, cycle, MyYSlices, LocalActiveDomainSize, nx, ny, nz, nzActive,
+                                           deltax, XMin, YMin, ZMin, nucleation.SuccessfulNucleationCounter, XSwitch,
+                                           cellData, CritTimeStep, SimulationType, layernumber, NumberOfLayers,
+                                           ZBound_Low, NGrainOrientations, GrainUnitVector, print, MeltTimeStep);
             }
 
         } while (XSwitch == 0);

--- a/unit_test/tstKokkosInitMPI.hpp
+++ b/unit_test/tstKokkosInitMPI.hpp
@@ -318,10 +318,9 @@ void testCellDataInit_ConstrainedGrowth() {
     cellData.init_substrate(id, FractSurfaceSitesActive, MyYSlices, nx, ny, MyYOffset, NeighborX, NeighborY, NeighborZ,
                             GrainUnitVector, NGrainOrientations, DiagonalLength, DOCenter, CritDiagonalLength, RNGSeed);
     // Copy CellType, GrainID views to host to check values
-    ViewI_H CellType_AllLayers_Host =
+    auto CellType_AllLayers_Host =
         Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), cellData.CellType_AllLayers);
-    ViewI_H GrainID_AllLayers_Host =
-        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), cellData.GrainID_AllLayers);
+    auto GrainID_AllLayers_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), cellData.GrainID_AllLayers);
     for (int i = 0; i < LocalDomainSize; i++) {
         if (i >= nx * MyYSlices) {
             // Not at bottom surface - should be liquid cells with GrainID still equal to 0
@@ -432,7 +431,7 @@ void testCellDataInit(bool PowderFirstLayer) {
                             SubstrateGrainSpacing, PowderActiveFraction, NumberOfSolidificationEvents);
 
     // Copy GrainID results back to host to check first layer's initialization
-    ViewI_H GrainID_AllLayers_H = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), cellData.GrainID_AllLayers);
+    auto GrainID_AllLayers_H = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), cellData.GrainID_AllLayers);
 
     // Baseplate grains - cells should have GrainIDs between 1 and np (inclusive)
     for (int i = 0; i < BaseplateSize; i++) {
@@ -463,7 +462,7 @@ void testCellDataInit(bool PowderFirstLayer) {
     }
 
     // Copy cell types back to host to check
-    ViewI_H CellType_AllLayers_Host =
+    auto CellType_AllLayers_Host =
         Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), cellData.CellType_AllLayers);
     for (int D3D1ConvPosition = 0; D3D1ConvPosition < LocalActiveDomainSize; D3D1ConvPosition++) {
         int Rem = D3D1ConvPosition % (nx * MyYSlices);
@@ -501,8 +500,8 @@ void testCellDataInit(bool PowderFirstLayer) {
     }
 
     // Subview grain IDs should match the grain IDs overall
-    ViewI GrainID = cellData.getGrainIDSubview();
-    ViewI_H GrainID_H = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), GrainID);
+    auto GrainID = cellData.getGrainIDSubview();
+    auto GrainID_H = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), GrainID);
     for (int D3D1ConvPosition = 0; D3D1ConvPosition < LocalActiveDomainSize; D3D1ConvPosition++) {
         int RankZ = D3D1ConvPosition / (nx * MyYSlices);
         int GlobalZ = RankZ + ZBound_Low;

--- a/unit_test/tstKokkosInitMPI.hpp
+++ b/unit_test/tstKokkosInitMPI.hpp
@@ -275,6 +275,10 @@ void testInputReadFromFile(int PrintVersion) {
 //---------------------------------------------------------------------------//
 void testCellDataInit_ConstrainedGrowth() {
 
+    using memory_space = TEST_MEMSPACE;
+    using view_int = Kokkos::View<int *, memory_space>;
+    using view_float = Kokkos::View<float *, memory_space>;
+
     int id, np;
     // Get number of processes
     MPI_Comm_size(MPI_COMM_WORLD, &np);
@@ -309,12 +313,13 @@ void testCellDataInit_ConstrainedGrowth() {
     NeighborListInit(NeighborX, NeighborY, NeighborZ);
 
     // Initialize views - set initial GrainID values to 0, all CellType values to liquid
-    ViewF DiagonalLength(Kokkos::ViewAllocateWithoutInitializing("DiagonalLength"), LocalActiveDomainSize);
-    ViewI NumberOfSolidificationEvents(Kokkos::ViewAllocateWithoutInitializing("NumberOfSolidificationEvents"),
-                                       LocalActiveDomainSize);
-    ViewF DOCenter(Kokkos::ViewAllocateWithoutInitializing("DOCenter"), 3 * LocalActiveDomainSize);
-    ViewF CritDiagonalLength(Kokkos::ViewAllocateWithoutInitializing("CritDiagonalLength"), 26 * LocalActiveDomainSize);
-    CellData<TEST_MEMSPACE> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
+    view_float DiagonalLength(Kokkos::ViewAllocateWithoutInitializing("DiagonalLength"), LocalActiveDomainSize);
+    view_int NumberOfSolidificationEvents(Kokkos::ViewAllocateWithoutInitializing("NumberOfSolidificationEvents"),
+                                          LocalActiveDomainSize);
+    view_float DOCenter(Kokkos::ViewAllocateWithoutInitializing("DOCenter"), 3 * LocalActiveDomainSize);
+    view_float CritDiagonalLength(Kokkos::ViewAllocateWithoutInitializing("CritDiagonalLength"),
+                                  26 * LocalActiveDomainSize);
+    CellData<memory_space> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
     cellData.init_substrate(id, FractSurfaceSitesActive, MyYSlices, nx, ny, MyYOffset, NeighborX, NeighborY, NeighborZ,
                             GrainUnitVector, NGrainOrientations, DiagonalLength, DOCenter, CritDiagonalLength, RNGSeed);
     // Copy CellType, GrainID views to host to check values
@@ -343,6 +348,10 @@ void testCellDataInit_ConstrainedGrowth() {
 }
 
 void testCellDataInit(bool PowderFirstLayer) {
+
+    using memory_space = TEST_MEMSPACE;
+    using view_int = Kokkos::View<int *, memory_space>;
+    using view_float = Kokkos::View<float *, memory_space>;
 
     int id, np;
     // Get number of processes
@@ -403,10 +412,10 @@ void testCellDataInit(bool PowderFirstLayer) {
     // unused views in constructor
     NList NeighborX, NeighborY, NeighborZ;
     NeighborListInit(NeighborX, NeighborY, NeighborZ);
-    ViewF GrainUnitVector(Kokkos::ViewAllocateWithoutInitializing("GrainUnitVector"), 0);
-    ViewF DiagonalLength(Kokkos::ViewAllocateWithoutInitializing("DiagonalLength"), 0);
-    ViewF DOCenter(Kokkos::ViewAllocateWithoutInitializing("DOCenter"), 0);
-    ViewF CritDiagonalLength(Kokkos::ViewAllocateWithoutInitializing("CritDiagonalLength"), 0);
+    view_float GrainUnitVector(Kokkos::ViewAllocateWithoutInitializing("GrainUnitVector"), 0);
+    view_float DiagonalLength(Kokkos::ViewAllocateWithoutInitializing("DiagonalLength"), 0);
+    view_float DOCenter(Kokkos::ViewAllocateWithoutInitializing("DOCenter"), 0);
+    view_float CritDiagonalLength(Kokkos::ViewAllocateWithoutInitializing("CritDiagonalLength"), 0);
 
     // Create dummy temperature data
     ViewI NumberOfSolidificationEvents(Kokkos::ViewAllocateWithoutInitializing("NumberOfSolidificationEvents"),
@@ -425,7 +434,7 @@ void testCellDataInit(bool PowderFirstLayer) {
         });
 
     // Call constructor
-    CellData<TEST_MEMSPACE> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
+    CellData<memory_space> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
     cellData.init_substrate("", false, false, PowderFirstLayer, nx, ny, nz, LayerHeight, LocalActiveDomainSize,
                             ZMaxLayer, ZMin, deltax, MyYSlices, MyYOffset, ZBound_Low, id, RNGSeed,
                             SubstrateGrainSpacing, PowderActiveFraction, NumberOfSolidificationEvents);

--- a/unit_test/tstKokkosInitMPI.hpp
+++ b/unit_test/tstKokkosInitMPI.hpp
@@ -314,10 +314,9 @@ void testCellDataInit_ConstrainedGrowth() {
                                        LocalActiveDomainSize);
     ViewF DOCenter(Kokkos::ViewAllocateWithoutInitializing("DOCenter"), 3 * LocalActiveDomainSize);
     ViewF CritDiagonalLength(Kokkos::ViewAllocateWithoutInitializing("CritDiagonalLength"), 26 * LocalActiveDomainSize);
-    CellData cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
-    cellData.substrate_init_dirsol(id, FractSurfaceSitesActive, MyYSlices, nx, ny, MyYOffset, NeighborX, NeighborY,
-                                   NeighborZ, GrainUnitVector, NGrainOrientations, DiagonalLength, DOCenter,
-                                   CritDiagonalLength, RNGSeed);
+    CellData<TEST_MEMSPACE> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
+    cellData.init_substrate(id, FractSurfaceSitesActive, MyYSlices, nx, ny, MyYOffset, NeighborX, NeighborY, NeighborZ,
+                            GrainUnitVector, NGrainOrientations, DiagonalLength, DOCenter, CritDiagonalLength, RNGSeed);
     // Copy CellType, GrainID views to host to check values
     ViewI_H CellType_AllLayers_Host =
         Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), cellData.CellType_AllLayers);
@@ -427,8 +426,8 @@ void testCellDataInit(bool PowderFirstLayer) {
         });
 
     // Call constructor
-    CellData cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
-    cellData.substrate_init("", false, false, PowderFirstLayer, nx, ny, nz, LayerHeight, LocalActiveDomainSize,
+    CellData<TEST_MEMSPACE> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
+    cellData.init_substrate("", false, false, PowderFirstLayer, nx, ny, nz, LayerHeight, LocalActiveDomainSize,
                             ZMaxLayer, ZMin, deltax, MyYSlices, MyYOffset, ZBound_Low, id, RNGSeed,
                             SubstrateGrainSpacing, PowderActiveFraction, NumberOfSolidificationEvents);
 

--- a/unit_test/tstKokkosInitMPI.hpp
+++ b/unit_test/tstKokkosInitMPI.hpp
@@ -305,7 +305,7 @@ void testCellDataInit_ConstrainedGrowth() {
     double RNGSeed = 0.0;
     std::string GrainOrientationFile = checkFileInstalled("GrainOrientationVectors.csv", id);
     int NGrainOrientations = 10000; // Number of grain orientations considered in the simulation
-    ViewF GrainUnitVector(Kokkos::ViewAllocateWithoutInitializing("GrainUnitVector"), 9 * NGrainOrientations);
+    view_float GrainUnitVector(Kokkos::ViewAllocateWithoutInitializing("GrainUnitVector"), 9 * NGrainOrientations);
     OrientationInit(id, NGrainOrientations, GrainUnitVector, GrainOrientationFile);
 
     // Initialize neighbor lists

--- a/unit_test/tstKokkosInitMPI.hpp
+++ b/unit_test/tstKokkosInitMPI.hpp
@@ -418,8 +418,8 @@ void testCellDataInit(bool PowderFirstLayer) {
     view_float CritDiagonalLength(Kokkos::ViewAllocateWithoutInitializing("CritDiagonalLength"), 0);
 
     // Create dummy temperature data
-    ViewI NumberOfSolidificationEvents(Kokkos::ViewAllocateWithoutInitializing("NumberOfSolidificationEvents"),
-                                       LocalActiveDomainSize);
+    view_int NumberOfSolidificationEvents(Kokkos::ViewAllocateWithoutInitializing("NumberOfSolidificationEvents"),
+                                          LocalActiveDomainSize);
     Kokkos::parallel_for(
         "InitTestTemperatureData", LocalActiveDomainSize, KOKKOS_LAMBDA(const int &D3D1ConvPosition) {
             int Rem = D3D1ConvPosition % (nx * MyYSlices);

--- a/unit_test/tstKokkosMPI.hpp
+++ b/unit_test/tstKokkosMPI.hpp
@@ -92,7 +92,7 @@ void testGhostNodes1D() {
     NeighborListInit(NeighborX, NeighborY, NeighborZ);
 
     // Initialize host views - set initial GrainID values to 0, all CellType values to liquid
-    CellData<TEST_MEMSPACE> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
+    CellData<device_memory_space> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
     auto CellType = cellData.getCellTypeSubview();
     auto GrainID = cellData.getGrainIDSubview();
     auto CellType_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), CellType);
@@ -277,7 +277,7 @@ void testResizeRefillBuffers() {
 
     // Allocate device views: entire domain on each rank
     // Default to wall cells (CellType(index) = 0) with GrainID of 0
-    CellData<TEST_MEMSPACE> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
+    CellData<device_memory_space> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
     Kokkos::deep_copy(cellData.CellType_AllLayers, Liquid);
     auto CellType = cellData.getCellTypeSubview();
     auto GrainID = cellData.getGrainIDSubview();

--- a/unit_test/tstKokkosMPI.hpp
+++ b/unit_test/tstKokkosMPI.hpp
@@ -92,7 +92,7 @@ void testGhostNodes1D() {
     NeighborListInit(NeighborX, NeighborY, NeighborZ);
 
     // Initialize host views - set initial GrainID values to 0, all CellType values to liquid
-    CellData cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
+    CellData<TEST_MEMSPACE> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
     ViewI CellType = cellData.getCellTypeSubview();
     ViewI GrainID = cellData.getGrainIDSubview();
     ViewI_H CellType_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), CellType);
@@ -277,7 +277,7 @@ void testResizeRefillBuffers() {
 
     // Allocate device views: entire domain on each rank
     // Default to wall cells (CellType(index) = 0) with GrainID of 0
-    CellData cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
+    CellData<TEST_MEMSPACE> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
     Kokkos::deep_copy(cellData.CellType_AllLayers, Liquid);
     ViewI CellType = cellData.getCellTypeSubview();
     ViewI GrainID = cellData.getGrainIDSubview();

--- a/unit_test/tstKokkosMPI.hpp
+++ b/unit_test/tstKokkosMPI.hpp
@@ -6,6 +6,7 @@
 #include <Kokkos_Core.hpp>
 #include <nlohmann/json.hpp>
 
+#include "CAcelldata.hpp"
 #include "CAfunctions.hpp"
 #include "CAghostnodes.hpp"
 #include "CAinitialize.hpp"
@@ -91,9 +92,12 @@ void testGhostNodes1D() {
     NeighborListInit(NeighborX, NeighborY, NeighborZ);
 
     // Initialize host views - set initial GrainID values to 0, all CellType values to liquid
-    ViewI_H CellType_Host(Kokkos::ViewAllocateWithoutInitializing("CellType_Host"), LocalDomainSize);
+    CellData cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
+    ViewI CellType = cellData.getCellTypeSubview();
+    ViewI GrainID = cellData.getGrainIDSubview();
+    ViewI_H CellType_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), CellType);
     Kokkos::deep_copy(CellType_Host, Liquid);
-    ViewI_H GrainID_Host("GrainID_Host", LocalDomainSize);
+    ViewI_H GrainID_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), GrainID);
     // Initialize active domain views to 0
     ViewF_H DiagonalLength_Host("DiagonalLength_Host", LocalActiveDomainSize);
     ViewF_H DOCenter_Host("DOCenter_Host", 3 * LocalActiveDomainSize);
@@ -103,9 +107,7 @@ void testGhostNodes1D() {
     // X = 2, Z = 6 is chosen for active cell placement on all ranks
     // Active cells will be located at Y = 1 and Y = MyYSlices-2 on each rank... these are located in the halo regions
     // and should be loaded into the send buffers
-    int HaloLocations[2], HaloLocations_ActiveRegion[2];
-    HaloLocations[0] = 6 * MyXSlices * MyYSlices + 2 * MyYSlices + 1;
-    HaloLocations[1] = 6 * MyXSlices * MyYSlices + 2 * MyYSlices + MyYSlices - 2;
+    int HaloLocations_ActiveRegion[2];
     HaloLocations_ActiveRegion[0] = (6 - ZBound_Low) * MyXSlices * MyYSlices + 2 * MyYSlices + 1;
     HaloLocations_ActiveRegion[1] = (6 - ZBound_Low) * MyXSlices * MyYSlices + 2 * MyYSlices + MyYSlices - 2;
     // Physical cell centers in Y are different for each location and each rank
@@ -113,8 +115,8 @@ void testGhostNodes1D() {
     OctCentersY[0] = MyYOffset + 1.5;
     OctCentersY[1] = MyYOffset + MyYSlices - 1.5;
     for (int n = 0; n < 2; n++) {
-        CellType_Host(HaloLocations[n]) = Active;
-        GrainID_Host(HaloLocations[n]) = 29;
+        CellType_Host(HaloLocations_ActiveRegion[n]) = Active;
+        GrainID_Host(HaloLocations_ActiveRegion[n]) = 29;
         // Initialize with an initial diagonal length, octahedra centered at cell center (X = 2.5, Y = varied, Z = 7.5)
         DiagonalLength_Host(HaloLocations_ActiveRegion[n]) = 0.01;
         DOCenter_Host(3 * HaloLocations_ActiveRegion[n]) = 2.5;
@@ -125,11 +127,7 @@ void testGhostNodes1D() {
     // Also testing an alternate situation where the ghost node data should NOT be unpacked, and the cells do not need
     // to be updated: X = 2, Z = 7 is chosen for active cell placement on all ranks Four active cells are located at Y =
     // 0, Y = 1, Y = MyYSlices - 2, and Y = MyYSlices - 1
-    int HaloLocations_Alt[4], HaloLocations_Alt_ActiveRegion[4];
-    HaloLocations_Alt[0] = 7 * MyXSlices * MyYSlices + 2 * MyYSlices + 0;
-    HaloLocations_Alt[1] = 7 * MyXSlices * MyYSlices + 2 * MyYSlices + 1;
-    HaloLocations_Alt[2] = 7 * MyXSlices * MyYSlices + 2 * MyYSlices + MyYSlices - 2;
-    HaloLocations_Alt[3] = 7 * MyXSlices * MyYSlices + 2 * MyYSlices + MyYSlices - 1;
+    int HaloLocations_Alt_ActiveRegion[4];
     HaloLocations_Alt_ActiveRegion[0] = (7 - ZBound_Low) * MyXSlices * MyYSlices + 2 * MyYSlices + 0;
     HaloLocations_Alt_ActiveRegion[1] = (7 - ZBound_Low) * MyXSlices * MyYSlices + 2 * MyYSlices + 1;
     HaloLocations_Alt_ActiveRegion[2] = (7 - ZBound_Low) * MyXSlices * MyYSlices + 2 * MyYSlices + MyYSlices - 2;
@@ -141,8 +139,8 @@ void testGhostNodes1D() {
     OctCentersY_Alt[2] = MyYOffset + MyYSlices - 1.5;
     OctCentersY_Alt[3] = MyYOffset + MyYSlices - 0.5;
     for (int n = 0; n < 4; n++) {
-        CellType_Host(HaloLocations_Alt[n]) = Active;
-        GrainID_Host(HaloLocations_Alt[n]) = -id;
+        CellType_Host(HaloLocations_Alt_ActiveRegion[n]) = Active;
+        GrainID_Host(HaloLocations_Alt_ActiveRegion[n]) = -id;
         // Initialize with an initial diagonal length, octahedra centered at cell center (X = 2.5, Y = varied, Z = 7.5)
         DiagonalLength_Host(HaloLocations_Alt_ActiveRegion[n]) = 0.01;
         DOCenter_Host(3 * HaloLocations_Alt_ActiveRegion[n]) = 2.5;
@@ -151,8 +149,8 @@ void testGhostNodes1D() {
     }
 
     // Copy view data to the device
-    ViewI CellType = Kokkos::create_mirror_view_and_copy(device_memory_space(), CellType_Host);
-    ViewI GrainID = Kokkos::create_mirror_view_and_copy(device_memory_space(), GrainID_Host);
+    CellType = Kokkos::create_mirror_view_and_copy(device_memory_space(), CellType_Host);
+    GrainID = Kokkos::create_mirror_view_and_copy(device_memory_space(), GrainID_Host);
     ViewF DiagonalLength = Kokkos::create_mirror_view_and_copy(device_memory_space(), DiagonalLength_Host);
     ViewF CritDiagonalLength = Kokkos::create_mirror_view_and_copy(device_memory_space(), CritDiagonalLength_Host);
     ViewF DOCenter = Kokkos::create_mirror_view_and_copy(device_memory_space(), DOCenter_Host);
@@ -183,10 +181,8 @@ void testGhostNodes1D() {
             int Rem = D3D1ConvPosition % (MyXSlices * MyYSlices);
             int RankX = Rem / MyYSlices;
             int RankY = Rem % MyYSlices;
-            int GlobalZ = RankZ + ZBound_Low;
-            int GlobalD3D1ConvPosition = GlobalZ * MyXSlices * MyYSlices + RankX * MyYSlices + RankY;
-            if (CellType(GlobalD3D1ConvPosition) == Active) {
-                int GhostGID = GrainID(GlobalD3D1ConvPosition);
+            if (CellType(D3D1ConvPosition) == Active) {
+                int GhostGID = GrainID(D3D1ConvPosition);
                 float GhostDOCX = DOCenter(3 * D3D1ConvPosition);
                 float GhostDOCY = DOCenter(3 * D3D1ConvPosition + 1);
                 float GhostDOCZ = DOCenter(3 * D3D1ConvPosition + 2);
@@ -198,13 +194,15 @@ void testGhostNodes1D() {
         });
 
     GhostNodes1D(0, id, NeighborRank_North, NeighborRank_South, MyXSlices, MyYSlices, MyYOffset, NeighborX, NeighborY,
-                 NeighborZ, CellType, DOCenter, GrainID, GrainUnitVector, DiagonalLength, CritDiagonalLength,
-                 NGrainOrientations, BufferNorthSend, BufferSouthSend, BufferNorthRecv, BufferSouthRecv, BufSize,
-                 ZBound_Low, SendSizeNorth, SendSizeSouth);
+                 NeighborZ, cellData, DOCenter, GrainUnitVector, DiagonalLength, CritDiagonalLength, NGrainOrientations,
+                 BufferNorthSend, BufferSouthSend, BufferNorthRecv, BufferSouthRecv, BufSize, ZBound_Low, SendSizeNorth,
+                 SendSizeSouth);
 
     // Copy CellType, GrainID, DiagonalLength, DOCenter, CritDiagonalLength views to host to check values
-    CellType_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), CellType);
+    CellType = cellData.getCellTypeSubview();
+    GrainID = cellData.getGrainIDSubview();
     GrainID_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), GrainID);
+    CellType_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), CellType);
     DiagonalLength_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), DiagonalLength);
     CritDiagonalLength_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), CritDiagonalLength);
     DOCenter_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), DOCenter);
@@ -216,18 +214,16 @@ void testGhostNodes1D() {
                                                    2.902006, 2.613426, 1.576758, 1.576758, 2.248777, 2.266173, 2.266173,
                                                    2.248777, 1.527831, 1.527831, 1.715195, 1.927272, 1.914002, 1.851513,
                                                    2.291471, 2.902006, 2.613426, 2.346452, 2.236490};
-    int HaloLocations_Unpacked[2], HaloLocations_Unpacked_ActiveRegion[2];
+    int HaloLocations_Unpacked_ActiveRegion[2];
     float OctCentersY_Unpacked[2];
-    HaloLocations_Unpacked[0] = 6 * MyXSlices * MyYSlices + 2 * MyYSlices;
-    HaloLocations_Unpacked[1] = 6 * MyXSlices * MyYSlices + 2 * MyYSlices + MyYSlices - 1;
     HaloLocations_Unpacked_ActiveRegion[0] = (6 - ZBound_Low) * MyXSlices * MyYSlices + 2 * MyYSlices;
     HaloLocations_Unpacked_ActiveRegion[1] = (6 - ZBound_Low) * MyXSlices * MyYSlices + 2 * MyYSlices + MyYSlices - 1;
     OctCentersY_Unpacked[0] = MyYOffset + 0.5;
     OctCentersY_Unpacked[1] = MyYOffset + MyYSlices - 0.5;
     for (int n = 0; n < 2; n++) {
         if (((n == 0) && (!(AtSouthBoundary))) || ((n == 1) && (!(AtNorthBoundary)))) {
-            EXPECT_EQ(CellType_Host(HaloLocations_Unpacked[n]), Active);
-            EXPECT_EQ(GrainID_Host(HaloLocations_Unpacked[n]), 29);
+            EXPECT_EQ(CellType_Host(HaloLocations_Unpacked_ActiveRegion[n]), Active);
+            EXPECT_EQ(GrainID_Host(HaloLocations_Unpacked_ActiveRegion[n]), 29);
             EXPECT_FLOAT_EQ(DiagonalLength_Host(HaloLocations_Unpacked_ActiveRegion[n]), 0.01);
             EXPECT_FLOAT_EQ(DOCenter_Host(3 * HaloLocations_Unpacked_ActiveRegion[n]), 2.5);
             EXPECT_FLOAT_EQ(DOCenter_Host(3 * HaloLocations_Unpacked_ActiveRegion[n] + 1), OctCentersY_Unpacked[n]);
@@ -241,8 +237,8 @@ void testGhostNodes1D() {
     }
     // These cells should not have been modified, as their data was unchanged
     for (int n = 0; n < 4; n++) {
-        EXPECT_EQ(CellType_Host(HaloLocations_Alt[n]), Active);
-        EXPECT_EQ(GrainID_Host(HaloLocations_Alt[n]), -id);
+        EXPECT_EQ(CellType_Host(HaloLocations_Alt_ActiveRegion[n]), Active);
+        EXPECT_EQ(GrainID_Host(HaloLocations_Alt_ActiveRegion[n]), -id);
         EXPECT_FLOAT_EQ(DiagonalLength_Host(HaloLocations_Alt_ActiveRegion[n]), 0.01);
         EXPECT_FLOAT_EQ(DOCenter_Host(3 * HaloLocations_Alt_ActiveRegion[n]), 2.5);
         EXPECT_FLOAT_EQ(DOCenter_Host(3 * HaloLocations_Alt_ActiveRegion[n] + 1), OctCentersY_Alt[n]);
@@ -281,8 +277,11 @@ void testResizeRefillBuffers() {
 
     // Allocate device views: entire domain on each rank
     // Default to wall cells (CellType(index) = 0) with GrainID of 0
-    ViewI GrainID("GrainID", LocalDomainSize);
-    ViewI CellType("CellType", LocalDomainSize);
+    CellData cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
+    Kokkos::deep_copy(cellData.CellType_AllLayers, Liquid);
+    ViewI CellType = cellData.getCellTypeSubview();
+    ViewI GrainID = cellData.getGrainIDSubview();
+
     // Allocate device views: only the active layer on each rank
     ViewF DiagonalLength("DiagonalLength", LocalActiveDomainSize);
     ViewF DOCenter(Kokkos::ViewAllocateWithoutInitializing("DOCenter"), 3 * LocalActiveDomainSize);
@@ -308,9 +307,8 @@ void testResizeRefillBuffers() {
             int RankY = MyYSlices - 2;
             int RankZ = 0;
             int D3D1ConvPosition = RankZ * nx * MyYSlices + RankX * MyYSlices + RankY;
-            int GlobalD3D1ConvPosition = (RankZ + ZBound_Low) * nx * MyYSlices + RankX * MyYSlices + RankY;
-            CellType(GlobalD3D1ConvPosition) = Active;
-            GrainID(GlobalD3D1ConvPosition) = RankX;
+            CellType(D3D1ConvPosition) = Active;
+            GrainID(D3D1ConvPosition) = RankX;
             int GhostGID = RankX;
             DOCenter(3 * D3D1ConvPosition) = RankX + 0.5;
             float GhostDOCX = RankX + 0.5;
@@ -331,9 +329,8 @@ void testResizeRefillBuffers() {
             int RankY = 1;
             int RankZ = 0;
             int D3D1ConvPosition = RankZ * nx * MyYSlices + RankX * MyYSlices + RankY;
-            int GlobalD3D1ConvPosition = (RankZ + ZBound_Low) * nx * MyYSlices + RankX * MyYSlices + RankY;
-            CellType(GlobalD3D1ConvPosition) = Active;
-            GrainID(GlobalD3D1ConvPosition) = RankX;
+            CellType(D3D1ConvPosition) = Active;
+            GrainID(D3D1ConvPosition) = RankX;
             int GhostGID = RankX;
             DOCenter(3 * D3D1ConvPosition) = RankX + 0.5;
             float GhostDOCX = RankX + 0.5;
@@ -360,8 +357,7 @@ void testResizeRefillBuffers() {
             int RankY = MyYSlices - 2;
             int RankZ = k;
             int D3D1ConvPosition = RankZ * nx * MyYSlices + RankX * MyYSlices + RankY;
-            int GlobalD3D1ConvPosition = (RankZ + ZBound_Low) * nx * MyYSlices + RankX * MyYSlices + RankY;
-            GrainID(GlobalD3D1ConvPosition) = RankX;
+            GrainID(D3D1ConvPosition) = RankX;
             int GhostGID = RankX;
             DOCenter(3 * D3D1ConvPosition) = RankX + 0.5;
             float GhostDOCX = RankX + 0.5;
@@ -378,7 +374,7 @@ void testResizeRefillBuffers() {
                                BufferNorthSend, NGrainOrientations, BufSize);
             if (!(DataFitsInBuffer)) {
                 // This cell's data did not fit in the buffer with current size BufSize - mark with temporary type
-                CellType(GlobalD3D1ConvPosition) = ActiveFailedBufferLoad;
+                CellType(D3D1ConvPosition) = ActiveFailedBufferLoad;
             }
         });
 
@@ -388,8 +384,7 @@ void testResizeRefillBuffers() {
             int RankY = 1;
             int RankZ = k;
             int D3D1ConvPosition = RankZ * nx * MyYSlices + RankX * MyYSlices + RankY;
-            int GlobalD3D1ConvPosition = (RankZ + ZBound_Low) * nx * MyYSlices + RankX * MyYSlices + RankY;
-            GrainID(GlobalD3D1ConvPosition) = RankX;
+            GrainID(D3D1ConvPosition) = RankX;
             int GhostGID = RankX;
             DOCenter(3 * D3D1ConvPosition) = RankX + 0.5;
             float GhostDOCX = RankX + 0.5;
@@ -406,7 +401,7 @@ void testResizeRefillBuffers() {
                                BufferNorthSend, NGrainOrientations, BufSize);
             if (!(DataFitsInBuffer)) {
                 // This cell's data did not fit in the buffer with current size BufSize - mark with temporary type
-                CellType(GlobalD3D1ConvPosition) = ActiveFailedBufferLoad;
+                CellType(D3D1ConvPosition) = ActiveFailedBufferLoad;
             }
         });
 
@@ -415,9 +410,9 @@ void testResizeRefillBuffers() {
     BufSize = ResizeBuffers(BufferNorthSend, BufferSouthSend, BufferNorthRecv, BufferSouthRecv, SendSizeNorth,
                             SendSizeSouth, SendSizeNorth_Host, SendSizeSouth_Host, OldBufSize);
     if (OldBufSize != BufSize)
-        RefillBuffers(nx, nzActive, MyYSlices, ZBound_Low, CellType, BufferNorthSend, BufferSouthSend, SendSizeNorth,
-                      SendSizeSouth, AtNorthBoundary, AtSouthBoundary, GrainID, DOCenter, DiagonalLength,
-                      NGrainOrientations, BufSize);
+        RefillBuffers(nx, nzActive, MyYSlices, ZBound_Low, cellData, BufferNorthSend, BufferSouthSend, SendSizeNorth,
+                      SendSizeSouth, AtNorthBoundary, AtSouthBoundary, DOCenter, DiagonalLength, NGrainOrientations,
+                      BufSize);
     // If there was 1 rank, buffer size should still be 1, as no data was loaded
     // Otherwise, 25 cells should have been added to the buffer in
     // addition to the required capacity increase during the resize

--- a/unit_test/tstKokkosMPI.hpp
+++ b/unit_test/tstKokkosMPI.hpp
@@ -93,8 +93,8 @@ void testGhostNodes1D() {
 
     // Initialize host views - set initial GrainID values to 0, all CellType values to liquid
     CellData<TEST_MEMSPACE> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
-    ViewI CellType = cellData.getCellTypeSubview();
-    ViewI GrainID = cellData.getGrainIDSubview();
+    auto CellType = cellData.getCellTypeSubview();
+    auto GrainID = cellData.getGrainIDSubview();
     ViewI_H CellType_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), CellType);
     Kokkos::deep_copy(CellType_Host, Liquid);
     ViewI_H GrainID_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), GrainID);

--- a/unit_test/tstKokkosMPI.hpp
+++ b/unit_test/tstKokkosMPI.hpp
@@ -95,9 +95,9 @@ void testGhostNodes1D() {
     CellData<TEST_MEMSPACE> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
     auto CellType = cellData.getCellTypeSubview();
     auto GrainID = cellData.getGrainIDSubview();
-    ViewI_H CellType_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), CellType);
+    auto CellType_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), CellType);
     Kokkos::deep_copy(CellType_Host, Liquid);
-    ViewI_H GrainID_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), GrainID);
+    auto GrainID_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), GrainID);
     // Initialize active domain views to 0
     ViewF_H DiagonalLength_Host("DiagonalLength_Host", LocalActiveDomainSize);
     ViewF_H DOCenter_Host("DOCenter_Host", 3 * LocalActiveDomainSize);
@@ -279,8 +279,8 @@ void testResizeRefillBuffers() {
     // Default to wall cells (CellType(index) = 0) with GrainID of 0
     CellData<TEST_MEMSPACE> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
     Kokkos::deep_copy(cellData.CellType_AllLayers, Liquid);
-    ViewI CellType = cellData.getCellTypeSubview();
-    ViewI GrainID = cellData.getGrainIDSubview();
+    auto CellType = cellData.getCellTypeSubview();
+    auto GrainID = cellData.getGrainIDSubview();
 
     // Allocate device views: only the active layer on each rank
     ViewF DiagonalLength("DiagonalLength", LocalActiveDomainSize);

--- a/unit_test/tstKokkosUpdate.hpp
+++ b/unit_test/tstKokkosUpdate.hpp
@@ -40,9 +40,9 @@ void testNucleation() {
     CellData<TEST_MEMSPACE> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
     Kokkos::deep_copy(cellData.CellType_AllLayers, Liquid);
     auto CellType = cellData.getCellTypeSubview();
-    ViewI_H CellType_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), CellType);
-    ViewI GrainID = cellData.getGrainIDSubview();
-    ViewI_H GrainID_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), GrainID);
+    auto CellType_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), CellType);
+    auto GrainID = cellData.getGrainIDSubview();
+    auto GrainID_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), GrainID);
 
     // Create test nucleation data - 10 possible events
     int PossibleNuclei = 10;
@@ -170,10 +170,10 @@ void testFillSteeringVector_Remelt() {
                                      LocalDomainSize); // initialize to 0, no initial undercooling
     ViewF3D_H LayerTimeTempHistory_Host("LayerTimeTempHistory_Host", LocalActiveDomainSize, 1,
                                         3); // initialize to 0, no initial undercooling
-    ViewI CellType = cellData.getCellTypeSubview();
-    ViewI_H CellType_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), CellType);
-    ViewI GrainID = cellData.getGrainIDSubview();
-    ViewI_H GrainID_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), GrainID);
+    auto CellType = cellData.getCellTypeSubview();
+    auto CellType_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), CellType);
+    auto GrainID = cellData.getGrainIDSubview();
+    auto GrainID_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), GrainID);
 
     for (int D3D1ConvPosition = 0; D3D1ConvPosition < LocalActiveDomainSize; D3D1ConvPosition++) {
         GrainID_Host(D3D1ConvPosition) = 1;

--- a/unit_test/tstKokkosUpdate.hpp
+++ b/unit_test/tstKokkosUpdate.hpp
@@ -39,7 +39,7 @@ void testNucleation() {
     // are unable to occur
     CellData<TEST_MEMSPACE> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
     Kokkos::deep_copy(cellData.CellType_AllLayers, Liquid);
-    ViewI CellType = cellData.getCellTypeSubview();
+    auto CellType = cellData.getCellTypeSubview();
     ViewI_H CellType_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), CellType);
     ViewI GrainID = cellData.getGrainIDSubview();
     ViewI_H GrainID_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), GrainID);

--- a/unit_test/tstKokkosUpdate.hpp
+++ b/unit_test/tstKokkosUpdate.hpp
@@ -158,7 +158,7 @@ void testFillSteeringVector_Remelt() {
     NList NeighborX, NeighborY, NeighborZ;
     NeighborListInit(NeighborX, NeighborY, NeighborZ);
 
-    CellData<TEST_MEMSPACE> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
+    CellData<device_memory_space> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
     ViewI_H MeltTimeStep_Host(Kokkos::ViewAllocateWithoutInitializing("MeltTimeStep_Host"), LocalDomainSize);
     ViewI_H CritTimeStep_Host(Kokkos::ViewAllocateWithoutInitializing("CritTimeStep_Host"), LocalDomainSize);
     ViewI_H SolidificationEventCounter_Host("SolidificationEventCounter_Host", LocalDomainSize); // init to 0

--- a/unit_test/tstKokkosUpdate.hpp
+++ b/unit_test/tstKokkosUpdate.hpp
@@ -37,7 +37,7 @@ void testNucleation() {
 
     // All cells have GrainID of 0, CellType of Liquid - with the exception of the locations where the nucleation events
     // are unable to occur
-    CellData<TEST_MEMSPACE> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
+    CellData<memory_space> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
     Kokkos::deep_copy(cellData.CellType_AllLayers, Liquid);
     auto CellType = cellData.getCellTypeSubview();
     auto CellType_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), CellType);

--- a/unit_test/tstKokkosUpdate.hpp
+++ b/unit_test/tstKokkosUpdate.hpp
@@ -37,7 +37,7 @@ void testNucleation() {
 
     // All cells have GrainID of 0, CellType of Liquid - with the exception of the locations where the nucleation events
     // are unable to occur
-    CellData cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
+    CellData<TEST_MEMSPACE> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
     Kokkos::deep_copy(cellData.CellType_AllLayers, Liquid);
     ViewI CellType = cellData.getCellTypeSubview();
     ViewI_H CellType_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), CellType);
@@ -158,7 +158,7 @@ void testFillSteeringVector_Remelt() {
     NList NeighborX, NeighborY, NeighborZ;
     NeighborListInit(NeighborX, NeighborY, NeighborZ);
 
-    CellData cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
+    CellData<TEST_MEMSPACE> cellData(LocalDomainSize, LocalActiveDomainSize, nx, MyYSlices, ZBound_Low);
     ViewI_H MeltTimeStep_Host(Kokkos::ViewAllocateWithoutInitializing("MeltTimeStep_Host"), LocalDomainSize);
     ViewI_H CritTimeStep_Host(Kokkos::ViewAllocateWithoutInitializing("CritTimeStep_Host"), LocalDomainSize);
     ViewI_H SolidificationEventCounter_Host("SolidificationEventCounter_Host", LocalDomainSize); // init to 0


### PR DESCRIPTION
- Moved cell type/substrate init/layer init subroutines into CellData struct
- Consolidated cell data init unit tests
- Used subviews for portions LayerID, GrainID, CellType, where the subviews are indexed with respect to a layer, not the whole domain