### PR TITLE
Use of short type for LayerID

### DIFF
--- a/analysis/src/GAprint.cpp
+++ b/analysis/src/GAprint.cpp
@@ -68,7 +68,7 @@ void printAnalysisHeader_Area(std::ofstream &QoIs, const int XLow_cells, const i
 // Print number of cells in the representative region that did not undergo melting, fraction consisting of nucleated
 // grains to the console/QoIs file
 void printGrainTypeFractions(std::ofstream &QoIs, const int XLow, const int XHigh, const int YLow, const int YHigh,
-                             const int ZLow, const int ZHigh, ViewI3D_H GrainID, ViewI3D_H LayerID,
+                             const int ZLow, const int ZHigh, ViewI3D_H GrainID, ViewS3D_H LayerID,
                              int RepresentativeRegionSize) {
 
     int NumberOfUnmeltedCells = 0;

--- a/analysis/src/GAprint.hpp
+++ b/analysis/src/GAprint.hpp
@@ -30,7 +30,7 @@ void printAnalysisHeader_Area(std::ofstream &QoIs, const int XLow_cells, const i
 //****
 // Functions for printing data for a region of various type
 void printGrainTypeFractions(std::ofstream &QoIs, const int XLow, const int XHigh, const int YLow, const int YHigh,
-                             const int ZLow, const int ZHigh, ViewI3D_H GrainID, ViewI3D_H LayerID,
+                             const int ZLow, const int ZHigh, ViewI3D_H GrainID, ViewS3D_H LayerID,
                              int RepresentativeRegionSize);
 void printMeanMisorientations(std::ofstream &QoIs, int NumberOfGrains, std::vector<float> GrainMisorientationXVector,
                               std::vector<float> GrainMisorientationYVector,

--- a/analysis/src/GArepresentativeregion.hpp
+++ b/analysis/src/GArepresentativeregion.hpp
@@ -461,7 +461,7 @@ struct RepresentativeRegion {
 
     // Create a histogram of orientations for texture determination, using the GrainID values in the volume bounded by
     // [XMin,XMax], [YMin,YMax], [ZMin,ZMax] and excluding and cells that did not undergo melting (GrainID = -1)
-    ViewI_H getOrientationHistogram(int NumberOfOrientations, ViewI3D_H GrainID, ViewI3D_H LayerID) {
+    ViewI_H getOrientationHistogram(int NumberOfOrientations, ViewI3D_H GrainID, ViewS3D_H LayerID) {
 
         // Init histogram values to zero
         ViewI_H GOHistogram("GOHistogram", NumberOfOrientations);
@@ -531,7 +531,7 @@ struct RepresentativeRegion {
 
     // Print number of cells in the representative region that did not undergo melting, fraction consisting of nucleated
     // grains to the console/QoIs file
-    void printGrainTypeFractions(std::ofstream &QoIs, ViewI3D_H GrainID, ViewI3D_H LayerID) {
+    void printGrainTypeFractions(std::ofstream &QoIs, ViewI3D_H GrainID, ViewS3D_H LayerID) {
 
         int NumberOfUnmeltedCells = 0;
         int NumberOfNucleatedGrainCells = 0;

--- a/analysis/src/GAutils.hpp
+++ b/analysis/src/GAutils.hpp
@@ -29,10 +29,7 @@ int FindTopOrBottom(int ***LayerID, int XLow, int XHigh, int YLow, int YHigh, in
 void ParseLogFile(std::string LogFile, int &nx, int &ny, int &nz, double &deltax, int &NumberOfLayers,
                   std::vector<double> &XYZBounds, std::string &RotationFilename, std::string &EulerAnglesFilename,
                   std::string &RGBFilename, bool OrientationFilesInInput);
-void ReadASCIIField(std::ifstream &InputDataStream, int nx, int ny, int nz, ViewI3D_H FieldOfInterest);
-void ReadBinaryField(std::ifstream &InputDataStream, int nx, int ny, int nz, ViewI3D_H FieldOfInterest,
-                     std::string FieldName);
-void InitializeData(std::string MicrostructureFile, int nx, int ny, int nz, ViewI3D_H GrainID, ViewI3D_H LayerID);
+void InitializeData(std::string MicrostructureFile, int nx, int ny, int nz, ViewI3D_H &GrainID, ViewS3D_H &LayerID);
 void CheckInputFiles(std::string &LogFile, std::string MicrostructureFile, std::string &RotationFilename,
                      std::string &RGBFilename, std::string &EulerAnglesFilename);
 double convertToMicrons(double deltax, std::string RegionType);
@@ -44,6 +41,61 @@ void dual_print(std::string temp, std::ostream &stream1, std::ostream &stream2);
 template <typename ReturnType, typename FirstType, typename SecondType>
 ReturnType DivideCast(FirstType Int1, SecondType Int2) {
     return static_cast<ReturnType>(Int1) / static_cast<ReturnType>(Int2);
+}
+
+// Reads portion of a paraview file and places data in the appropriate data structure
+// ASCII data at each Z value is separated by a newline
+template <typename read_view_type_3d_host>
+read_view_type_3d_host ReadASCIIField(std::ifstream &InputDataStream, int nx, int ny, int nz, std::string label) {
+    read_view_type_3d_host FieldOfInterest(Kokkos::ViewAllocateWithoutInitializing(label), nz, nx, ny);
+    using value_type = typename read_view_type_3d_host::value_type;
+    for (int k = 0; k < nz; k++) {
+        // Get line from file
+        std::string line;
+        getline(InputDataStream, line);
+        // Parse string at spaces
+        std::istringstream ss(line);
+        for (int j = 0; j < ny; j++) {
+            for (int i = 0; i < nx; i++) {
+                FieldOfInterest(k, i, j) = ParseASCIIData<value_type>(ss);
+            }
+        }
+    }
+    return FieldOfInterest;
+}
+
+// Reads binary string of type read_datatype from a paraview file, converts field to the appropriate type to match
+// read_view_type_3d_host (i.e, value_type), and place data in the appropriate data structure Each field consists of a
+// single binary string (no newlines) Store converted values in view - LayerID data is a short int, GrainID data is an
+// int In some older vtk files, LayerID may have been stored as an int and should be converted
+template <typename read_view_type_3d_host, typename read_datatype>
+read_view_type_3d_host ReadBinaryField(std::ifstream &InputDataStream, int nx, int ny, int nz, std::string label) {
+    read_view_type_3d_host FieldOfInterest(Kokkos::ViewAllocateWithoutInitializing(label), nz, nx, ny);
+    using value_type = typename read_view_type_3d_host::value_type;
+    for (int k = 0; k < nz; k++) {
+        for (int j = 0; j < ny; j++) {
+            for (int i = 0; i < nx; i++) {
+                read_datatype parsed_value = ReadBinaryData<read_datatype>(InputDataStream, true);
+                FieldOfInterest(k, i, j) = static_cast<value_type>(parsed_value);
+            }
+        }
+    }
+    return FieldOfInterest;
+}
+
+void ReadIgnoreASCIIField(std::ifstream &InputDataStream, int nx, int ny, int nz);
+
+// Reads and discards binary string of type read_datatype from a paraview file
+template <typename read_datatype>
+void ReadIgnoreBinaryField(std::ifstream &InputDataStream, int nx, int ny, int nz) {
+    unsigned char temp[sizeof(read_datatype)];
+    for (int k = 0; k < nz; k++) {
+        for (int j = 0; j < ny; j++) {
+            for (int i = 0; i < nx; i++) {
+                InputDataStream.read(reinterpret_cast<char *>(temp), sizeof(read_datatype));
+            }
+        }
+    }
 }
 
 #endif

--- a/analysis/src/runGA.cpp
+++ b/analysis/src/runGA.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[]) {
 
         // Allocate memory blocks for GrainID and LayerID data
         ViewI3D_H GrainID(Kokkos::ViewAllocateWithoutInitializing("GrainID"), nz, nx, ny);
-        ViewI3D_H LayerID(Kokkos::ViewAllocateWithoutInitializing("LayerID"), nz, nx, ny);
+        ViewS3D_H LayerID(Kokkos::ViewAllocateWithoutInitializing("LayerID"), nz, nx, ny);
 
         // Fill arrays with data from paraview file
         InitializeData(MicrostructureFile, nx, ny, nz, GrainID, LayerID);

--- a/src/CAcelldata.hpp
+++ b/src/CAcelldata.hpp
@@ -28,12 +28,13 @@ struct CellData {
     using view_type_int = Kokkos::View<int *, memory_space>;
     using view_type_int_host = typename view_type_int::HostMirror;
     using view_type_int_unmanaged = Kokkos::View<int *, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    using view_type_short = Kokkos::View<short *, memory_space>;
     using view_type_float = Kokkos::View<float *, memory_space>;
 
     int NextLayer_FirstEpitaxialGrainID, BottomOfCurrentLayer, TopOfCurrentLayer;
     std::pair<int, int> LayerRange;
-    view_type_int GrainID_AllLayers, CellType_AllLayers, LayerID_AllLayers;
-
+    view_type_int GrainID_AllLayers, CellType_AllLayers;
+    view_type_short LayerID_AllLayers;
     // Constructor for views and view bounds for current layer
     // TODO: CellType is only needed for the current layer, and LayerID is only needed for all layers/no subview is
     // needed. Leaving them as-is for now each with the "AllLayers" and "Current layer/subview slice" to minimize
@@ -41,7 +42,7 @@ struct CellData {
     CellData(int LocalDomainSize, int LocalActiveDomainSize, int nx, int MyYSlices, int ZBound_Low)
         : GrainID_AllLayers(view_type_int("GrainID", LocalDomainSize))
         , CellType_AllLayers(view_type_int(Kokkos::ViewAllocateWithoutInitializing("CellType"), LocalDomainSize))
-        , LayerID_AllLayers(view_type_int(Kokkos::ViewAllocateWithoutInitializing("LayerID"), LocalDomainSize)) {
+        , LayerID_AllLayers(view_type_short(Kokkos::ViewAllocateWithoutInitializing("LayerID"), LocalDomainSize)) {
 
         BottomOfCurrentLayer = ZBound_Low * nx * MyYSlices;
         TopOfCurrentLayer = BottomOfCurrentLayer + LocalActiveDomainSize;

--- a/src/CAfunctions.cpp
+++ b/src/CAfunctions.cpp
@@ -166,7 +166,7 @@ ViewF_H MisorientationCalc(int NumberOfOrientations, ViewF_H GrainUnitVector, in
 }
 
 // Stores/returns the volume fraction of nucleated grains to the console
-float calcVolFractionNucleated(int id, int nx, int MyYSlices, int LocalDomainSize, ViewI LayerID, ViewI GrainID,
+float calcVolFractionNucleated(int id, int nx, int MyYSlices, int LocalDomainSize, ViewS LayerID, ViewI GrainID,
                                bool AtNorthBoundary, bool AtSouthBoundary) {
 
     // For interior cells, add the number of cells that underwent melting/solidification and the number of cells with

--- a/src/CAfunctions.hpp
+++ b/src/CAfunctions.hpp
@@ -113,7 +113,7 @@ double MaxVal(double TestVec3[6], int NVals);
 void InitialDecomposition(int id, int np, int &NeighborRank_North, int &NeighborRank_South, bool &AtNorthBoundary,
                           bool &AtSouthBoundary);
 ViewF_H MisorientationCalc(int NumberOfOrientations, ViewF_H GrainUnitVector, int dir);
-float calcVolFractionNucleated(int id, int nx, int MyYSlices, int LocalDomainSize, ViewI LayerID, ViewI GrainID,
+float calcVolFractionNucleated(int id, int nx, int MyYSlices, int LocalDomainSize, ViewS LayerID, ViewI GrainID,
                                bool AtNorthBoundary, bool AtSouthBoundary);
 
 #endif

--- a/src/CAtypes.hpp
+++ b/src/CAtypes.hpp
@@ -25,6 +25,7 @@ enum TypeNames {
 // Use Kokkos::DefaultExecutionSpace
 typedef Kokkos::View<float *> ViewF;
 typedef Kokkos::View<int *> ViewI;
+typedef Kokkos::View<short *> ViewS;
 typedef Kokkos::View<int **> ViewI2D;
 typedef Kokkos::View<int *, Kokkos::MemoryTraits<Kokkos::Atomic>> View_a;
 typedef Kokkos::View<float **> Buffer2D;
@@ -38,6 +39,8 @@ typedef Kokkos::View<double *, layout, Kokkos::HostSpace> ViewD_H;
 typedef Kokkos::View<float *, layout, Kokkos::HostSpace> ViewF_H;
 typedef Kokkos::View<float **, layout, Kokkos::HostSpace> ViewF2D_H;
 typedef Kokkos::View<float ***, layout, Kokkos::HostSpace> ViewF3D_H;
+typedef Kokkos::View<short ***, layout, Kokkos::HostSpace> ViewS3D_H;
+typedef Kokkos::View<short *, layout, Kokkos::HostSpace> ViewS_H;
 typedef Kokkos::View<int *, layout, Kokkos::HostSpace> ViewI_H;
 typedef Kokkos::View<int **, layout, Kokkos::HostSpace> ViewI2D_H;
 typedef Kokkos::View<int ***, layout, Kokkos::HostSpace> ViewI3D_H;

--- a/unit_test/tstKokkosMPI.hpp
+++ b/unit_test/tstKokkosMPI.hpp
@@ -531,7 +531,7 @@ void testcalcVolFractionNucleated() {
     // Let all cells except those at Z = 0 have undergone solidification
     // Let the cells at Z = 1 consist of positive grain IDs, and those at Z = 2 of negative grain IDs
     ViewI_H GrainID_Host(Kokkos::ViewAllocateWithoutInitializing("GrainID"), LocalDomainSize);
-    ViewI_H LayerID_Host(Kokkos::ViewAllocateWithoutInitializing("LayerID"), LocalDomainSize);
+    ViewS_H LayerID_Host(Kokkos::ViewAllocateWithoutInitializing("LayerID"), LocalDomainSize);
     for (int k = 0; k < nz; k++) {
         for (int i = 0; i < nx; i++) {
             for (int j = 0; j < MyYSlices; j++) {
@@ -548,7 +548,7 @@ void testcalcVolFractionNucleated() {
         }
     }
     ViewI GrainID = Kokkos::create_mirror_view_and_copy(device_memory_space(), GrainID_Host);
-    ViewI LayerID = Kokkos::create_mirror_view_and_copy(device_memory_space(), LayerID_Host);
+    ViewS LayerID = Kokkos::create_mirror_view_and_copy(device_memory_space(), LayerID_Host);
 
     // Perform calculation and compare to expected value (half of the solidified portion of the domain should consist of
     // nucleated grains, regardless of the number of MPI ranks used)


### PR DESCRIPTION
* Consistent use of `short` for LayerID
* Modification of analysis field parsing routine to ensure that each parsed field is the correct type, with either `int` or `short` possible for LayerID based which commit was used to generate the vtk data (though it is now always stored as `short`)
* Template analysis field parsing routines to make more adaptable for future fields that may appear in the vtk output with various names/types