### PR TITLE
Fixup baseplate top location for spot melt array problems

### DIFF
--- a/src/CAinputs.hpp
+++ b/src/CAinputs.hpp
@@ -286,6 +286,10 @@ struct Inputs {
             // file)
             if (inputdata["Substrate"].contains("BaseplateTopZ"))
                 substrate.BaseplateTopZ = inputdata["Substrate"]["BaseplateTopZ"];
+            else if (SimulationType == "S") {
+                // Baseplate top if not otherwise given for spot array problem is at the top of the first layer
+                substrate.BaseplateTopZ = domain.deltax * domain.SpotRadius;
+            }
             if ((substrate.BaseplateThroughPowder) && (inputdata["Substrate"].contains("PowderDensity")))
                 throw std::runtime_error("Error: if the option to extend the baseplate through the powder layers is "
                                          "toggled, a powder layer density cannot be given");

--- a/unit_test/tstInputs.hpp
+++ b/unit_test/tstInputs.hpp
@@ -187,8 +187,8 @@ void testInputs(int PrintVersion) {
             EXPECT_EQ(inputs.domain.LayerHeight, 20);
             EXPECT_FALSE(inputs.substrate.UseSubstrateFile);
             EXPECT_FALSE(inputs.substrate.BaseplateThroughPowder);
-            // Option defaults to 0.0
-            EXPECT_DOUBLE_EQ(inputs.substrate.BaseplateTopZ, 0.0);
+            // For spot melt array, this is the top of first layer
+            EXPECT_DOUBLE_EQ(inputs.substrate.BaseplateTopZ, inputs.domain.deltax * inputs.domain.SpotRadius);
             EXPECT_FLOAT_EQ(inputs.substrate.SubstrateGrainSpacing, 25.0);
             EXPECT_TRUE(inputs.print.BaseFileName == "TestProblemSpot");
             EXPECT_TRUE(inputs.print.PrintInitCritTimeStep);


### PR DESCRIPTION
Defaults to 0 for problem type R, but should not default to zero for problem type S