### PR TITLE
Change bounds for analysis of SmallDirS

### DIFF
--- a/analysis/examples/AnalyzeSmallDirS.json
+++ b/analysis/examples/AnalyzeSmallDirS.json
@@ -2,9 +2,9 @@
     "Regions": {
         "RepresentativeVolume": {
             "units": "Cells",
-            "xBounds": [5, 45],
-            "yBounds": [5, 45],
-            "zBounds": [1, 49],
+            "xBounds": [0, 19],
+            "yBounds": [0, 19],
+            "zBounds": [0, 19],
             "printExaConstit": false,
             "printPoleFigure": true,
             "printAvgStats": ["GrainTypeFractions","Misorientation","Size", "BuildTransAspectRatio","Extent"],
@@ -13,7 +13,7 @@
         },
         "XYCross": {
             "units": "Cells",
-            "zBounds": [45,45],
+            "zBounds": [19,19],
             "printPoleFigureData": true,
             "printInversePoleFigureData": true
         },


### PR DESCRIPTION
The size of the test problem `Inp_SmallDirSolidification.json` was previously reduced, but the bounds for analysis of the microstructure were never changed, leading to an out of bounds error when running `grain_analysis` using `AnalyzeSmallDirSolidification.json`

Fixup of #202 