### PR TITLE
Reorganized init and update for directional/equiaxed problems

### DIFF
--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -17,8 +17,8 @@
 #include <string>
 
 void FillSteeringVector_NoRemelt(int cycle, int DomainSize, Temperature<device_memory_space> &temperature,
-                                 CellData<device_memory_space> &cellData, int layernumber, ViewI SteeringVector,
-                                 ViewI numSteer, ViewI_H numSteer_Host);
+                                 CellData<device_memory_space> &cellData, ViewI SteeringVector, ViewI numSteer,
+                                 ViewI_H numSteer_Host);
 void FillSteeringVector_Remelt(int cycle, int DomainSize, int nx, int ny_local, NList NeighborX, NList NeighborY,
                                NList NeighborZ, Temperature<device_memory_space> &temperature,
                                CellData<device_memory_space> &cellData, int nz_layer, ViewI SteeringVector,

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -148,12 +148,9 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     // Initialize cell types, grain IDs, and layer IDs
     CellData<device_memory_space> cellData(DomainSize_AllLayers, DomainSize, nx, ny_local, z_layer_bottom);
     if (SimulationType == "C")
-        cellData.init_substrate(id, FractSurfaceSitesActive, ny_local, nx, ny, y_offset, NeighborX, NeighborY,
-                                NeighborZ, GrainUnitVector, NGrainOrientations, DiagonalLength, DOCenter,
-                                CritDiagonalLength, RNGSeed);
+        cellData.init_substrate(id, FractSurfaceSitesActive, ny_local, nx, ny, y_offset, RNGSeed);
     else if (SimulationType == "SingleGrain")
-        cellData.init_substrate(id, singleGrainOrientation, nx, ny, nz, ny_local, y_offset, DomainSize, NeighborX,
-                                NeighborY, NeighborZ, GrainUnitVector, DiagonalLength, DOCenter, CritDiagonalLength);
+        cellData.init_substrate(id, singleGrainOrientation, nx, ny, nz, ny_local, y_offset, DomainSize);
     else
         cellData.init_substrate(SubstrateFileName, UseSubstrateFile, BaseplateThroughPowder, PowderFirstLayer, nx, ny,
                                 nz, LayerHeight, DomainSize, ZMaxLayer, ZMin, deltax, ny_local, y_offset,
@@ -225,12 +222,12 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
             // FillSteeringVector_NoRemelt (a simplified version of FillSteeringVector_Remelt
             StartCreateSVTime = MPI_Wtime();
 
-            if (SimulationType != "C")
+            if ((SimulationType == "C") || (SimulationType == "SingleGrain"))
+                FillSteeringVector_NoRemelt(cycle, DomainSize, temperature, cellData, SteeringVector, numSteer,
+                                            numSteer_Host);
+            else
                 FillSteeringVector_Remelt(cycle, DomainSize, nx, ny_local, NeighborX, NeighborY, NeighborZ, temperature,
                                           cellData, nz_layer, SteeringVector, numSteer, numSteer_Host);
-            else
-                FillSteeringVector_NoRemelt(cycle, DomainSize, temperature, cellData, layernumber, SteeringVector,
-                                            numSteer, numSteer_Host);
             CreateSVTime += MPI_Wtime() - StartCreateSVTime;
 
             StartCaptureTime = MPI_Wtime();

--- a/unit_test/tstUpdateMPI.hpp
+++ b/unit_test/tstUpdateMPI.hpp
@@ -599,7 +599,7 @@ void testSmallEquiaxedGrain() {
     std::ifstream LogDataStream(LogFile);
     nlohmann::json logdata = nlohmann::json::parse(LogDataStream);
     int TimeStepOfOutput = logdata["TimeStepOfOutput"];
-    EXPECT_EQ(TimeStepOfOutput, 4819);
+    EXPECT_EQ(TimeStepOfOutput, 4820);
 }
 //---------------------------------------------------------------------------//
 // RUN TESTS


### PR DESCRIPTION
Updated problem types C (directional solidification) and SingleGrain to separate initialization routines from cell activation/update routines. These routines now initialize the grains as "future active" cells rather than "active", and these future active cells are handled in `CellCapture` as "grains that were activated on the first time step", rather than "grains that already existed and had active cell structures before the simulation started" (which seems more physically realistic and is in line with the other problem types). Minor changes to `FillSteeringVector_NoRemelt`, which is now used by both of these problem types.

This change has a negligible effect on the results of these problems, other than making them 1 time step longer (since cell activation is on time step 1, not time step 0).