### PR TITLE
Data type consistency

### DIFF
--- a/analysis/src/GArepresentativeregion.hpp
+++ b/analysis/src/GArepresentativeregion.hpp
@@ -368,7 +368,7 @@ struct RepresentativeRegion {
             int grain_size_cells =
                 std::count(grain_id_vector.begin(), grain_id_vector.end(), unique_grain_id_vector[n]);
             // convert to either microns, square microns, or cubic microns
-            grain_size_vector[n] = static_cast<float>(conv * grain_size_cells);
+            grain_size_vector[n] = static_cast<float>(conv) * static_cast<float>(grain_size_cells);
         }
         return grain_size_vector;
     }

--- a/analysis/src/GArepresentativeregion.hpp
+++ b/analysis/src/GArepresentativeregion.hpp
@@ -368,7 +368,7 @@ struct RepresentativeRegion {
             int grain_size_cells =
                 std::count(grain_id_vector.begin(), grain_id_vector.end(), unique_grain_id_vector[n]);
             // convert to either microns, square microns, or cubic microns
-            grain_size_vector[n] = conv * grain_size_cells;
+            grain_size_vector[n] = static_cast<float>(conv * grain_size_cells);
         }
         return grain_size_vector;
     }
@@ -597,7 +597,7 @@ struct RepresentativeRegion {
     // Print the average grain size and the number of grains in the region
     void printMeanSize(std::ofstream &qois) {
 
-        double avg_size_per_grain = divideCast<double>(region_size_microns, number_of_grains);
+        float avg_size_per_grain = divideCast<float>(region_size_microns, number_of_grains);
         std::string temp = "-- There are " + std::to_string(number_of_grains) + " grains in this " + region_type +
                            " , and the mean grain " + region_type + " is " + std::to_string(avg_size_per_grain) + " " +
                            units_dimension + "\n";
@@ -688,7 +688,7 @@ struct RepresentativeRegion {
             it = std::unique(unique_grain_id_vector_area.begin(), unique_grain_id_vector_area.end());
             unique_grain_id_vector_area.resize(std::distance(unique_grain_id_vector_area.begin(), it));
             int number_of_grains_area = unique_grain_id_vector_area.size();
-            double mean_grain_area_this_layer = divideCast<double>(layer_area, number_of_grains_area);
+            float mean_grain_area_this_layer = divideCast<float>(layer_area, number_of_grains_area);
             if (print_unweighted_areas)
                 grainplot1 << z_bounds_meters[0] * Kokkos::pow(10, 6) + convertToMicrons(deltax, "length") << ","
                            << mean_grain_area_this_layer * convertToMicrons(deltax, "area") << std::endl;
@@ -698,12 +698,12 @@ struct RepresentativeRegion {
                 for (int n = 0; n < number_of_grains_area; n++) {
                     int grain_size_cells = std::count(grain_id_vector_area.begin(), grain_id_vector_area.end(),
                                                       unique_grain_id_vector_area[n]);
-                    grain_size_vector_microns_area[n] = conv * grain_size_cells;
+                    grain_size_vector_microns_area[n] = static_cast<float>(conv) * grain_size_cells;
                 }
                 float area_x_area = 0.0;
                 for (int n = 0; n < number_of_grains_area; n++)
                     area_x_area += grain_size_vector_microns_area[n] * grain_size_vector_microns_area[n];
-                double weighted_area = divideCast<double>(area_x_area, layer_area);
+                float weighted_area = divideCast<float>(area_x_area, layer_area);
                 grainplot2 << z_bounds_meters[0] * Kokkos::pow(10, 6) + convertToMicrons(deltax, "length") << ","
                            << weighted_area << std::endl;
                 if (k == z_bounds_cells[1])

--- a/analysis/unit_test/tstRepresentativeRegion.hpp
+++ b/analysis/unit_test/tstRepresentativeRegion.hpp
@@ -246,8 +246,8 @@ void testCollectGrainStats() {
 
     // Check against expected grain sizes, in cubic microns (each grain spans 50 cells)
     for (int n = 0; n < representativeregion.number_of_grains; n++) {
-        EXPECT_FLOAT_EQ(representativeregion.grain_size_vector_microns[n],
-                        50 * Kokkos::pow(deltax, 3) * Kokkos::pow(10, 18));
+        float grain_size_microns_expected = static_cast<float>(50 * Kokkos::pow(deltax, 3) * Kokkos::pow(10, 18));
+        EXPECT_FLOAT_EQ(representativeregion.grain_size_vector_microns[n], grain_size_microns_expected);
     }
 
     // Obtain the grain extents

--- a/src/CAinputs.hpp
+++ b/src/CAinputs.hpp
@@ -673,8 +673,9 @@ struct Inputs {
         // If this problem type includes a powder layer of some grain density, ensure that integer overflow won't occur
         // when assigning powder layer GrainIDs
         if (!(substrate.baseplate_through_powder)) {
-            long int num_cells_powder_layers =
-                (long int)(nx) * (long int)(ny) * (long int)(layer_height) * (long int)(number_of_layers - 1);
+            long int num_cells_powder_layers = static_cast<long int>(nx) * static_cast<long int>(ny) *
+                                               static_cast<long int>(layer_height) *
+                                               static_cast<long int>(number_of_layers - 1);
             long int num_assigned_cells_powder_layers = std::lround(
                 Kokkos::round(static_cast<double>(num_cells_powder_layers) * substrate.powder_active_fraction));
             if (num_assigned_cells_powder_layers > INT_MAX)

--- a/src/CAinterface.hpp
+++ b/src/CAinterface.hpp
@@ -205,7 +205,7 @@ struct Interface {
         // neighbor). The critical diagonal length will be the maximum of these (since all other
         // planes will have passed over the point by then
         // ... meaning it must be in the octahedron)
-        double fx[4], fy[4], fz[4];
+        float fx[4], fy[4], fz[4];
 
         fx[0] = grain_unit_vector(9 * my_orientation) + grain_unit_vector(9 * my_orientation + 3) +
                 grain_unit_vector(9 * my_orientation + 6);

--- a/src/CAinterfacialresponse.hpp
+++ b/src/CAinterfacialresponse.hpp
@@ -20,11 +20,11 @@
 // Interfacial repsonse function with various functional forms.
 struct InterfacialResponseFunction {
 
-    double freezing_range;
-    double A;
-    double B;
-    double C;
-    double D = 0.0;
+    float freezing_range;
+    float A;
+    float B;
+    float C;
+    float D = 0.0;
     enum IRFtypes {
         cubic = 0,
         quadratic = 1,
@@ -73,35 +73,35 @@ struct InterfacialResponseFunction {
     void normalize(const double deltat, const double deltax) {
         if (function == cubic) {
             // Normalize all 4 coefficients: V = A*x^3 + B*x^2 + C*x + D
-            A *= deltat / deltax;
-            B *= deltat / deltax;
-            C *= deltat / deltax;
-            D *= deltat / deltax;
+            A *= static_cast<float>(deltat / deltax);
+            B *= static_cast<float>(deltat / deltax);
+            C *= static_cast<float>(deltat / deltax);
+            D *= static_cast<float>(deltat / deltax);
         }
         else if (function == quadratic) {
             // Normalize the 3 relevant coefficients: V = A*x^2 + B*x + C
-            A *= deltat / deltax;
-            B *= deltat / deltax;
-            C *= deltat / deltax;
+            A *= static_cast<float>(deltat / deltax);
+            B *= static_cast<float>(deltat / deltax);
+            C *= static_cast<float>(deltat / deltax);
         }
         else if (function == power) {
             // Normalize only the leading and last coefficient: V = A*x^B + C
-            A *= deltat / deltax;
-            C *= deltat / deltax;
+            A *= static_cast<float>(deltat / deltax);
+            C *= static_cast<float>(deltat / deltax);
         }
     }
 
     // Compute velocity from local undercooling.
     // functional form is assumed to be cubic if not explicitly given in input file
     KOKKOS_INLINE_FUNCTION
-    double compute(const double LocU) const {
-        double V;
+    float compute(const float loc_u) const {
+        float V;
         if (function == quadratic)
-            V = A * Kokkos::pow(LocU, 2.0) + B * LocU + C;
+            V = A * Kokkos::pow(loc_u, 2.0) + B * loc_u + C;
         else if (function == power)
-            V = A * Kokkos::pow(LocU, B) + C;
+            V = A * Kokkos::pow(loc_u, B) + C;
         else
-            V = A * Kokkos::pow(LocU, 3.0) + B * Kokkos::pow(LocU, 2.0) + C * LocU + D;
+            V = A * Kokkos::pow(loc_u, 3.0) + B * Kokkos::pow(loc_u, 2.0) + C * loc_u + D;
         return Kokkos::fmax(0.0, V);
     }
 

--- a/src/CAnucleation.hpp
+++ b/src/CAnucleation.hpp
@@ -102,7 +102,7 @@ struct Nucleation {
         std::uniform_real_distribution<double> y_dist(-0.49999, grid.ny - 0.5);
         std::uniform_real_distribution<double> z_dist(-0.49999, grid.nz_layer - 0.5);
         // Gaussian distribution of nucleation undercooling
-        std::normal_distribution<double> g_distribution(_inputs.dtn, _inputs.dtsigma);
+        std::normal_distribution<float> g_distribution(_inputs.dtn, _inputs.dtsigma);
 
         // Max number of nucleated grains in this layer
         // Use long int in intermediate steps calculating the number of nucleated grains, though the number should be
@@ -146,7 +146,7 @@ struct Nucleation {
                 // Assign each nuclei a Grain ID (negative values used for nucleated grains) and an undercooling
                 nuclei_grain_id_whole_domain_v[n_event] =
                     -(nuclei_whole_domain + n_event + 1); // avoid using grain ID 0
-                nuclei_undercooling_whole_domain_v[n_event] = static_cast<float>(g_distribution(generator));
+                nuclei_undercooling_whole_domain_v[n_event] = g_distribution(generator);
             }
         }
 

--- a/src/CAnucleation.hpp
+++ b/src/CAnucleation.hpp
@@ -122,11 +122,11 @@ struct Nucleation {
                                      "events in the temperature data, or the domain size should be reduced");
         int nuclei_this_layer_single = static_cast<int>(nuclei_this_layer_single_long);
         int nuclei_this_layer = static_cast<int>(nuclei_this_layer_long);
-        int nuclei_multiplier = static_cast<long int>(nuclei_multiplier_long);
+        int nuclei_multiplier = static_cast<int>(nuclei_multiplier_long);
 
         // Nuclei Grain ID are assigned to avoid reusing values from previous layers
         std::vector<int> nuclei_grain_id_whole_domain_v(nuclei_this_layer);
-        std::vector<double> nuclei_undercooling_whole_domain_v(nuclei_this_layer);
+        std::vector<float> nuclei_undercooling_whole_domain_v(nuclei_this_layer);
         // Views for storing potential nucleated grain coordinates
         view_type_int_host nuclei_x(Kokkos::ViewAllocateWithoutInitializing("NucleiX"), nuclei_this_layer);
         view_type_int_host nuclei_y(Kokkos::ViewAllocateWithoutInitializing("NucleiY"), nuclei_this_layer);
@@ -146,7 +146,7 @@ struct Nucleation {
                 // Assign each nuclei a Grain ID (negative values used for nucleated grains) and an undercooling
                 nuclei_grain_id_whole_domain_v[n_event] =
                     -(nuclei_whole_domain + n_event + 1); // avoid using grain ID 0
-                nuclei_undercooling_whole_domain_v[n_event] = g_distribution(generator);
+                nuclei_undercooling_whole_domain_v[n_event] = static_cast<float>(g_distribution(generator));
             }
         }
 
@@ -189,7 +189,7 @@ struct Nucleation {
                         float undercooling_change_this_event =
                             layer_time_temp_history_host(nuclei_location_this_layer, meltevent, 2);
                         float time_to_nuc_und =
-                            Kokkos::round(crit_time_step_this_event +
+                            Kokkos::round(static_cast<float>(crit_time_step_this_event) +
                                           nuclei_undercooling_whole_domain_v[n_event] / undercooling_change_this_event);
                         if (crit_time_step_this_event > time_to_nuc_und)
                             time_to_nuc_und = crit_time_step_this_event;

--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -413,12 +413,12 @@ struct Print {
     void printIdleIntralayer(const int id, const int np, const int layernumber, const int deltat, const int cycle,
                              const Grid &grid, CellData<MemorySpace> &celldata, Temperature<MemorySpace> &temperature,
                              Interface<MemorySpace> &interface, Orientation<MemorySpace> &orientation,
-                             const unsigned long int global_next_melt_time_step) {
+                             const int global_next_melt_time_step) {
 
         if (_inputs.intralayer_idle_frames) {
             // Print current state of ExaCA simulation (up to and including the current layer's data) during the skipped
             // time steps, if intermediate output is toggled
-            for (unsigned long int cycle_jump = cycle + 1; cycle_jump < global_next_melt_time_step; cycle_jump++) {
+            for (int cycle_jump = cycle + 1; cycle_jump < global_next_melt_time_step; cycle_jump++) {
                 printIntralayer(id, np, layernumber, deltat, cycle_jump, grid, celldata, temperature, interface,
                                 orientation);
             }

--- a/src/CAtemperature.hpp
+++ b/src/CAtemperature.hpp
@@ -678,7 +678,7 @@ struct Temperature {
     // Extract the next time that this point undergoes melting
     KOKKOS_INLINE_FUNCTION
     int getMeltTimeStep(const int cycle, const int index) const {
-        double melt_time_step;
+        int melt_time_step;
         int solidification_event_counter_cell = solidification_event_counter(index);
         melt_time_step = static_cast<int>(layer_time_temp_history(index, solidification_event_counter_cell, 0));
         if (cycle > melt_time_step) {

--- a/unit_test/tstCellData.hpp
+++ b/unit_test/tstCellData.hpp
@@ -52,7 +52,7 @@ void testCellDataInit_SingleGrain() {
     CellData<memory_space> celldata(grid.domain_size, grid.domain_size_all_layers, inputs.substrate);
 
     // Check that default substrate single grain orientation was set
-    EXPECT_DOUBLE_EQ(inputs.substrate.single_grain_orientation, celldata._inputs.single_grain_orientation);
+    EXPECT_EQ(inputs.substrate.single_grain_orientation, celldata._inputs.single_grain_orientation);
 
     // Init grain
     celldata.initSubstrate(id, grid);

--- a/unit_test/tstInputs.hpp
+++ b/unit_test/tstInputs.hpp
@@ -135,11 +135,11 @@ void testInputs(int print_version) {
             EXPECT_DOUBLE_EQ(inputs.nucleation.n_max, 1.0 * pow(10, 13));
         EXPECT_DOUBLE_EQ(inputs.nucleation.dtn, 5.0);
         EXPECT_DOUBLE_EQ(inputs.nucleation.dtsigma, 0.5);
-        EXPECT_DOUBLE_EQ(irf.A, -0.00000010302 * inputs.domain.deltat / inputs.domain.deltax);
-        EXPECT_DOUBLE_EQ(irf.B, 0.00010533 * inputs.domain.deltat / inputs.domain.deltax);
-        EXPECT_DOUBLE_EQ(irf.C, 0.0022196 * inputs.domain.deltat / inputs.domain.deltax);
-        EXPECT_DOUBLE_EQ(irf.D, 0);
-        EXPECT_DOUBLE_EQ(irf.freezing_range, 210);
+        EXPECT_FLOAT_EQ(irf.A, -0.00000010302 * inputs.domain.deltat / inputs.domain.deltax);
+        EXPECT_FLOAT_EQ(irf.B, 0.00010533 * inputs.domain.deltat / inputs.domain.deltax);
+        EXPECT_FLOAT_EQ(irf.C, 0.0022196 * inputs.domain.deltat / inputs.domain.deltax);
+        EXPECT_FLOAT_EQ(irf.D, 0);
+        EXPECT_FLOAT_EQ(irf.freezing_range, 210);
 
         // These are different for all 3 test problems
         if ((filename == input_filenames[0]) || (filename == input_filenames[3])) {

--- a/unit_test/tstInterfacialResponse.hpp
+++ b/unit_test/tstInterfacialResponse.hpp
@@ -31,8 +31,8 @@ void testInterfacialResponse() {
         // Check that fitting parameters were correctly initialized and normalized
         // Fitting parameters should've been normalized by deltat / deltax, i.e. twice as large as the numbers in the
         // file
-        double a_test, b_test, c_test, d_test, freezing_range_test, expected_v;
-        double loc_u = 11.0;
+        float a_test, b_test, c_test, d_test, freezing_range_test, expected_v;
+        float loc_u = 11.0;
         if (file_name == "Inconel625.json") {
             a_test = -0.00000010302;
             b_test = 0.00010533;
@@ -62,18 +62,18 @@ void testInterfacialResponse() {
         // For all IRFs, A and C should be normalized by deltat/deltax (i.e., 2)
         // For the power law IRF (SS316), B is dimensionless and should not be normalized unlike the other IRFs where
         // all coefficients are normalized
-        EXPECT_DOUBLE_EQ(irf.A, a_test * 2);
+        EXPECT_FLOAT_EQ(irf.A, a_test * 2);
         if (file_name == "SS316.json")
-            EXPECT_DOUBLE_EQ(irf.B, b_test);
+            EXPECT_FLOAT_EQ(irf.B, b_test);
         else
-            EXPECT_DOUBLE_EQ(irf.B, b_test * 2);
-        EXPECT_DOUBLE_EQ(irf.C, c_test * 2);
+            EXPECT_FLOAT_EQ(irf.B, b_test * 2);
+        EXPECT_FLOAT_EQ(irf.C, c_test * 2);
         if (file_name == "Inconel625.json") {
-            EXPECT_DOUBLE_EQ(irf.D, d_test * 2);
+            EXPECT_FLOAT_EQ(irf.D, d_test * 2);
         }
-        EXPECT_DOUBLE_EQ(irf.freezing_range, freezing_range_test);
-        double computed_v = irf.compute(loc_u);
-        EXPECT_DOUBLE_EQ(computed_v, expected_v);
+        EXPECT_FLOAT_EQ(irf.freezing_range, freezing_range_test);
+        float computed_v = irf.compute(loc_u);
+        EXPECT_FLOAT_EQ(computed_v, expected_v);
     }
 }
 //---------------------------------------------------------------------------//

--- a/unit_test/tstPrint.hpp
+++ b/unit_test/tstPrint.hpp
@@ -33,7 +33,7 @@ void testPrintExaConstitDefaultRVE() {
     // default inputs struct - manually set non-default substrateInputs values
     Inputs inputs;
     inputs.print.print_default_rve = true;
-    inputs.print.rve_size = 0.0005 / grid.deltax;
+    inputs.print.rve_size = Kokkos::round(0.0005 / grid.deltax);
     // File name/path for test RVE output
     inputs.print.base_filename = "TestRVE";
     // Initialize printing struct from inputs
@@ -41,7 +41,7 @@ void testPrintExaConstitDefaultRVE() {
 
     // Check that inputs in print struct match the initialization from inputs
     EXPECT_TRUE(print._inputs.print_default_rve);
-    EXPECT_DOUBLE_EQ(inputs.print.rve_size, print._inputs.rve_size);
+    EXPECT_EQ(inputs.print.rve_size, print._inputs.rve_size);
     EXPECT_EQ(inputs.print.base_filename, print._inputs.base_filename);
 
     // Create test data


### PR DESCRIPTION
Consistent use of `int`, `float` for variables used in ExaCA (conversions to and from `long int` and `double` were sometimes performed). Closes #152 