### PR TITLE
Fixup view resize for layer time-temperature history

### DIFF
--- a/src/CAtemperature.hpp
+++ b/src/CAtemperature.hpp
@@ -454,7 +454,7 @@ struct Temperature {
         view_type_int_host MaxSolidificationEvents_Host =
             Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), MaxSolidificationEvents);
         calcMaxSolidificationEvents(id, layernumber, MaxSolidificationEvents_Host, StartRange, EndRange, grid);
-        int MaxNumSolidificationEvents = MaxSolidificationEvents_Host(0);
+        int MaxNumSolidificationEvents = MaxSolidificationEvents_Host(layernumber);
 
         // Resize LayerTimeTempHistory now that the max number of solidification events is known for this layer
         Kokkos::resize(LayerTimeTempHistory, grid.domain_size, MaxNumSolidificationEvents, 3);


### PR DESCRIPTION
Use layer-specific number of melt/solidification events when resizing this view - otherwise this may seg fault if layer "n" has more melt/solidification events than layer 0