### PR TITLE
Correct behavior of getMeltTimeStep

### DIFF
--- a/src/CAupdate.cpp
+++ b/src/CAupdate.cpp
@@ -58,7 +58,7 @@ void FillSteeringVector_Remelt(int cycle, int DomainSize, int nx, int ny_local, 
             int cellType = CellType(index);
             // Only iterate over cells that are not Solid type
             if (cellType != Solid) {
-                int MeltTimeStep = temperature.getMeltTimeStep(index);
+                int MeltTimeStep = temperature.getMeltTimeStep(cycle, index);
                 int CritTimeStep = temperature.getCritTimeStep(index);
                 bool atMeltTime = (cycle == MeltTimeStep);
                 bool atCritTime = (cycle == CritTimeStep);


### PR DESCRIPTION
Previously, the function `getMeltTimeStep` always returned the time step at which the cell melts corresponding to the current melt-solidification cycle. If said time step was already exceeded, `getMeltTimeStep` now returns the time step associated with the next melting event in the cell, letting a cell remelt even if its solidification was not yet complete. INT_MAX is returned if the cell does notmelt again in the layer.

Fixup of #223, which accidentally removed the bug fix made in #205.