### PR TITLE
Store final undercooling for all cells in multilayer domain

### DIFF
--- a/examples/Inp_TwoLineTwoLayer.json
+++ b/examples/Inp_TwoLineTwoLayer.json
@@ -29,7 +29,7 @@
       "PrintBinary": false,
       "PrintExaConstitSize": 0,
       "PrintFieldsInit": [],
-      "PrintFieldsFinal": ["GrainID", "LayerID", "GrainMisorientation"],
+      "PrintFieldsFinal": ["GrainID", "LayerID", "GrainMisorientation", "UndercoolingCurrent"],
       "PrintIntermediateOutput": {
           "Frequency": 0,
           "PrintIdleFrames": false

--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -311,7 +311,7 @@ struct Print {
             }
             if (_inputs.PrintFinalUndercoolingCurrent) {
                 auto UndercoolingCurrent_WholeDomain =
-                    collectViewData(id, np, grid, grid.nz_layer, MPI_FLOAT, temperature.UndercoolingCurrent);
+                    collectViewData(id, np, grid, grid.nz_layer, MPI_FLOAT, temperature.UndercoolingCurrent_AllLayers);
                 printViewData(id, GrainplotF, grid, grid.nz_layer, "float", "UndercoolingFinal",
                               UndercoolingCurrent_WholeDomain);
             }

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -34,7 +34,7 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
         inputs.checkPowderOverflow(grid.nx, grid.ny, grid.layer_height, grid.number_of_layers);
 
     // Temperature fields characterized by data in this structure
-    Temperature<memory_space> temperature(grid.domain_size, grid.number_of_layers, inputs.temperature);
+    Temperature<memory_space> temperature(grid, inputs.temperature);
     // Read temperature data if necessary
     if (simulation_type == "R")
         temperature.readTemperatureData(id, grid, 0);
@@ -189,10 +189,9 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
                 temperature.initialize(layernumber + 1, id, grid, irf.FreezingRange, inputs.domain.deltat);
             }
 
-            // Reset initial undercooling/solidification event counter of all cells to zeros for the next layer,
-            // resizing the views to the number of cells associated with the next layer
-            temperature.reset_layer_events_undercooling(grid.domain_size);
-
+            // Reset solidification event counter of all cells to zeros for the next layer, resizing to number of cells
+            // associated with the next layer, and get the subview for undercooling
+            temperature.reset_layer_events_undercooling(grid);
             // Resize and zero all view data relating to the active region from the last layer, in preparation for the
             // next layer
             interface.init_next_layer(grid.domain_size);

--- a/unit_test/tstNucleation.hpp
+++ b/unit_test/tstNucleation.hpp
@@ -51,8 +51,10 @@ void testNucleiInit() {
     grid.ny = 2 * np;
     grid.ny_local = 2;
     grid.y_offset = 2 * id;
+    grid.nz = 6;
     grid.deltax = 1;
     grid.domain_size = grid.nx * grid.ny_local * grid.nz_layer;
+    grid.domain_size_all_layers = grid.nx * grid.ny_local * grid.nz;
     grid.bottom_of_current_layer = grid.get_bottom_of_current_layer();
     grid.top_of_current_layer = grid.get_top_of_current_layer();
     grid.layer_range = std::make_pair(grid.bottom_of_current_layer, grid.top_of_current_layer);
@@ -80,7 +82,7 @@ void testNucleiInit() {
     inputs.nucleation.NMax = 0.125;
 
     // Allocate temperature data structures
-    Temperature<memory_space> temperature(grid.domain_size, grid.number_of_layers, inputs.temperature, 1);
+    Temperature<memory_space> temperature(grid, inputs.temperature);
     // Resize LayerTimeTempHistory with the known max number of solidification events
     Kokkos::resize(temperature.LayerTimeTempHistory, grid.domain_size, MaxSolidificationEvents_Count, 3);
     // Initialize MaxSolidificationEvents to 3 for each layer. LayerTimeTempHistory and NumberOfSolidificationEvents are

--- a/unit_test/tstTemperature.hpp
+++ b/unit_test/tstTemperature.hpp
@@ -48,6 +48,8 @@ void testReadTemperatureData(int NumberOfLayers, bool LayerwiseTempRead, bool Te
     grid.ny = 12;
     grid.nz = 3;
     grid.domain_size = grid.nx * grid.ny * grid.nz;
+    grid.domain_size_all_layers = grid.domain_size;
+    grid.layer_range = std::make_pair(0, grid.domain_size);
     // Write fake OpenFOAM data - only rank 0. Temperature data should be of type double
     // Write two files, one or both of which should be read
     std::string TestTempFileName1 = "TestData1";
@@ -122,7 +124,7 @@ void testReadTemperatureData(int NumberOfLayers, bool LayerwiseTempRead, bool Te
     inputs.temperature.LayerwiseTempRead = LayerwiseTempRead;
 
     // Ensure that constructor correctly initialized the local values of inputs
-    Temperature<memory_space> temperature(grid.domain_size, NumberOfLayers, inputs.temperature);
+    Temperature<memory_space> temperature(grid, inputs.temperature);
     if (LayerwiseTempRead)
         EXPECT_TRUE(temperature._inputs.LayerwiseTempRead);
     else
@@ -192,6 +194,9 @@ void testInit_UnidirectionalGradient(std::string SimulationType, double G) {
     grid.ny_local = 5;
     grid.nz = 6; // (Front is at Z = 0 for directional growth, single grain seed at Z = 2 for singlegrain problem)
     grid.domain_size = grid.nx * grid.ny_local * grid.nz;
+    grid.domain_size_all_layers = grid.domain_size;
+    grid.number_of_layers = 1;
+    grid.layer_range = std::make_pair(0, grid.domain_size);
     int coord_z_Center = Kokkos::floorf(static_cast<float>(grid.nz) / 2.0);
 
     // default inputs struct - manually set non-default substrateInputs values
@@ -217,7 +222,7 @@ void testInit_UnidirectionalGradient(std::string SimulationType, double G) {
     double RNorm = inputs.temperature.R * deltat;
 
     // Temperature struct
-    Temperature<memory_space> temperature(grid.domain_size, 1, inputs.temperature);
+    Temperature<memory_space> temperature(grid, inputs.temperature);
     // Test constructor initialization of _inputs
     // These should've been initialized with default values
     EXPECT_FALSE(temperature._inputs.LayerwiseTempRead);


### PR DESCRIPTION
Previously, only the undercooling of cells in the final layer was stored. This uses a subview so that only the undercooling of cells in the current layer of a multilayer problem is used by the update routines, but the undercooling of cells from previous layers remains stored and can be printed at the end of the simulation.