### PR TITLE
Enable commandline args for unit tests

### DIFF
--- a/unit_test/unit_test_cmd_line.hpp
+++ b/unit_test/unit_test_cmd_line.hpp
@@ -1,0 +1,15 @@
+// Copyright 2021-2023 Lawrence Livermore National Security, LLC and other ExaCA Project Developers.
+// See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#ifndef EXACA_TEST_COMMANDLINE_HPP
+#define EXACA_TEST_COMMANDLINE_HPP
+
+#include <string>
+
+namespace ExaCAUnitTestingInput {
+extern std::string command_line_arg;
+}
+
+#endif

--- a/unit_test/unit_test_main.cpp
+++ b/unit_test/unit_test_main.cpp
@@ -9,11 +9,22 @@
 
 #include <mpi.h>
 
+#include <unit_test_cmd_line.hpp>
+
+std::string ExaCAUnitTestingInput::command_line_arg = "";
+
 int main(int argc, char *argv[]) {
     MPI_Init(&argc, &argv);
     Kokkos::initialize(argc, argv);
     ::testing::InitGoogleTest(&argc, argv);
+
+    // Only for input case with optional commandline input.
+    if (argc > 1)
+        ExaCAUnitTestingInput::command_line_arg = argv[1];
+
+    // Run.
     int return_val = RUN_ALL_TESTS();
+
     Kokkos::finalize();
     MPI_Finalize();
     return return_val;


### PR DESCRIPTION
Needed outside of using ctest directly. Not a fan of the global variable, but it works. Closes #67 