### PR TITLE
Rename libraries and executables

### DIFF
--- a/analysis/bin/CMakeLists.txt
+++ b/analysis/bin/CMakeLists.txt
@@ -1,3 +1,9 @@
-add_executable(grain_analysis runGA.cpp)
-target_link_libraries(grain_analysis ExaGA)
-install(TARGETS grain_analysis DESTINATION ${CMAKE_INSTALL_BINDIR})
+add_executable(ExaCA-GrainAnalysis runGA.cpp)
+target_link_libraries(ExaCA-GrainAnalysis ExaCA-Analysis)
+install(TARGETS ExaCA-GrainAnalysis DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Symlink for backwards compatibility
+add_custom_target(grain_analysis ALL
+                  COMMAND ${CMAKE_COMMAND} -E create_symlink ExaCA-GrainAnalysis grain_analysis)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grain_analysis
+        DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/analysis/src/CMakeLists.txt
+++ b/analysis/src/CMakeLists.txt
@@ -3,17 +3,17 @@ file(GLOB EXAGA_SOURCES GLOB *.cpp)
 
 install(FILES ${EXAGA_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-add_library(ExaGA ${EXAGA_SOURCES})
-add_library(ExaCA::ExaGA ALIAS ExaGA)
+add_library(ExaCA-Analysis ${EXAGA_SOURCES})
+add_library(ExaCA::Analysis ALIAS ExaCA-Analysis)
 
-target_link_libraries(ExaGA PUBLIC ExaCA)
+target_link_libraries(ExaCA-Analysis PUBLIC ExaCA-Core)
 
-target_include_directories(ExaGA PUBLIC
+target_include_directories(ExaCA-Analysis PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
-install(TARGETS ExaGA
-  EXPORT ExaGA_Targets
+install(TARGETS ExaCA-Analysis
+  EXPORT ExaCA_Targets
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/analysis/unit_test/CMakeLists.txt
+++ b/analysis/unit_test/CMakeLists.txt
@@ -1,4 +1,4 @@
 include(${TEST_HARNESS_DIR}/test_harness.cmake)
 
-ExaCA_add_tests(PACKAGE ExaGA NAMES Utils KokkosUtils)
-ExaCA_add_tests(PACKAGE ExaGA NAMES RepresentativeRegion)
+ExaCA_add_tests(PACKAGE ExaCA-Analysis NAMES Utils KokkosUtils)
+ExaCA_add_tests(PACKAGE ExaCA-Analysis NAMES RepresentativeRegion)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_executable(ExaCA-Kokkos main.cpp)
-target_link_libraries(ExaCA-Kokkos ExaCA)
-install(TARGETS ExaCA-Kokkos DESTINATION ${CMAKE_INSTALL_BINDIR})
+add_executable(ExaCA run.cpp)
+target_link_libraries(ExaCA ExaCA-Core)
+install(TARGETS ExaCA DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,3 +1,9 @@
-add_executable(ExaCA run.cpp)
+add_executable(ExaCA main.cpp)
 target_link_libraries(ExaCA ExaCA-Core)
 install(TARGETS ExaCA DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Symlink for backwards compatibility
+add_custom_target(ExaCA-Kokkos ALL
+                  COMMAND ${CMAKE_COMMAND} -E create_symlink ExaCA ExaCA-Kokkos)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ExaCA-Kokkos
+        DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,21 +7,21 @@ install(FILES ${EXACA_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CAconfig.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-add_library(ExaCA ${EXACA_SOURCES})
-add_library(ExaCA::ExaCA ALIAS ExaCA)
+add_library(ExaCA-Core ${EXACA_SOURCES})
+add_library(ExaCA::Core ALIAS ExaCA-Core)
 
-target_link_libraries(ExaCA PUBLIC
+target_link_libraries(ExaCA-Core PUBLIC
     MPI::MPI_CXX
     Kokkos::kokkos
     nlohmann_json::nlohmann_json
 )
 
-target_include_directories(ExaCA PUBLIC
+target_include_directories(ExaCA-Core PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
-install(TARGETS ExaCA
+install(TARGETS ExaCA-Core
   EXPORT ExaCA_Targets
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -20,6 +20,6 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../examples/Materials/Inconel625_Quad
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../examples/Materials/SS316.json
   ${CMAKE_CURRENT_BINARY_DIR}/SS316.json COPYONLY)
 
-ExaCA_add_tests(PACKAGE ExaCA NAMES InterfacialResponse Inputs Orientation Parse Print)
+ExaCA_add_tests(PACKAGE ExaCA-Core NAMES InterfacialResponse Inputs Orientation Parse Print)
 
-ExaCA_add_tests(MPI PACKAGE ExaCA NAMES CellData Grid Interface Nucleation Temperature Update)
+ExaCA_add_tests(MPI PACKAGE ExaCA-Core NAMES CellData Grid Interface Nucleation Temperature Update)


### PR DESCRIPTION
Renames exe, but keeps symlinks for compatibility for now. Can choose different names if we want of course

Renames libraries without alias to old names

Closes #309 