### PR TITLE
Ability to read temperature data with additional columns

### DIFF
--- a/src/CAparsefiles.cpp
+++ b/src/CAparsefiles.cpp
@@ -91,7 +91,7 @@ void splitString(std::string line, std::vector<std::string> &parsed_line, std::s
 std::size_t checkForHeaderValues(std::string header_line) {
 
     // Header values from file - number of commas plus one is the size of the header
-    size_t header_size = std::count(header_line.begin(), header_line.end(), ',') + 1;
+    std::size_t header_size = std::count(header_line.begin(), header_line.end(), ',') + 1;
     std::vector<std::string> header_values(header_size, "");
     splitString(header_line, header_values, header_size);
 

--- a/src/CAparsefiles.cpp
+++ b/src/CAparsefiles.cpp
@@ -67,9 +67,10 @@ double getInputDouble(std::string val_input, int factor) {
 // Given a string ("line"), parse at "separator" (commas used by default)
 // Modifies "parsed_line" to hold the separated values
 // expected_num_values may be larger than parsed_line_size, if only a portion of the line is being parsed
-void splitString(std::string line, std::vector<std::string> &parsed_line, int expected_num_values, char separator) {
+void splitString(std::string line, std::vector<std::string> &parsed_line, std::size_t expected_num_values,
+                 char separator) {
     // Make sure the right number of values are present on the line - one more than the number of separators
-    int actual_num_values = std::count(line.begin(), line.end(), separator) + 1;
+    std::size_t actual_num_values = std::count(line.begin(), line.end(), separator) + 1;
     if (expected_num_values != actual_num_values) {
         std::string error = "Error: Expected " + std::to_string(expected_num_values) +
                             " values while reading file; but " + std::to_string(actual_num_values) + " were found";
@@ -87,10 +88,10 @@ void splitString(std::string line, std::vector<std::string> &parsed_line, int ex
 
 // Check to make sure that the 6 expected column names appear in the correct order in the header for this temperature
 // file Return the number of columns present - ignore any columns after the 6 of interest
-int checkForHeaderValues(std::string header_line) {
+std::size_t checkForHeaderValues(std::string header_line) {
 
     // Header values from file - number of commas plus one is the size of the header
-    size_t header_size = static_cast<size_t>(std::count(header_line.begin(), header_line.end(), ',') + 1);
+    size_t header_size = std::count(header_line.begin(), header_line.end(), ',') + 1;
     std::vector<std::string> header_values(header_size, "");
     splitString(header_line, header_values, header_size);
 
@@ -113,7 +114,7 @@ int checkForHeaderValues(std::string header_line) {
                 throw std::runtime_error(ev + " not found in temperature file header");
         }
     }
-    return static_cast<int>(header_size);
+    return header_size;
 }
 
 bool checkFileExists(const std::string path, const int id, const bool error) {
@@ -188,7 +189,7 @@ std::array<double, 6> parseTemperatureCoordinateMinMax(std::string tempfile_this
     std::array<double, 6> XYZMinMax;
     std::ifstream TemperatureFilestream;
     TemperatureFilestream.open(tempfile_thislayer);
-    int vals_per_line;
+    std::size_t vals_per_line;
 
     // Binary temperature data should contain only the six columns of interest
     // Comma-separated double type values may contain additional columns after the 6 used by ExaCA

--- a/src/CAparsefiles.cpp
+++ b/src/CAparsefiles.cpp
@@ -85,21 +85,24 @@ void splitString(std::string line, std::vector<std::string> &parsed_line, int ex
     parsed_line[parsed_line_size - 1] = line;
 }
 
-// Check to make sure that all expected column names appear in the header for this temperature file
-void checkForHeaderValues(std::string header_line) {
+// Check to make sure that the 6 expected column names appear in the correct order in the header for this temperature
+// file Return the number of columns present - ignore any columns after the 6 of interest
+int checkForHeaderValues(std::string header_line) {
 
-    // Header values from file
-    std::size_t header_size = 6;
+    // Header values from file - number of commas plus one is the size of the header
+    size_t header_size = static_cast<size_t>(std::count(header_line.begin(), header_line.end(), ',') + 1);
     std::vector<std::string> header_values(header_size, "");
-    splitString(header_line, header_values, 6);
+    splitString(header_line, header_values, header_size);
 
     std::vector<std::vector<std::string>> expected_values = {{"x"}, {"y"}, {"z"}, {"tm"}, {"tl", "ts"}, {"r", "cr"}};
+    std::size_t num_expected_values = expected_values.size();
+    if (num_expected_values > header_size)
+        throw std::runtime_error("Error: Fewer values than expected found in temperature file header");
 
     // Case insensitive comparison
-    for (std::size_t n = 0; n < header_size; n++) {
+    for (std::size_t n = 0; n < num_expected_values; n++) {
         auto val = removeWhitespace(header_values[n]);
         std::transform(val.begin(), val.end(), val.begin(), ::tolower);
-
         // Check each header column label against the expected value(s) - throw error if no match
         std::size_t options_size = expected_values[n].size();
         for (std::size_t e = 0; e < options_size; e++) {
@@ -110,6 +113,7 @@ void checkForHeaderValues(std::string header_line) {
                 throw std::runtime_error(ev + " not found in temperature file header");
         }
     }
+    return static_cast<int>(header_size);
 }
 
 bool checkFileExists(const std::string path, const int id, const bool error) {
@@ -184,13 +188,18 @@ std::array<double, 6> parseTemperatureCoordinateMinMax(std::string tempfile_this
     std::array<double, 6> XYZMinMax;
     std::ifstream TemperatureFilestream;
     TemperatureFilestream.open(tempfile_thislayer);
+    int vals_per_line;
 
-    if (!(BinaryInputData)) {
+    // Binary temperature data should contain only the six columns of interest
+    // Comma-separated double type values may contain additional columns after the 6 used by ExaCA
+    if (BinaryInputData)
+        vals_per_line = 6;
+    else {
         // Read the header line data
         // Make sure the first line contains all required column names: x, y, z, tm, tl, cr
         std::string HeaderLine;
         getline(TemperatureFilestream, HeaderLine);
-        checkForHeaderValues(HeaderLine);
+        vals_per_line = checkForHeaderValues(HeaderLine);
     }
 
     // Units are assumed to be in meters, meters, seconds, seconds, and K/second
@@ -225,7 +234,7 @@ std::array<double, 6> parseTemperatureCoordinateMinMax(std::string tempfile_this
             std::string ReadLine;
             if (!getline(TemperatureFilestream, ReadLine))
                 break;
-            splitString(ReadLine, ParsedLine, 6);
+            splitString(ReadLine, ParsedLine, vals_per_line);
             // Only get x, y, and z values from ParsedLine
             XCoordinates[XYZPointCounter] = getInputDouble(ParsedLine[0]);
             YCoordinates[XYZPointCounter] = getInputDouble(ParsedLine[1]);

--- a/src/CAparsefiles.hpp
+++ b/src/CAparsefiles.hpp
@@ -22,7 +22,7 @@ float getInputFloat(std::string val_input, int factor = 0);
 double getInputDouble(std::string val_input, int factor = 0);
 void splitString(std::string line, std::vector<std::string> &parsed_line, int expected_num_values,
                  char separator = ',');
-void checkForHeaderValues(std::string header_line);
+int checkForHeaderValues(std::string header_line);
 bool checkFileExists(const std::string path, const int id, const bool error = true);
 std::string checkFileInstalled(const std::string name, const int id);
 void checkFileNotEmpty(std::string testfilename);
@@ -105,15 +105,17 @@ void parseTemperatureData(std::string tempfile_thislayer, double YMin, double de
         }
     }
     else {
-        std::string DummyLine;
-        // ignore header line
-        getline(TemperatureFilestream, DummyLine);
+        // Get number of columns in this temperature file
+        std::string HeaderLine;
+        getline(TemperatureFilestream, HeaderLine);
+        int vals_per_line = checkForHeaderValues(HeaderLine);
         while (!TemperatureFilestream.eof()) {
             std::vector<std::string> ParsedLine(6); // Each line has an x, y, z, tm, tl, cr
             std::string ReadLine;
             if (!getline(TemperatureFilestream, ReadLine))
                 break;
-            splitString(ReadLine, ParsedLine, 6);
+            // Only parse the first 6 columns of the temperature data
+            splitString(ReadLine, ParsedLine, vals_per_line);
             // Check the y value from ParsedLine, to check if this point is stored on this rank
             double YTemperaturePoint = getInputDouble(ParsedLine[1]);
             // Check the CA grid positions of the data point to see which rank(s) should store it

--- a/src/CAparsefiles.hpp
+++ b/src/CAparsefiles.hpp
@@ -20,9 +20,9 @@ bool getInputBool(std::string val_input);
 int getInputInt(std::string val_input);
 float getInputFloat(std::string val_input, int factor = 0);
 double getInputDouble(std::string val_input, int factor = 0);
-void splitString(std::string line, std::vector<std::string> &parsed_line, int expected_num_values,
+void splitString(std::string line, std::vector<std::string> &parsed_line, std::size_t expected_num_values,
                  char separator = ',');
-int checkForHeaderValues(std::string header_line);
+std::size_t checkForHeaderValues(std::string header_line);
 bool checkFileExists(const std::string path, const int id, const bool error = true);
 std::string checkFileInstalled(const std::string name, const int id);
 void checkFileNotEmpty(std::string testfilename);


### PR DESCRIPTION
This will allow ExaCA to read data created using finch with the extra Gx, Gy, Gz columns (or any other arbitrary extra columns), as long as the first 6 columns are the x, y, z, tm, tl, cr data required for simulation type R