### PR TITLE
Remove max undercooling and max octahedron growth rate per time step

### DIFF
--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -166,12 +166,10 @@ void cell_capture(const int, const int np, const Grid &grid, const InterfacialRe
 
             // Cells of interest for the CA - active cells and future active/liquid cells
             if (cellData.CellType(index) == Active) {
-                // Update local diagonal length of active cell
+                // Get undercooling of active cell
                 double LocU = temperature.UndercoolingCurrent(index);
-                LocU = Kokkos::fmin(210.0, LocU);
-                double V = irf.compute(LocU);
-                // Max amount the diagonal can grow per time step
-                interface.diagonal_length(index) += Kokkos::fmin(0.045, V);
+                // Update diagonal length of octahedron based on local undercooling and interfacial response function
+                interface.diagonal_length(index) += irf.compute(LocU);
                 // Cycle through all neigboring cells on this processor to see if they have been captured
                 // Cells in ghost nodes cannot capture cells on other processors
                 bool DeactivateCell = true; // switch that becomes false if the cell has at least 1 liquid type neighbor


### PR DESCRIPTION
The time step is typically (and should be) selected such that the interface does not advance more than a specified amount per time step during a simulation. In the event that this threshold is exceeded, ExaCA currently opts to cap the maximum growth velocity at 0.045 cell lengths per time step (also capping the maximum undercooling at the arbitrary threshold of 210 K, which happens to be the freezing range for the Inconel625.json material). While these limits help prevent time steps where a liquid cell undergoes multiple potential capture events, which in turn would introduce an iteration order-dependence of the code, these limits lead to a worse accuracy degradation than simply allowing the interface to advance as normal. 

This change will not affect problems where the time step is appropriately selected. For the example problems, this was based on the expression dt = alpha * deltax / Vmax, where deltax is the cell size, alpha is 1/25, and Vmax is the maximum expected solidification velocity in a problem of interest (such as a pulling velocity for directional solidification or a scan speed for simulation of a laser scan over a substrate).