### PR TITLE
Remove extra newline/comma in log file

### DIFF
--- a/src/CAprint.cpp
+++ b/src/CAprint.cpp
@@ -63,7 +63,7 @@ void PrintExaCALog(int id, int np, std::string InputFile, std::string PathToOutp
         if (SimulationType != "C") {
             ExaCALog << "," << std::endl;
             ExaCALog << "      \"NumberOfLayers\": " << NumberOfLayers << "," << std::endl;
-            ExaCALog << "      \"LayerOffset\": " << LayerHeight << "," << std::endl;
+            ExaCALog << "      \"LayerOffset\": " << LayerHeight;
             if (SimulationType == "S") {
                 ExaCALog << "," << std::endl;
                 ExaCALog << "      \"NSpotsX\": " << NSpotsX << "," << std::endl;


### PR DESCRIPTION
For problem type R, this lead to an extra comma and newline being inserted after the "LayerOffset" value, leading to a parsing error when running the analysis script