### PR TITLE
Avoiding writing file headers if no data/stats will be written to the file

### DIFF
--- a/analysis/bin/runGA.cpp
+++ b/analysis/bin/runGA.cpp
@@ -73,9 +73,12 @@ int main(int argc, char *argv[]) {
             // Output file stream for quantities of interest
             std::ofstream qois;
             std::string qois_fname = base_filename_this_region + "_QoIs.txt";
-            qois.open(qois_fname);
-            // Header data for qois file
-            representativeregion.printAnalysisHeader(qois);
+            // Print QoIs file if at least one analysis option is turned on
+            if (representativeregion.print_stats_yn) {
+                qois.open(qois_fname);
+                // Header data for qois file
+                representativeregion.printAnalysisHeader(qois);
+            }
 
             // Fraction of region consisting of nucleated grains, unmelted material
             if (representativeregion.analysis_options_stats_yn[0])
@@ -130,7 +133,8 @@ int main(int argc, char *argv[]) {
             if ((representativeregion.analysis_options_layerwise_stats_yn[0]) ||
                 (representativeregion.analysis_options_layerwise_stats_yn[1]))
                 representativeregion.writeAreaSeries(base_filename_this_region, deltax, grain_id);
-            qois.close();
+            if (representativeregion.print_stats_yn)
+                qois.close();
 
             // Write per-grain stats for the analysis types specified to the file
             // "[base_filename_this_region]_grains.csv"

--- a/analysis/src/GArepresentativeregion.hpp
+++ b/analysis/src/GArepresentativeregion.hpp
@@ -51,8 +51,9 @@ struct RepresentativeRegion {
         "YExtent",               // all regions
         "ZExtent",               // all regions
     };
+    bool print_stats_yn = false;
     std::vector<bool> analysis_options_stats_yn = std::vector<bool>(7, false);
-    std::vector<std::string> AnalysisOptions_PerGrainStats_key = {
+    std::vector<std::string> analysis_options_per_grain_stats_key = {
         "Misorientation",        // all regions
         "Size",                  // all regions - volume, area, or length
         "XExtent",               // all regions
@@ -66,7 +67,7 @@ struct RepresentativeRegion {
         "MeanGrainArea",        // volume only
         "MeanWeightedGrainArea" // volume only
     };
-    bool print_per_grain_stats_yn;
+    bool print_per_grain_stats_yn = false;
     std::vector<bool> analysis_options_layerwise_stats_yn = std::vector<bool>(2, false);
 
     // Analysis options that print separate files
@@ -99,8 +100,14 @@ struct RepresentativeRegion {
 
         // Check which overall stats and per grain stats should be printed for this region
         readAnalysisOptionsFromList(region_data, "printStats", analysis_options_stats_key, analysis_options_stats_yn);
+        // print_stats_yn = true if any one of the options are toggled
+        int num_analysis_options_stats = analysis_options_stats_yn.size();
+        for (int n = 0; n < num_analysis_options_stats; n++) {
+            if (analysis_options_stats_yn[n])
+                print_stats_yn = true;
+        }
         // print_per_grain_stats_yn = true if any one of the options are toggled
-        readAnalysisOptionsFromList(region_data, "printPerGrainStats", AnalysisOptions_PerGrainStats_key,
+        readAnalysisOptionsFromList(region_data, "printPerGrainStats", analysis_options_per_grain_stats_key,
                                     analysis_options_per_grain_stats_yn);
         int num_analysis_options_per_grain_stats = analysis_options_per_grain_stats_yn.size();
         for (int n = 0; n < num_analysis_options_per_grain_stats; n++) {

--- a/src/CAinputs.hpp
+++ b/src/CAinputs.hpp
@@ -552,7 +552,6 @@ struct Inputs {
         else {
             if (input_data["Printing"].contains("Intralayer")) {
                 // Fields to be printed during a simulation or during a layer of a simulation - if increment
-                print.intralayer = true;
                 if (input_data["Printing"]["Intralayer"]["Increment"] == 0) {
                     // Files only printed for the initial state of a given layer
                     print.intralayer_increment = INT_MAX;


### PR DESCRIPTION
Currently, ExaCA prints headers for intralayer files and some grain analysis files even if no data fields or analysis options are toggled. This update avoids creating and writing anything to files unless at least one field or stat will be written to them