### PR TITLE
Use input baseplate top location to set powder layer start

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -98,12 +98,12 @@ The .json files in the examples subdirectory are provided on the command line to
 |FractionSurfaceSitesActive | C           | What fraction of cells at the bottom surface of the domain are the source of a grain?
 |MeanSize      | S, R                     | Mean spacing between grain centers in the baseplate/substrate (in microns) (see note (a))
 |SubstrateFilename |  S, R                | Path to and filename for substrate data (see note (a))
-|PowderDensity | S, R                     | Density of sites in the powder layer to be assigned as the home of a unique grain, normalized by 1 x 10^12 m^-3 (default value is 1/(CA cell size ^3) (see note (b))
-|ExtendSubstrateThroughPower| S, R        | true/false value: Whether to use the baseplate microstructure as the boundary condition for the entire height of the simulation (defaults to false) (see note (b))
+|PowderDensity | S, R                     | Density of sites in the powder layer to be assigned as the home of a unique grain, normalized by 1 x 10^12 m^-3 (default value is 1/(CA cell size ^3) (see note (a))
+|ExtendSubstrateThroughPowder| S, R        | true/false value: Whether to use the baseplate microstructure as the boundary condition for the entire height of the simulation (defaults to false) (see note (a))
+| BaseplateTopZ   | S, R                  | The Z coordinate that marks the top of the baseplate/boundary of the baseplate with the powder. If not given, Z = 0 microns will be assumed to be the baseplate top if ExtendSubstrateThroughPowder = false (If ExtendSubstrateThroughPowder = true, the entire domain will be initialized with the baseplate grain structure)
 |GrainOrientation | SingleGrain           | Which orientation from the orientation's file is assigned to the grain (starts at 0). Default is 0 
 
 (a) One of these inputs must be provided, but not both
-(b) This is optional, but if this is given, "extendSubstrateThroughPower" must be set to false
 
 ## Printing inputs
 | Input        | Relevant problem type(s))| Details |

--- a/src/CAinitialize.cpp
+++ b/src/CAinitialize.cpp
@@ -32,7 +32,7 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
                        float &SubstrateGrainSpacing, bool &UseSubstrateFile, double &G, double &R, int &nx, int &ny,
                        int &nz, double &FractSurfaceSitesActive, int &NSpotsX, int &NSpotsY, int &SpotOffset,
                        int &SpotRadius, double &RNGSeed, bool &BaseplateThroughPowder, double &PowderActiveFraction,
-                       bool &LayerwiseTempRead, bool &PowderFirstLayer, Print &print, double &initUndercooling,
+                       bool &LayerwiseTempRead, double &BaseplateTopZ, Print &print, double &initUndercooling,
                        int &singleGrainOrientation) {
 
     std::ifstream InputData(InputFile);
@@ -201,16 +201,18 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
         }
         else
             PowderActiveFraction = 1.0; // defaults to a unique grain at each site in the powder layers
-        // Should a powder layer be initialized at the top of the baseplate for the first layer? (Defaults to false,
-        // where the baseplate spans all of layer 0, and only starting with layer 1 is a powder layer present)
-        if (inputdata["Substrate"].contains("PowderFirstLayer"))
-            PowderFirstLayer = inputdata["Substrate"]["PowderFirstLayer"];
+        if ((inputdata["Substrate"].contains("PowderFirstLayer")) && (id == 0))
+            std::cout << "Warning: PowderFirstLayer input is no longer used, the top of the first layer must be "
+                         "specified using BaseplateTopZ (which will otherwise default to Z = 0)"
+                      << std::endl;
+        // The top of the baseplate is designated using BaseplateTopZ (assumed to be Z = 0 if not given in input file)
+        if (inputdata["Substrate"].contains("BaseplateTopZ"))
+            BaseplateTopZ = inputdata["Substrate"]["BaseplateTopZ"];
         else
-            PowderFirstLayer = false;
-        if ((BaseplateThroughPowder) && ((PowderFirstLayer) || (inputdata["Substrate"].contains("PowderDensity"))))
-            throw std::runtime_error(
-                "Error: if the option to extend the baseplate through the powder layers is toggled, options regarding "
-                "the powder layer (PowderFirstLayer/PowderDensity cannot be given");
+            BaseplateTopZ = 0.0;
+        if ((BaseplateThroughPowder) && (inputdata["Substrate"].contains("PowderDensity")))
+            throw std::runtime_error("Error: if the option to extend the baseplate through the powder layers is "
+                                     "toggled, a powder layer density cannot be given");
     }
 
     // Printing inputs:

--- a/src/CAinitialize.hpp
+++ b/src/CAinitialize.hpp
@@ -22,7 +22,7 @@ void InputReadFromFile(int id, std::string InputFile, std::string &SimulationTyp
                        float &SubstrateGrainSpacing, bool &UseSubstrateFile, double &G, double &R, int &nx, int &ny,
                        int &nz, double &FractSurfaceSitesActive, int &NSpotsX, int &NSpotsY, int &SpotOffset,
                        int &SpotRadius, double &RNGSeed, bool &BaseplateThroughPowder, double &PowderActiveFraction,
-                       bool &LayerwiseTempRead, bool &PowderFirstLayer, Print &print, double &InitUndercooling,
+                       bool &LayerwiseTempRead, double &BaseplateTopZ, Print &print, double &InitUndercooling,
                        int &SingleGrainOrientation);
 void checkPowderOverflow(int nx, int ny, int LayerHeight, int NumberOfLayers, bool BaseplateThroughPowder,
                          double PowderDensity);

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -26,10 +26,10 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
 
     int nx, ny, nz, NumberOfLayers, LayerHeight, TempFilesInSeries;
     int NSpotsX, NSpotsY, SpotOffset, SpotRadius, HTtoCAratio, singleGrainOrientation;
-    bool UseSubstrateFile, BaseplateThroughPowder, LayerwiseTempRead, PowderFirstLayer;
+    bool UseSubstrateFile, BaseplateThroughPowder, LayerwiseTempRead;
     float SubstrateGrainSpacing;
     double HT_deltax, deltax, deltat, FractSurfaceSitesActive, G, R, NMax, dTN, dTsigma, RNGSeed, PowderActiveFraction,
-        initUndercooling;
+        initUndercooling, BaseplateTopZ;
     std::string SubstrateFileName, MaterialFileName, SimulationType, GrainOrientationFile;
     std::vector<std::string> temp_paths;
 
@@ -41,7 +41,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                       TempFilesInSeries, temp_paths, HT_deltax, deltat, NumberOfLayers, LayerHeight, MaterialFileName,
                       SubstrateFileName, SubstrateGrainSpacing, UseSubstrateFile, G, R, nx, ny, nz,
                       FractSurfaceSitesActive, NSpotsX, NSpotsY, SpotOffset, SpotRadius, RNGSeed,
-                      BaseplateThroughPowder, PowderActiveFraction, LayerwiseTempRead, PowderFirstLayer, print,
+                      BaseplateThroughPowder, PowderActiveFraction, LayerwiseTempRead, BaseplateTopZ, print,
                       initUndercooling, singleGrainOrientation);
     InterfacialResponseFunction irf(id, MaterialFileName, deltat, deltax);
 
@@ -152,10 +152,10 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     else if (SimulationType == "SingleGrain")
         cellData.init_substrate(id, singleGrainOrientation, nx, ny, nz, ny_local, y_offset, DomainSize);
     else
-        cellData.init_substrate(SubstrateFileName, UseSubstrateFile, BaseplateThroughPowder, PowderFirstLayer, nx, ny,
-                                nz, LayerHeight, DomainSize, ZMaxLayer, ZMin, deltax, ny_local, y_offset,
-                                z_layer_bottom, id, RNGSeed, SubstrateGrainSpacing, PowderActiveFraction,
-                                temperature.NumberOfSolidificationEvents);
+        cellData.init_substrate(SubstrateFileName, UseSubstrateFile, BaseplateThroughPowder, nx, ny, nz, DomainSize,
+                                ZMaxLayer, ZMin, deltax, ny_local, y_offset, z_layer_bottom, id, RNGSeed,
+                                SubstrateGrainSpacing, PowderActiveFraction, temperature.NumberOfSolidificationEvents,
+                                BaseplateTopZ);
     MPI_Barrier(MPI_COMM_WORLD);
     if (id == 0)
         std::cout << "Grain struct initialized" << std::endl;
@@ -313,9 +313,9 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
             MPI_Barrier(MPI_COMM_WORLD);
 
             // Sets up views, powder layer (if necessary), and cell types for the next layer of a multilayer problem
-            cellData.init_next_layer(layernumber + 1, id, nx, ny, ny_local, y_offset, z_layer_bottom, LayerHeight,
-                                     DomainSize, UseSubstrateFile, BaseplateThroughPowder, ZMin, ZMaxLayer, deltax,
-                                     RNGSeed, PowderActiveFraction, temperature.NumberOfSolidificationEvents);
+            cellData.init_next_layer(layernumber + 1, id, nx, ny, ny_local, y_offset, z_layer_bottom, DomainSize,
+                                     BaseplateThroughPowder, ZMin, ZMaxLayer, deltax, RNGSeed, PowderActiveFraction,
+                                     temperature.NumberOfSolidificationEvents);
 
             // Initialize potential nucleation event data for next layer "layernumber + 1"
             // Views containing nucleation data will be resized to the possible number of nuclei on a given MPI rank for

--- a/unit_test/tstInitializeMPI.hpp
+++ b/unit_test/tstInitializeMPI.hpp
@@ -52,7 +52,7 @@ void WriteTestData(std::string InputFilename, int PrintVersion) {
     TestDataFile << "   \"Substrate\": {" << std::endl;
     TestDataFile << "      \"SubstrateFilename\": \"DummySubstrate.txt\"," << std::endl;
     TestDataFile << "      \"PowderDensity\": 1000," << std::endl;
-    TestDataFile << "      \"PowderFirstLayer\": true" << std::endl;
+    TestDataFile << "      \"BaseplateTopZ\": -0.00625" << std::endl;
     TestDataFile << "   }," << std::endl;
     TestDataFile << "   \"Printing\": {" << std::endl;
     TestDataFile << "      \"PathToOutput\": \"ExaCA\"," << std::endl;
@@ -128,8 +128,8 @@ void testInputReadFromFile(int PrintVersion) {
             singleGrainOrientation;
         float SubstrateGrainSpacing;
         double deltax, NMax, dTN, dTsigma, HT_deltax, deltat, G, R, FractSurfaceSitesActive, RNGSeed,
-            PowderActiveFraction, initUndercooling;
-        bool BaseplateThroughPowder, LayerwiseTempRead, UseSubstrateFile, PowderFirstLayer;
+            PowderActiveFraction, initUndercooling, BaseplateTopZ;
+        bool BaseplateThroughPowder, LayerwiseTempRead, UseSubstrateFile;
         std::string SimulationType, GrainOrientationFile, temppath, tempfile, SubstrateFileName, MaterialFileName;
         std::vector<std::string> temp_paths;
         std::cout << "Reading " << FileName << std::endl;
@@ -139,7 +139,7 @@ void testInputReadFromFile(int PrintVersion) {
                           TempFilesInSeries, temp_paths, HT_deltax, deltat, NumberOfLayers, LayerHeight,
                           MaterialFileName, SubstrateFileName, SubstrateGrainSpacing, UseSubstrateFile, G, R, nx, ny,
                           nz, FractSurfaceSitesActive, NSpotsX, NSpotsY, SpotOffset, SpotRadius, RNGSeed,
-                          BaseplateThroughPowder, PowderActiveFraction, LayerwiseTempRead, PowderFirstLayer, print,
+                          BaseplateThroughPowder, PowderActiveFraction, LayerwiseTempRead, BaseplateTopZ, print,
                           initUndercooling, singleGrainOrientation);
         InterfacialResponseFunction irf(0, MaterialFileName, deltat, deltax);
         MPI_Barrier(MPI_COMM_WORLD);
@@ -207,8 +207,8 @@ void testInputReadFromFile(int PrintVersion) {
             EXPECT_EQ(LayerHeight, 20);
             EXPECT_FALSE(UseSubstrateFile);
             EXPECT_FALSE(BaseplateThroughPowder);
-            // Option defaults to false
-            EXPECT_FALSE(PowderFirstLayer);
+            // Option defaults to 0.0
+            EXPECT_DOUBLE_EQ(BaseplateTopZ, 0.0);
             EXPECT_FLOAT_EQ(SubstrateGrainSpacing, 25.0);
             EXPECT_TRUE(print.BaseFileName == "TestProblemSpot");
             EXPECT_TRUE(print.PrintInitCritTimeStep);
@@ -234,7 +234,8 @@ void testInputReadFromFile(int PrintVersion) {
             EXPECT_TRUE(UseSubstrateFile);
             EXPECT_FALSE(LayerwiseTempRead);
             EXPECT_DOUBLE_EQ(PowderActiveFraction, 0.001);
-            EXPECT_TRUE(PowderFirstLayer);
+            // -0.00625 was input
+            EXPECT_DOUBLE_EQ(BaseplateTopZ, -0.00625);
             EXPECT_DOUBLE_EQ(HT_deltax, deltax);
             EXPECT_TRUE(print.BaseFileName == "Test");
             EXPECT_TRUE(temp_paths[0] == ".//1DummyTemperature.txt");


### PR DESCRIPTION
The current code fails to correctly initialize a powder layer in the case where `LayerHeight` = 0 for simulations using externally generated temperature data (where the layer offset is built into the temperature data itself). The new code uses a new input, `BaseplateTopZ`, to explicitly state where the baseplate ends and the powder layer(s) begin. If the new input is not given, a value of Z = 0 µm is assumed (which has been used for the example problems and most other problems to date). By specifying a baseplate top value, the different between the top of the temperature data for layer `n` and layer `n+1` can be correctly used to place the powder for layer `n+1`

Addresses #229 