### PR TITLE
New problem type for solidification of a single grain in an initially liquid domain

### DIFF
--- a/src/CAcelldata.hpp
+++ b/src/CAcelldata.hpp
@@ -52,8 +52,9 @@ struct CellData {
     // Initializes the single active cell and associated active cell data structures for the single grain at the domain
     // center
     void init_substrate(int id, int singleGrainOrientation, int nx, int ny, int nz, int ny_local, int y_offset,
-                        int DomainSize, NList NeighborX, NList NeighborY, NList NeighborZ, ViewF GrainUnitVector,
-                        ViewF DiagonalLength, ViewF DOCenter, ViewF CritDiagonalLength) {
+                        int DomainSize, NList NeighborX, NList NeighborY, NList NeighborZ,
+                        view_type_float GrainUnitVector, view_type_float DiagonalLength, view_type_float DOCenter,
+                        view_type_float CritDiagonalLength) {
 
         // Location of the single grain
         int grainLocationX = floorf(static_cast<float>(nx) / 2.0);

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -22,7 +22,8 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
                        float &SubstrateGrainSpacing, bool &UseSubstrateFile, double &G, double &R, int &nx, int &ny,
                        int &nz, double &FractSurfaceSitesActive, int &NSpotsX, int &NSpotsY, int &SpotOffset,
                        int &SpotRadius, double &RNGSeed, bool &BaseplateThroughPowder, double &PowderActiveFraction,
-                       bool &LayerwiseTempRead, bool &PowderFirstLayer, Print &print);
+                       bool &LayerwiseTempRead, bool &PowderFirstLayer, Print &print, double &InitUndercooling,
+                       int &SingleGrainOrientation);
 void checkPowderOverflow(int nx, int ny, int LayerHeight, int NumberOfLayers, bool BaseplateThroughPowder,
                          double PowderDensity);
 void NeighborListInit(NList &NeighborX, NList &NeighborY, NList &NeighborZ);

--- a/src/CAtemperature.hpp
+++ b/src/CAtemperature.hpp
@@ -193,7 +193,7 @@ struct Temperature {
                 MaxSolidificationEvents_local(0) = 1;
                 NumberOfSolidificationEvents_local(index) = 1;
                 // All cells at init undercooling
-                UndercoolingCurrent(index) = initUndercooling;
+                UndercoolingCurrent_local(index) = initUndercooling;
             });
         if (id == 0)
             std::cout << "Undercooling field initialized to = " << initUndercooling << " K for all cells" << std::endl;
@@ -225,14 +225,16 @@ struct Temperature {
                 // All cells past melting time step
                 LayerTimeTempHistory_local(index, 0, 0) = -1;
                 // Cells reach liquidus at a time dependent on their Z coordinate
-                float liquidusTime = distFromLiquidus * G * deltax / (R * deltat);
                 // Cells with negative liquidus time values are already undercooled, should have positive undercooling
-                // Cells with positive liquidus time values are not yet tracked
-                // Leave current undercooling as default zeros
-                if (liquidusTime < 0)
+                // and negative liquidus time step Cells with positive liquidus time values are not yet tracked - leave
+                // current undercooling as default zeros and set liquidus time step
+                if (distFromLiquidus < 0) {
                     LayerTimeTempHistory_local(index, 0, 1) = -1;
+                    UndercoolingCurrent_local(index) = initUndercooling - distFromLiquidus * (G * deltax);
+                }
                 else
-                    LayerTimeTempHistory_local(index, 0, 1) = liquidusTime;
+                    LayerTimeTempHistory_local(index, 0, 1) = distFromLiquidus * G * deltax / (R * deltat);
+                ;
                 // Cells cool at a constant rate
                 LayerTimeTempHistory_local(index, 0, 2) = R * deltat;
                 // All cells solidify once

--- a/src/CAtemperature.hpp
+++ b/src/CAtemperature.hpp
@@ -227,17 +227,12 @@ struct Temperature {
                 // Cells reach liquidus at a time dependent on their Z coordinate
                 float liquidusTime = distFromLiquidus * G * deltax / (R * deltat);
                 // Cells with negative liquidus time values are already undercooled, should have positive undercooling
-                // Cells with positive liquidus time values are not yet tracked, leave as default init 0s
-                if (liquidusTime < 0) {
+                // Cells with positive liquidus time values are not yet tracked
+                // Leave current undercooling as default zeros
+                if (liquidusTime < 0)
                     LayerTimeTempHistory_local(index, 0, 1) = -1;
-                }
-                else {
+                else
                     LayerTimeTempHistory_local(index, 0, 1) = liquidusTime;
-                    if (SimulationType == "C")
-                        UndercoolingCurrent(index) = 0.0;
-                    else
-                        UndercoolingCurrent(index) = -R * deltat * liquidusTime;
-                }
                 // Cells cool at a constant rate
                 LayerTimeTempHistory_local(index, 0, 2) = R * deltat;
                 // All cells solidify once

--- a/src/CAtemperature.hpp
+++ b/src/CAtemperature.hpp
@@ -169,29 +169,84 @@ struct Temperature {
         }
     }
 
-    // Initialize temperature data for a constrained solidification problem
-    void initialize(double G, double R, int id, int nx, int ny_local, double deltax, double deltat, int DomainSize) {
+    // Initialize temperature data without a thermal gradient for constrained/single grain problem types
+    void initialize(double R, int id, double deltat, int DomainSize, double initUndercooling) {
 
         // Initialize temperature field in Z direction with thermal gradient G set in input file
-        // Cells at the bottom surface (Z = 0) are at the liquidus at time step 0 (no wall cells at the bottom boundary)
-        if (id == 0)
-            std::cout << "Initializing temperature field for directional solidification simulation" << std::endl;
+        // Liquidus front (InitUndercooling = 0) is at domain bottom for directional solidification, is at domain center
+        // (with custom InitUndercooling value) for single grain solidification
         auto LayerTimeTempHistory_local = LayerTimeTempHistory;
         auto MaxSolidificationEvents_local = MaxSolidificationEvents;
         auto NumberOfSolidificationEvents_local = NumberOfSolidificationEvents;
+        auto UndercoolingCurrent_local = UndercoolingCurrent;
+
+        // Uniform undercooling field
         Kokkos::parallel_for(
-            "TempInitDirS", DomainSize, KOKKOS_LAMBDA(const int &index) {
+            "TempInitUniform", DomainSize, KOKKOS_LAMBDA(const int &index) {
+                // All cells past melting time step and liquidus time step
+                LayerTimeTempHistory_local(index, 0, 0) = -1;
+                // Cells reach liquidus at a time dependent on their Z coordinate
+                LayerTimeTempHistory_local(index, 0, 1) = -1;
+                // Cells cool at a constant rate
+                LayerTimeTempHistory_local(index, 0, 2) = R * deltat;
+                // All cells solidify once
+                MaxSolidificationEvents_local(0) = 1;
+                NumberOfSolidificationEvents_local(index) = 1;
+                // All cells at init undercooling
+                UndercoolingCurrent(index) = initUndercooling;
+            });
+        if (id == 0)
+            std::cout << "Undercooling field initialized to = " << initUndercooling << " K for all cells" << std::endl;
+    }
+
+    // Initialize temperature data with a thermal gradient in Z for constrained/single grain problem types
+    void initialize(std::string SimulationType, double G, double R, int id, int nx, int ny_local, int nz, double deltax,
+                    double deltat, int DomainSize, double initUndercooling) {
+
+        // Initialize temperature field in Z direction with thermal gradient G set in input file
+        // Liquidus front (InitUndercooling = 0) is at domain bottom for directional solidification, is at domain center
+        // (with custom InitUndercooling value) for single grain solidification
+        int locationOfInitUndercooling;
+        if (SimulationType == "C")
+            locationOfInitUndercooling = 0;
+        else
+            locationOfInitUndercooling = floorf(static_cast<float>(nz) / 2.0);
+        int locationOfLiquidus = locationOfInitUndercooling + round(initUndercooling / (G * deltax));
+
+        auto LayerTimeTempHistory_local = LayerTimeTempHistory;
+        auto MaxSolidificationEvents_local = MaxSolidificationEvents;
+        auto NumberOfSolidificationEvents_local = NumberOfSolidificationEvents;
+        auto UndercoolingCurrent_local = UndercoolingCurrent;
+        Kokkos::parallel_for(
+            "TempInitG", DomainSize, KOKKOS_LAMBDA(const int &index) {
                 int coord_z = getCoordZ(index, nx, ny_local);
+                // Negative distFromLiquidus values for cells below the liquidus
+                int distFromLiquidus = coord_z - locationOfLiquidus;
                 // All cells past melting time step
                 LayerTimeTempHistory_local(index, 0, 0) = -1;
                 // Cells reach liquidus at a time dependent on their Z coordinate
-                LayerTimeTempHistory_local(index, 0, 1) = static_cast<int>((coord_z * G * deltax) / (R * deltat));
+                float liquidusTime = distFromLiquidus * G * deltax / (R * deltat);
+                // Cells with negative liquidus time values are already undercooled, should have positive undercooling
+                // Cells with positive liquidus time values are not yet tracked, leave as default init 0s
+                if (liquidusTime < 0) {
+                    LayerTimeTempHistory_local(index, 0, 1) = -1;
+                }
+                else {
+                    LayerTimeTempHistory_local(index, 0, 1) = liquidusTime;
+                    if (SimulationType == "C")
+                        UndercoolingCurrent(index) = 0.0;
+                    else
+                        UndercoolingCurrent(index) = -R * deltat * liquidusTime;
+                }
                 // Cells cool at a constant rate
                 LayerTimeTempHistory_local(index, 0, 2) = R * deltat;
                 // All cells solidify once
                 MaxSolidificationEvents_local(0) = 1;
                 NumberOfSolidificationEvents_local(index) = 1;
             });
+        if (id == 0)
+            std::cout << "Temperature field initialized for unidirectional solidification with G = " << G << " K/m"
+                      << std::endl;
     }
 
     // For an overlapping spot melt pattern, determine max number of times a cell will melt/solidify as part of a layer

--- a/src/CAtypes.hpp
+++ b/src/CAtypes.hpp
@@ -31,6 +31,7 @@ typedef Kokkos::View<int *, Kokkos::MemoryTraits<Kokkos::Atomic>> View_a;
 typedef Kokkos::View<float **> Buffer2D;
 typedef Kokkos::View<float *> TestView;
 typedef Kokkos::View<float ***> ViewF3D;
+typedef Kokkos::View<bool **> ViewB2D;
 
 using exe_space = Kokkos::DefaultExecutionSpace::execution_space;
 using device_memory_space = Kokkos::DefaultExecutionSpace::memory_space;
@@ -45,6 +46,7 @@ typedef Kokkos::View<int *, layout, Kokkos::HostSpace> ViewI_H;
 typedef Kokkos::View<int **, layout, Kokkos::HostSpace> ViewI2D_H;
 typedef Kokkos::View<int ***, layout, Kokkos::HostSpace> ViewI3D_H;
 typedef Kokkos::View<float **, layout, Kokkos::HostSpace> Buffer2D_H;
+typedef Kokkos::View<bool **, layout, Kokkos::HostSpace> ViewB2D_H;
 
 typedef Kokkos::Array<int, 26> NList;
 

--- a/src/CAupdate.cpp
+++ b/src/CAupdate.cpp
@@ -631,8 +631,8 @@ void IntermediateOutputAndCheck(int id, int np, int &cycle, int ny_local, int Do
 //*****************************************************************************/
 // Prints intermediate code output to stdout and checks to see the single grain simulation end condition (the grain has
 // reached a domain edge) has been satisfied
-void IntermediateOutputAndCheck_SingleGrain(int id, int cycle, int ny_local, int y_offset, int DomainSize, int nx,
-                                            int ny, int nz, int &XSwitch, ViewI CellType_AllLayers) {
+void IntermediateOutputAndCheck(int id, int cycle, int ny_local, int y_offset, int DomainSize, int nx, int ny, int nz,
+                                int &XSwitch, ViewI CellType_AllLayers) {
 
     unsigned long int LocalLiquidCells, LocalActiveCells, LocalSolidCells;
     ViewB2D EdgesReached(Kokkos::ViewAllocateWithoutInitializing("EdgesReached"), 3, 2); // init to false

--- a/src/CAupdate.cpp
+++ b/src/CAupdate.cpp
@@ -627,3 +627,71 @@ void IntermediateOutputAndCheck(int id, int np, int &cycle, int ny_local, int Do
                      z_layer_bottom, cellData, id, layernumber, np, nx, ny, GrainUnitVector, print, NGrainOrientations,
                      nz_layer, nz, deltax, XMin, YMin, ZMin);
 }
+
+//*****************************************************************************/
+// Prints intermediate code output to stdout and checks to see the single grain simulation end condition (the grain has
+// reached a domain edge) has been satisfied
+void IntermediateOutputAndCheck_SingleGrain(int id, int cycle, int ny_local, int y_offset, int DomainSize, int nx,
+                                            int ny, int nz, int &XSwitch, ViewI CellType_AllLayers) {
+
+    unsigned long int LocalLiquidCells, LocalActiveCells, LocalSolidCells;
+    ViewB2D EdgesReached(Kokkos::ViewAllocateWithoutInitializing("EdgesReached"), 3, 2); // init to false
+    Kokkos::deep_copy(EdgesReached, false);
+
+    Kokkos::parallel_reduce(
+        DomainSize,
+        KOKKOS_LAMBDA(const int &index, unsigned long int &sum_liquid, unsigned long int &sum_active,
+                      unsigned long int &sum_solid) {
+            if (CellType_AllLayers(index) == Liquid)
+                sum_liquid += 1;
+            else if (CellType_AllLayers(index) == Active) {
+                sum_active += 1;
+                // Did this cell reach a domain edge?
+                int coord_x = getCoordX(index, nx, ny_local);
+                int coord_y = getCoordY(index, nx, ny_local);
+                int coord_z = getCoordZ(index, nx, ny_local);
+                int coord_y_global = coord_y + y_offset;
+                if (coord_x == 0)
+                    EdgesReached(0, 0) = true;
+                if (coord_x == nx - 1)
+                    EdgesReached(0, 1) = true;
+                if (coord_y_global == 0)
+                    EdgesReached(1, 0) = true;
+                if (coord_y_global == ny - 1)
+                    EdgesReached(1, 1) = true;
+                if (coord_z == 0)
+                    EdgesReached(2, 0) = true;
+                if (coord_z == nz - 1)
+                    EdgesReached(2, 1) = true;
+            }
+            else if (CellType_AllLayers(index) == Solid)
+                sum_solid += 1;
+        },
+        LocalLiquidCells, LocalActiveCells, LocalSolidCells);
+
+    unsigned long int GlobalLiquidCells, GlobalActiveCells, GlobalSolidCells;
+    MPI_Reduce(&LocalLiquidCells, &GlobalLiquidCells, 1, MPI_UNSIGNED_LONG, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&LocalActiveCells, &GlobalActiveCells, 1, MPI_UNSIGNED_LONG, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&LocalSolidCells, &GlobalSolidCells, 1, MPI_UNSIGNED_LONG, MPI_SUM, 0, MPI_COMM_WORLD);
+    if (id == 0)
+        std::cout << "cycle = " << cycle << " : Liquid cells = " << GlobalLiquidCells
+                  << " Active cells = " << GlobalActiveCells << " Solid cells = " << GlobalSolidCells << std::endl;
+
+    // Each rank checks to see if a global domain boundary was reached
+    ViewB2D_H EdgesReached_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), EdgesReached);
+    int XSwitchLocal = 0;
+    std::vector<std::string> EdgeDims = {"X", "Y", "Z"};
+    std::vector<std::string> EdgeNames = {"Lower", "Upper"};
+    for (int edgedim = 0; edgedim < 3; edgedim++) {
+        for (int edgename = 0; edgename < 2; edgename++) {
+            if (EdgesReached_Host(edgedim, edgename)) {
+                std::cout << EdgeNames[edgename] << " edge of domain in the " << EdgeDims[edgedim]
+                          << " direction was reached on rank " << id << " and cycle " << cycle
+                          << "; simulation is complete" << std::endl;
+                XSwitchLocal = 1;
+            }
+        }
+    }
+    // Simulation ends if a global domain boundary was reached on any rank
+    MPI_Allreduce(&XSwitchLocal, &XSwitch, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+}

--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -40,5 +40,7 @@ void IntermediateOutputAndCheck(int id, int np, int &cycle, int ny_local, int Do
                                 int SuccessfulNucEvents_ThisRank, int &XSwitch, CellData<device_memory_space> &cellData,
                                 Temperature<device_memory_space> &temperature, std::string SimulationType,
                                 int layernumber, int NGrainOrientations, ViewF GrainUnitVector, Print print);
+void IntermediateOutputAndCheck_SingleGrain(int id, int cycle, int ny_local, int y_offset, int DomainSize, int nx,
+                                            int ny, int nz, int &XSwitch, ViewI CellType_AllLayers);
 
 #endif

--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -40,7 +40,7 @@ void IntermediateOutputAndCheck(int id, int np, int &cycle, int ny_local, int Do
                                 int SuccessfulNucEvents_ThisRank, int &XSwitch, CellData<device_memory_space> &cellData,
                                 Temperature<device_memory_space> &temperature, std::string SimulationType,
                                 int layernumber, int NGrainOrientations, ViewF GrainUnitVector, Print print);
-void IntermediateOutputAndCheck_SingleGrain(int id, int cycle, int ny_local, int y_offset, int DomainSize, int nx,
-                                            int ny, int nz, int &XSwitch, ViewI CellType_AllLayers);
+void IntermediateOutputAndCheck(int id, int cycle, int ny_local, int y_offset, int DomainSize, int nx, int ny, int nz,
+                                int &XSwitch, ViewI CellType_AllLayers);
 
 #endif

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -271,8 +271,8 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                                            GrainUnitVector, print);
             }
             else if (SimulationType == "SingleGrain") {
-                IntermediateOutputAndCheck_SingleGrain(id, cycle, ny_local, y_offset, DomainSize, nx, ny, nz, XSwitch,
-                                                       cellData.CellType_AllLayers);
+                IntermediateOutputAndCheck(id, cycle, ny_local, y_offset, DomainSize, nx, ny, nz, XSwitch,
+                                           cellData.CellType_AllLayers);
             }
 
         } while (XSwitch == 0);

--- a/unit_test/tstCellData.hpp
+++ b/unit_test/tstCellData.hpp
@@ -27,6 +27,7 @@ namespace Test {
 void testCellDataInit_SingleGrain() {
 
     using memory_space = TEST_MEMSPACE;
+    using view_float = Kokkos::View<float *, memory_space>;
 
     int id, np;
     // Get number of processes
@@ -61,13 +62,13 @@ void testCellDataInit_SingleGrain() {
     CellData<memory_space> cellData(DomainSize, DomainSize, nx, ny_local, 0);
 
     // Orientation data - init to dummy values
-    ViewF GrainUnitVector(Kokkos::ViewAllocateWithoutInitializing("GrainUnitVector"), 9);
+    view_float GrainUnitVector(Kokkos::ViewAllocateWithoutInitializing("GrainUnitVector"), 9);
     Kokkos::deep_copy(GrainUnitVector, 1.0 / sqrt(3.0));
 
     // Cells for octahedron data
-    ViewF DiagonalLength(Kokkos::ViewAllocateWithoutInitializing("DiagonalLength"), DomainSize);
-    ViewF DOCenter(Kokkos::ViewAllocateWithoutInitializing("DOCenter"), 3 * DomainSize);
-    ViewF CritDiagonalLength(Kokkos::ViewAllocateWithoutInitializing("CritDiagonalLength"), 26 * DomainSize);
+    view_float DiagonalLength(Kokkos::ViewAllocateWithoutInitializing("DiagonalLength"), DomainSize);
+    view_float DOCenter(Kokkos::ViewAllocateWithoutInitializing("DOCenter"), 3 * DomainSize);
+    view_float CritDiagonalLength(Kokkos::ViewAllocateWithoutInitializing("CritDiagonalLength"), 26 * DomainSize);
 
     // Init grain
     cellData.init_substrate(id, singleGrainOrientation, nx, ny, nz, ny_local, y_offset, DomainSize, NeighborX,
@@ -75,8 +76,8 @@ void testCellDataInit_SingleGrain() {
 
     // Copy cell type and grain ID back to host to check if the values match - only 1 cell should've been assigned type
     // active and GrainID = 1 (though it may be duplicated in the ghost nodes of other ranks)
-    ViewI_H GrainID_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), cellData.GrainID_AllLayers);
-    ViewI_H CellType_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), cellData.CellType_AllLayers);
+    auto GrainID_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), cellData.GrainID_AllLayers);
+    auto CellType_Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), cellData.CellType_AllLayers);
     for (int coord_z = 0; coord_z < nz; coord_z++) {
         for (int coord_x = 0; coord_x < nx; coord_x++) {
             for (int coord_y = 0; coord_y < ny_local; coord_y++) {

--- a/unit_test/tstInitializeMPI.hpp
+++ b/unit_test/tstInitializeMPI.hpp
@@ -124,10 +124,11 @@ void testInputReadFromFile(int PrintVersion) {
 
     // Read and parse each input file
     for (auto FileName : InputFilenames) {
-        int TempFilesInSeries, NumberOfLayers, LayerHeight, nx, ny, nz, NSpotsX, NSpotsY, SpotOffset, SpotRadius;
+        int TempFilesInSeries, NumberOfLayers, LayerHeight, nx, ny, nz, NSpotsX, NSpotsY, SpotOffset, SpotRadius,
+            singleGrainOrientation;
         float SubstrateGrainSpacing;
         double deltax, NMax, dTN, dTsigma, HT_deltax, deltat, G, R, FractSurfaceSitesActive, RNGSeed,
-            PowderActiveFraction;
+            PowderActiveFraction, initUndercooling;
         bool BaseplateThroughPowder, LayerwiseTempRead, UseSubstrateFile, PowderFirstLayer;
         std::string SimulationType, GrainOrientationFile, temppath, tempfile, SubstrateFileName, MaterialFileName;
         std::vector<std::string> temp_paths;
@@ -138,7 +139,8 @@ void testInputReadFromFile(int PrintVersion) {
                           TempFilesInSeries, temp_paths, HT_deltax, deltat, NumberOfLayers, LayerHeight,
                           MaterialFileName, SubstrateFileName, SubstrateGrainSpacing, UseSubstrateFile, G, R, nx, ny,
                           nz, FractSurfaceSitesActive, NSpotsX, NSpotsY, SpotOffset, SpotRadius, RNGSeed,
-                          BaseplateThroughPowder, PowderActiveFraction, LayerwiseTempRead, PowderFirstLayer, print);
+                          BaseplateThroughPowder, PowderActiveFraction, LayerwiseTempRead, PowderFirstLayer, print,
+                          initUndercooling, singleGrainOrientation);
         InterfacialResponseFunction irf(0, MaterialFileName, deltat, deltax);
         MPI_Barrier(MPI_COMM_WORLD);
 
@@ -163,6 +165,7 @@ void testInputReadFromFile(int PrintVersion) {
             EXPECT_FALSE(print.PrintIdleTimeSeriesFrames);
             EXPECT_DOUBLE_EQ(G, 500000.0);
             EXPECT_DOUBLE_EQ(R, 300000.0);
+            EXPECT_DOUBLE_EQ(initUndercooling, 0.0);
             // compare with float to avoid floating point error with irrational number
             float deltat_comp = static_cast<float>(deltat);
             EXPECT_FLOAT_EQ(deltat_comp, pow(10, -6) / 15.0);


### PR DESCRIPTION
The temperature initialization routine was repurposed to allow initialization of both the single grain problem and the directional solidification problem, as both have unidirectional thermal gradients and cooling rates in initially liquid domains. The single grain problem is also unique in the fact that it does not continue until the active layer or the simulation domain has fully solidified, but stops when the grain reaches a simulation edge - this is accounted for in a new `IntermediateOutputAndCheck` routine that is called each time step
Also includes new unit tests for the new substrate init routine, the modified temperature init routine, and the new intermediate output and check routine

Replaces #206 which was out of date