### PR TITLE
Zero init for print counter

### DIFF
--- a/src/CAinputs.hpp
+++ b/src/CAinputs.hpp
@@ -94,9 +94,6 @@ struct PrintInputs {
     bool PrintIdleTimeSeriesFrames = false;
     // If printing the time series, the increment, in time steps, between printing of intermediate output
     int TimeSeriesInc = 1;
-    // If printing the time series, the counter for the number of intermediate files that have been printed for a
-    // given layer of a multilayer problem
-    int IntermediateFileCounter = 0;
 
     // Should binary be used for printing vtk data?
     bool PrintBinary = false;

--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -43,7 +43,7 @@ struct Print {
 
     // If printing the time series, the counter for the number of intermediate files that have been printed for a given
     // layer of a multilayer problem
-    int IntermediateFileCounter;
+    int IntermediateFileCounter = 0;
 
     // Message sizes and data offsets for data send/recieved to/from other ranks- message size different for different
     // ranks


### PR DESCRIPTION
`IntermediateFileCounter` was redundantly defined in `inputs` and `print`, and was not initialized to zero in the right place