### PR TITLE
Reorganized functions in CAparsefiles

### DIFF
--- a/analysis/src/GAutils.hpp
+++ b/analysis/src/GAutils.hpp
@@ -31,61 +31,6 @@ ReturnType DivideCast(FirstType Int1, SecondType Int2) {
     return static_cast<ReturnType>(Int1) / static_cast<ReturnType>(Int2);
 }
 
-// Reads portion of a paraview file and places data in the appropriate data structure
-// ASCII data at each Z value is separated by a newline
-template <typename read_view_type_3d_host>
-read_view_type_3d_host ReadASCIIField(std::ifstream &InputDataStream, int nx, int ny, int nz, std::string label) {
-    read_view_type_3d_host FieldOfInterest(Kokkos::ViewAllocateWithoutInitializing(label), nz, nx, ny);
-    using value_type = typename read_view_type_3d_host::value_type;
-    for (int k = 0; k < nz; k++) {
-        // Get line from file
-        std::string line;
-        getline(InputDataStream, line);
-        // Parse string at spaces
-        std::istringstream ss(line);
-        for (int j = 0; j < ny; j++) {
-            for (int i = 0; i < nx; i++) {
-                FieldOfInterest(k, i, j) = ParseASCIIData<value_type>(ss);
-            }
-        }
-    }
-    return FieldOfInterest;
-}
-
-// Reads binary string of type read_datatype from a paraview file, converts field to the appropriate type to match
-// read_view_type_3d_host (i.e, value_type), and place data in the appropriate data structure Each field consists of a
-// single binary string (no newlines) Store converted values in view - LayerID data is a short int, GrainID data is an
-// int In some older vtk files, LayerID may have been stored as an int and should be converted
-template <typename read_view_type_3d_host, typename read_datatype>
-read_view_type_3d_host ReadBinaryField(std::ifstream &InputDataStream, int nx, int ny, int nz, std::string label) {
-    read_view_type_3d_host FieldOfInterest(Kokkos::ViewAllocateWithoutInitializing(label), nz, nx, ny);
-    using value_type = typename read_view_type_3d_host::value_type;
-    for (int k = 0; k < nz; k++) {
-        for (int j = 0; j < ny; j++) {
-            for (int i = 0; i < nx; i++) {
-                read_datatype parsed_value = ReadBinaryData<read_datatype>(InputDataStream, true);
-                FieldOfInterest(k, i, j) = static_cast<value_type>(parsed_value);
-            }
-        }
-    }
-    return FieldOfInterest;
-}
-
-void ReadIgnoreASCIIField(std::ifstream &InputDataStream, int nx, int ny, int nz);
-
-// Reads and discards binary string of type read_datatype from a paraview file
-template <typename read_datatype>
-void ReadIgnoreBinaryField(std::ifstream &InputDataStream, int nx, int ny, int nz) {
-    unsigned char temp[sizeof(read_datatype)];
-    for (int k = 0; k < nz; k++) {
-        for (int j = 0; j < ny; j++) {
-            for (int i = 0; i < nx; i++) {
-                InputDataStream.read(reinterpret_cast<char *>(temp), sizeof(read_datatype));
-            }
-        }
-    }
-}
-
 // Search a specified region of LayerID in x and y for either the smallest Z that doesn't contain any layer "L",
 // or the largest Z that doesn't contain any layer "L"
 template <typename ViewTypeShort3dHost>

--- a/src/CAinputs.hpp
+++ b/src/CAinputs.hpp
@@ -405,6 +405,40 @@ struct Inputs {
         }
     }
 
+    // TODO: Old version, remove when old print options parsing format compatibility is no longer needed
+    // Check the field names from the given input (Fieldtype = PrintFieldsInit or PrintFieldsFinal) against the possible
+    // fieldnames listed in Fieldnames_key. Fill the vector PrintFields_given with true or false values depending on
+    // whether the corresponding field name from Fieldnames_key appeared in the input or not
+    std::vector<bool> getPrintFieldValues_Old(nlohmann::json inputdata, std::string Fieldtype,
+                                              std::vector<std::string> Fieldnames_key) {
+        int NumFields_key = Fieldnames_key.size();
+        int NumFields_given = inputdata["Printing"][Fieldtype].size();
+        std::vector<bool> PrintFields_given(NumFields_key, false);
+        // Check each given field against each possible input field name
+        for (int field_given = 0; field_given < NumFields_given; field_given++) {
+            for (int field_key = 0; field_key < NumFields_key; field_key++) {
+                if (inputdata["Printing"][Fieldtype][field_given] == Fieldnames_key[field_key])
+                    PrintFields_given[field_key] = true;
+            }
+        }
+        return PrintFields_given;
+    }
+    // Updated version, where fields are organized into intralayer and interlayer
+    std::vector<bool> getPrintFieldValues(nlohmann::json inputdata, std::string Fieldtype,
+                                          std::vector<std::string> Fieldnames_key) {
+        int NumFields_key = Fieldnames_key.size();
+        int NumFields_given = inputdata["Printing"][Fieldtype]["Fields"].size();
+        std::vector<bool> PrintFields_given(NumFields_key, false);
+        // Check each given field against each possible input field name
+        for (int field_given = 0; field_given < NumFields_given; field_given++) {
+            for (int field_key = 0; field_key < NumFields_key; field_key++) {
+                if (inputdata["Printing"][Fieldtype]["Fields"][field_given] == Fieldnames_key[field_key])
+                    PrintFields_given[field_key] = true;
+            }
+        }
+        return PrintFields_given;
+    }
+
     // Using the old print inputs, read the input data file and initialize appropriate variables to non-default values
     // if necessary
     void getPrintDataFromInputFile_Old(nlohmann::json inputdata, int id, double deltat) {

--- a/src/CAparsefiles.cpp
+++ b/src/CAparsefiles.cpp
@@ -84,37 +84,6 @@ void splitString(const std::string line, std::vector<std::string> &parsed_line, 
     parsed_line[parsed_line_size - 1] = line_copy;
 }
 
-// Check to make sure that the 6 expected column names appear in the correct order in the header for this temperature
-// file Return the number of columns present - ignore any columns after the 6 of interest
-std::size_t checkForHeaderValues(std::string header_line) {
-
-    // Header values from file - number of commas plus one is the size of the header
-    std::size_t header_size = std::count(header_line.begin(), header_line.end(), ',') + 1;
-    std::vector<std::string> header_values(header_size, "");
-    splitString(header_line, header_values, header_size);
-
-    std::vector<std::vector<std::string>> expected_values = {{"x"}, {"y"}, {"z"}, {"tm"}, {"tl", "ts"}, {"r", "cr"}};
-    std::size_t num_expected_values = expected_values.size();
-    if (num_expected_values > header_size)
-        throw std::runtime_error("Error: Fewer values than expected found in temperature file header");
-
-    // Case insensitive comparison
-    for (std::size_t n = 0; n < num_expected_values; n++) {
-        auto val = removeWhitespace(header_values[n]);
-        std::transform(val.begin(), val.end(), val.begin(), ::tolower);
-        // Check each header column label against the expected value(s) - throw error if no match
-        std::size_t options_size = expected_values[n].size();
-        for (std::size_t e = 0; e < options_size; e++) {
-            auto ev = expected_values[n][e];
-            if (val == ev)
-                break;
-            else if (e == options_size - 1)
-                throw std::runtime_error(ev + " not found in temperature file header");
-        }
-    }
-    return header_size;
-}
-
 bool checkFileExists(const std::string path, const int id, const bool error) {
     std::ifstream stream;
     stream.open(path);
@@ -162,40 +131,6 @@ void checkFileNotEmpty(std::string testfilename) {
     testfilestream.close();
 }
 
-// TODO: Old version, remove when old print options parsing format compatibility is no longer needed
-// Check the field names from the given input (Fieldtype = PrintFieldsInit or PrintFieldsFinal) against the possible
-// fieldnames listed in Fieldnames_key. Fill the vector PrintFields_given with true or false values depending on whether
-// the corresponding field name from Fieldnames_key appeared in the input or not
-std::vector<bool> getPrintFieldValues_Old(nlohmann::json inputdata, std::string Fieldtype,
-                                          std::vector<std::string> Fieldnames_key) {
-    int NumFields_key = Fieldnames_key.size();
-    int NumFields_given = inputdata["Printing"][Fieldtype].size();
-    std::vector<bool> PrintFields_given(NumFields_key, false);
-    // Check each given field against each possible input field name
-    for (int field_given = 0; field_given < NumFields_given; field_given++) {
-        for (int field_key = 0; field_key < NumFields_key; field_key++) {
-            if (inputdata["Printing"][Fieldtype][field_given] == Fieldnames_key[field_key])
-                PrintFields_given[field_key] = true;
-        }
-    }
-    return PrintFields_given;
-}
-// Updated version, where fields are organized into intralayer and interlayer
-std::vector<bool> getPrintFieldValues(nlohmann::json inputdata, std::string Fieldtype,
-                                      std::vector<std::string> Fieldnames_key) {
-    int NumFields_key = Fieldnames_key.size();
-    int NumFields_given = inputdata["Printing"][Fieldtype]["Fields"].size();
-    std::vector<bool> PrintFields_given(NumFields_key, false);
-    // Check each given field against each possible input field name
-    for (int field_given = 0; field_given < NumFields_given; field_given++) {
-        for (int field_key = 0; field_key < NumFields_key; field_key++) {
-            if (inputdata["Printing"][Fieldtype]["Fields"][field_given] == Fieldnames_key[field_key])
-                PrintFields_given[field_key] = true;
-        }
-    }
-    return PrintFields_given;
-}
-
 // Check if the temperature data is in ASCII or binary format
 bool checkTemperatureFileFormat(std::string tempfile_thislayer) {
     bool BinaryInputData;
@@ -207,84 +142,33 @@ bool checkTemperatureFileFormat(std::string tempfile_thislayer) {
     return BinaryInputData;
 }
 
-// Read x, y, z coordinates in tempfile_thislayer (temperature file in either an ASCII or binary format) and return the
-// min and max values
-std::array<double, 6> parseTemperatureCoordinateMinMax(std::string tempfile_thislayer, bool BinaryInputData) {
+// Check to make sure that the 6 expected column names appear in the correct order in the header for this temperature
+// file Return the number of columns present - ignore any columns after the 6 of interest
+std::size_t checkForHeaderValues(std::string header_line) {
 
-    std::array<double, 6> XYZMinMax;
-    std::ifstream TemperatureFilestream;
-    TemperatureFilestream.open(tempfile_thislayer);
-    std::size_t vals_per_line;
+    // Header values from file - number of commas plus one is the size of the header
+    std::size_t header_size = std::count(header_line.begin(), header_line.end(), ',') + 1;
+    std::vector<std::string> header_values(header_size, "");
+    splitString(header_line, header_values, header_size);
 
-    // Binary temperature data should contain only the six columns of interest
-    // Comma-separated double type values may contain additional columns after the 6 used by ExaCA
-    if (BinaryInputData)
-        vals_per_line = 6;
-    else {
-        // Read the header line data
-        // Make sure the first line contains all required column names: x, y, z, tm, tl, cr
-        std::string HeaderLine;
-        getline(TemperatureFilestream, HeaderLine);
-        vals_per_line = checkForHeaderValues(HeaderLine);
-    }
+    std::vector<std::vector<std::string>> expected_values = {{"x"}, {"y"}, {"z"}, {"tm"}, {"tl", "ts"}, {"r", "cr"}};
+    std::size_t num_expected_values = expected_values.size();
+    if (num_expected_values > header_size)
+        throw std::runtime_error("Error: Fewer values than expected found in temperature file header");
 
-    // Units are assumed to be in meters, meters, seconds, seconds, and K/second
-    int XYZPointCount_Estimate = 1000000;
-    std::vector<double> XCoordinates(XYZPointCount_Estimate), YCoordinates(XYZPointCount_Estimate),
-        ZCoordinates(XYZPointCount_Estimate);
-    long unsigned int XYZPointCounter = 0;
-    if (BinaryInputData) {
-        while (!TemperatureFilestream.eof()) {
-            // Get x from the binary string, or, if no data is left, exit the file read
-            double XValue = ReadBinaryData<double>(TemperatureFilestream);
-            if (!(TemperatureFilestream))
+    // Case insensitive comparison
+    for (std::size_t n = 0; n < num_expected_values; n++) {
+        auto val = removeWhitespace(header_values[n]);
+        std::transform(val.begin(), val.end(), val.begin(), ::tolower);
+        // Check each header column label against the expected value(s) - throw error if no match
+        std::size_t options_size = expected_values[n].size();
+        for (std::size_t e = 0; e < options_size; e++) {
+            auto ev = expected_values[n][e];
+            if (val == ev)
                 break;
-            // Store the x value that was read, and parse the y and z values
-            XCoordinates[XYZPointCounter] = XValue;
-            YCoordinates[XYZPointCounter] = ReadBinaryData<double>(TemperatureFilestream);
-            ZCoordinates[XYZPointCounter] = ReadBinaryData<double>(TemperatureFilestream);
-            // Ignore the tm, tl, cr values associated with this x, y, z
-            unsigned char temp[3 * sizeof(double)];
-            TemperatureFilestream.read(reinterpret_cast<char *>(temp), 3 * sizeof(double));
-            XYZPointCounter++;
-            if (XYZPointCounter == XCoordinates.size()) {
-                XCoordinates.resize(XYZPointCounter + XYZPointCount_Estimate);
-                YCoordinates.resize(XYZPointCounter + XYZPointCount_Estimate);
-                ZCoordinates.resize(XYZPointCounter + XYZPointCount_Estimate);
-            }
+            else if (e == options_size - 1)
+                throw std::runtime_error(ev + " not found in temperature file header");
         }
     }
-    else {
-        while (!TemperatureFilestream.eof()) {
-            std::vector<std::string> ParsedLine(3); // Get x, y, z - ignore tm, tl, cr
-            std::string ReadLine;
-            if (!getline(TemperatureFilestream, ReadLine))
-                break;
-            splitString(ReadLine, ParsedLine, vals_per_line);
-            // Only get x, y, and z values from ParsedLine
-            XCoordinates[XYZPointCounter] = getInputDouble(ParsedLine[0]);
-            YCoordinates[XYZPointCounter] = getInputDouble(ParsedLine[1]);
-            ZCoordinates[XYZPointCounter] = getInputDouble(ParsedLine[2]);
-            XYZPointCounter++;
-            if (XYZPointCounter == XCoordinates.size()) {
-                XCoordinates.resize(XYZPointCounter + XYZPointCount_Estimate);
-                YCoordinates.resize(XYZPointCounter + XYZPointCount_Estimate);
-                ZCoordinates.resize(XYZPointCounter + XYZPointCount_Estimate);
-            }
-        }
-    }
-
-    XCoordinates.resize(XYZPointCounter);
-    YCoordinates.resize(XYZPointCounter);
-    ZCoordinates.resize(XYZPointCounter);
-    TemperatureFilestream.close();
-
-    // Min/max x, y, and z coordinates from this layer's data
-    XYZMinMax[0] = *min_element(XCoordinates.begin(), XCoordinates.end());
-    XYZMinMax[1] = *max_element(XCoordinates.begin(), XCoordinates.end());
-    XYZMinMax[2] = *min_element(YCoordinates.begin(), YCoordinates.end());
-    XYZMinMax[3] = *max_element(YCoordinates.begin(), YCoordinates.end());
-    XYZMinMax[4] = *min_element(ZCoordinates.begin(), ZCoordinates.end());
-    XYZMinMax[5] = *max_element(ZCoordinates.begin(), ZCoordinates.end());
-    return XYZMinMax;
+    return header_size;
 }

--- a/src/CAtemperature.hpp
+++ b/src/CAtemperature.hpp
@@ -77,6 +77,86 @@ struct Temperature {
         get_current_layer_undercooling(grid.layer_range);
     }
 
+    // Read and parse the temperature file (double precision values in a comma-separated, ASCII format with a header
+    // line - or a binary string of double precision values), storing the x, y, z, tm, tl, cr values in the RawData
+    // vector. Each rank only contains the points corresponding to cells within the associated Y bounds.
+    // NumberOfTemperatureDataPoints is incremented on each rank as data is added to RawData
+    void parseTemperatureData(std::string tempfile_thislayer, double YMin, double deltax, int LowerYBound,
+                              int UpperYBound, int &NumberOfTemperatureDataPoints, bool BinaryInputData) {
+
+        std::ifstream TemperatureFilestream;
+        TemperatureFilestream.open(tempfile_thislayer);
+        if (BinaryInputData) {
+            while (!TemperatureFilestream.eof()) {
+                double XTemperaturePoint = ReadBinaryData<double>(TemperatureFilestream);
+                double YTemperaturePoint = ReadBinaryData<double>(TemperatureFilestream);
+                // If no data was extracted from the stream, the end of the file was reached
+                if (!(TemperatureFilestream))
+                    break;
+                // Check the y value from ParsedLine, to check if this point is stored on this rank
+                // Check the CA grid positions of the data point to see which rank(s) should store it
+                int YInt = Kokkos::round((YTemperaturePoint - YMin) / deltax);
+                if ((YInt >= LowerYBound) && (YInt <= UpperYBound)) {
+                    // This data point is inside the bounds of interest for this MPI rank
+                    // Store the x and y values in RawData
+                    RawTemperatureData(NumberOfTemperatureDataPoints) = XTemperaturePoint;
+                    NumberOfTemperatureDataPoints++;
+                    RawTemperatureData(NumberOfTemperatureDataPoints) = YTemperaturePoint;
+                    NumberOfTemperatureDataPoints++;
+                    // Parse the remaining 4 components (z, tm, tl, cr) from the line and store in RawData
+                    for (int component = 2; component < 6; component++) {
+                        RawTemperatureData(NumberOfTemperatureDataPoints) =
+                            ReadBinaryData<double>(TemperatureFilestream);
+                        NumberOfTemperatureDataPoints++;
+                    }
+                    int RawTemperatureData_extent = RawTemperatureData.extent(0);
+                    // Adjust size of RawData if it is near full
+                    if (NumberOfTemperatureDataPoints >= RawTemperatureData_extent - 6) {
+                        Kokkos::resize(RawTemperatureData, RawTemperatureData_extent + 1000000);
+                    }
+                }
+                else {
+                    // This data point is inside the bounds of interest for this MPI rank
+                    // ignore the z, tm, tl, cr values associated with it
+                    unsigned char temp[4 * sizeof(double)];
+                    TemperatureFilestream.read(reinterpret_cast<char *>(temp), 4 * sizeof(double));
+                }
+            }
+        }
+        else {
+            // Get number of columns in this temperature file
+            std::string HeaderLine;
+            getline(TemperatureFilestream, HeaderLine);
+            int vals_per_line = checkForHeaderValues(HeaderLine);
+            while (!TemperatureFilestream.eof()) {
+                std::vector<std::string> ParsedLine(6); // Each line has an x, y, z, tm, tl, cr
+                std::string ReadLine;
+                if (!getline(TemperatureFilestream, ReadLine))
+                    break;
+                // Only parse the first 6 columns of the temperature data
+                splitString(ReadLine, ParsedLine, vals_per_line);
+                // Check the y value from ParsedLine, to check if this point is stored on this rank
+                double YTemperaturePoint = getInputDouble(ParsedLine[1]);
+                // Check the CA grid positions of the data point to see which rank(s) should store it
+                int YInt = Kokkos::round((YTemperaturePoint - YMin) / deltax);
+                if ((YInt >= LowerYBound) && (YInt <= UpperYBound)) {
+                    // This data point is inside the bounds of interest for this MPI rank: Store the x, z, tm, tl, and
+                    // cr vals inside of RawData, incrementing with each value added
+                    for (int component = 0; component < 6; component++) {
+                        RawTemperatureData(NumberOfTemperatureDataPoints) = getInputDouble(ParsedLine[component]);
+                        NumberOfTemperatureDataPoints++;
+                    }
+                    // Adjust size of RawData if it is near full
+                    int RawTemperatureData_extent = RawTemperatureData.extent(0);
+                    // Adjust size of RawData if it is near full
+                    if (NumberOfTemperatureDataPoints >= RawTemperatureData_extent - 6) {
+                        Kokkos::resize(RawTemperatureData, RawTemperatureData_extent + 1000000);
+                    }
+                }
+            }
+        }
+    }
+
     // Read in temperature data from files, stored in the host view "RawData", with the appropriate MPI ranks storing
     // the appropriate data
     void readTemperatureData(int id, const Grid &grid, int layernumber) {
@@ -119,7 +199,7 @@ struct Temperature {
             // rank within RawData and incrementing NumberOfTemperatureDataPoints appropriately
             bool BinaryInputData = checkTemperatureFileFormat(tempfile_thislayer);
             parseTemperatureData(tempfile_thislayer, grid.y_min, grid.deltax, LowerYBound, UpperYBound,
-                                 NumberOfTemperatureDataPoints, BinaryInputData, RawTemperatureData);
+                                 NumberOfTemperatureDataPoints, BinaryInputData);
             LastValue(LayerReadCount) = NumberOfTemperatureDataPoints;
         } // End loop over all files read for all layers
         Kokkos::resize(RawTemperatureData, NumberOfTemperatureDataPoints);


### PR DESCRIPTION
Parsing functions exclusively used as part of the inputs, grid, or temperature struct have been moved into the appropriate file. Parsing functions used in multiple points in the code (or will be in the future, i.e. reading vtk field data as part of restarting ExaCA from a previous state) have been consolidated in `CAparsefiles.cpp` and `CAparsefiles.hpp`