### PR TITLE
Combine initialize routines and fix init undercooling bug

### DIFF
--- a/src/CAinputs.hpp
+++ b/src/CAinputs.hpp
@@ -234,13 +234,13 @@ struct Inputs {
             // problem type C if not given, should be a positive number
             if (inputdata["TemperatureData"].contains("InitUndercooling"))
                 if (inputdata["TemperatureData"]["InitUndercooling"] < 0)
-                    throw std::runtime_error("Error: optional temperature data argument `InitUndercooling` should be "
+                    throw std::runtime_error("Error: optional temperature data argument InitUndercooling should be "
                                              "greater than or equal to zero");
             if (SimulationType == "SingleGrain")
                 temperature.initUndercooling = inputdata["TemperatureData"]["InitUndercooling"];
             else if ((SimulationType == "C") && (inputdata["TemperatureData"].contains("InitUndercooling")))
                 temperature.initUndercooling = inputdata["TemperatureData"]["InitUndercooling"];
-            if ((temperature.G > 0) && (temperature.R == 0)) {
+            if ((temperature.G > 0) && (fabs(temperature.R) < 0.000001)) {
                 // Throw error for edge case where the cooling rate is 0, but cells in the domain would be initialized
                 // above the liquidus temperature (i.e., cells that would never solidify)
                 int location_init_undercooling;

--- a/src/CAinputs.hpp
+++ b/src/CAinputs.hpp
@@ -240,7 +240,7 @@ struct Inputs {
                 temperature.initUndercooling = inputdata["TemperatureData"]["InitUndercooling"];
             else if ((SimulationType == "C") && (inputdata["TemperatureData"].contains("InitUndercooling")))
                 temperature.initUndercooling = inputdata["TemperatureData"]["InitUndercooling"];
-            if ((temperature.G > 0) && (fabs(temperature.R) < 0.000001)) {
+            if ((temperature.G > 0) && (Kokkos::fabs(temperature.R) < 0.000001)) {
                 // Throw error for edge case where the cooling rate is 0, but cells in the domain would be initialized
                 // above the liquidus temperature (i.e., cells that would never solidify)
                 int location_init_undercooling;

--- a/src/CAinputs.hpp
+++ b/src/CAinputs.hpp
@@ -231,11 +231,30 @@ struct Inputs {
             temperature.G = inputdata["TemperatureData"]["G"];
             temperature.R = inputdata["TemperatureData"]["R"];
             // Optional initial undercooling for problem type C (required for type SingleGrain). Defaults to 0 for
-            // problem type C if not given
+            // problem type C if not given, should be a positive number
+            if (inputdata["TemperatureData"].contains("InitUndercooling"))
+                if (inputdata["TemperatureData"]["InitUndercooling"] < 0)
+                    throw std::runtime_error("Error: optional temperature data argument `InitUndercooling` should be "
+                                             "greater than or equal to zero");
             if (SimulationType == "SingleGrain")
                 temperature.initUndercooling = inputdata["TemperatureData"]["InitUndercooling"];
             else if ((SimulationType == "C") && (inputdata["TemperatureData"].contains("InitUndercooling")))
                 temperature.initUndercooling = inputdata["TemperatureData"]["InitUndercooling"];
+            if ((temperature.G > 0) && (temperature.R == 0)) {
+                // Throw error for edge case where the cooling rate is 0, but cells in the domain would be initialized
+                // above the liquidus temperature (i.e., cells that would never solidify)
+                int location_init_undercooling;
+                if (SimulationType == "C")
+                    location_init_undercooling = 0;
+                else
+                    location_init_undercooling = Kokkos::floorf(static_cast<float>(domain.nz) / 2.0);
+                int location_liquidus_isotherm =
+                    location_init_undercooling +
+                    Kokkos::round(temperature.initUndercooling / (temperature.G * domain.deltax));
+                if ((temperature.R == 0) && (location_liquidus_isotherm <= domain.nz - 1))
+                    throw std::runtime_error("Error: Domain will not fully solidify based on the size in Z, initial "
+                                             "undercooling, thermal gradient, and cooling rate in the input file");
+            }
         }
 
         // Substrate inputs:

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -39,12 +39,8 @@ void RunProgram_Reduced(int id, int np, std::string InputFile) {
     if (simulation_type == "R")
         temperature.readTemperatureData(id, grid, 0);
     // Initialize the temperature fields for the simualtion type of interest
-    if ((simulation_type == "C") || (simulation_type == "SingleGrain")) {
-        if (inputs.temperature.G == 0)
-            temperature.initialize(id, grid, inputs.domain.deltat);
-        else
-            temperature.initialize(id, simulation_type, grid, inputs.domain.deltat);
-    }
+    if ((simulation_type == "C") || (simulation_type == "SingleGrain"))
+        temperature.initialize(id, simulation_type, grid, inputs.domain.deltat);
     else if (simulation_type == "S")
         temperature.initialize(id, grid, irf.FreezingRange, inputs);
     else if (simulation_type == "R")

--- a/unit_test/tstTemperature.hpp
+++ b/unit_test/tstTemperature.hpp
@@ -317,7 +317,7 @@ TEST(TEST_CATEGORY, temperature) {
     // problem and with/without an initial undercooling present at the initial solidification front
     testInit_UnidirectionalGradient("C", 1000000, 0);
     testInit_UnidirectionalGradient("C", 1000000, 2);
-    //    testInit_UnidirectionalGradient("SingleGrain", 0, 2);
-    //    testInit_UnidirectionalGradient("SingleGrain", 1000000, 2);
+    testInit_UnidirectionalGradient("SingleGrain", 0, 2);
+    testInit_UnidirectionalGradient("SingleGrain", 1000000, 2);
 }
 } // end namespace Test


### PR DESCRIPTION
- Added additional constraints on `G`, `R`, and `InitUndercooling` inputs for problem types `C` and `SingleGrain`
- Consolidated temperature initialize routines for cases with uniform cooling and `G` given as either zero or non-zero
- Fixed bug in initial undercooling field for problem type `C` when a non-zero value is given for `InitUndercooling`
- Updated temperature unit test and added `G` as a test input