### PR TITLE
Realloc celltype during new layer init

### DIFF
--- a/src/CAcelldata.hpp
+++ b/src/CAcelldata.hpp
@@ -551,6 +551,8 @@ struct CellData {
                              view_type_int number_of_solidification_events) {
 
         int melt_pool_cell_count;
+        // Realloc celltype to the domain size of the next layer
+        Kokkos::realloc(cell_type, grid.domain_size);
         // Local copies for lambda capture.
         auto cell_type_local = cell_type;
         auto layer_id_all_layers_local = layer_id_all_layers;


### PR DESCRIPTION
Fixup of #280 , where a bug would occur in `initCellTypeLayerID` for the edge case where 1) External temperature data was used, 2) A multilayer simulation with multiple temperature data files were used, and 3) The size of the melted region for layer "n" was more than the size for layer "n-1"