### PR TITLE
Option to record solidification front undercooling for problem type C

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -112,6 +112,7 @@ The .json files in the examples subdirectory are provided on the command line to
 | PathToOutput | All                      | File path location for the output files
 | OutputFile   | All                      | All output files will begin with the string specified on this line
 | PrintBinary  | All                      | Whether or not ExaCA vtk output data should be printed as big endian binary data, or as ASCII characters (defaults to false)
+| PrintFrontUndercooling | C              | Whether or not ExaCA will store and print the undercooling at the solidification front when solidification begins and ends at each Z coordinate
 | PrintExaConstitSize | R                 | Length of the cubic representative volume element (RVE) data for ExaConstit, taken from the domain center in X and Y, and at the domain top in Z excluding the final layer's grain structure. If not given (or given a value of 0), the RVE will not be printed 
 | Intralayer   | All | Optional section for printing the state of the simulation during a given layer of a multilayer problem/during a single layer problem
 | Intralayer: Increment | All | Increment, in time steps, at which intermediate output should be printed. If 0, will only print the state of the system at the start of each layer

--- a/src/CAinputs.hpp
+++ b/src/CAinputs.hpp
@@ -122,6 +122,7 @@ struct PrintInputs {
     bool interlayer_number_of_solidification_events = false;
     // True if intralayer_undercooling_solidification_start or interlayer_undercooling_solidification_start is true
     bool store_solidification_start = false;
+    bool print_front_undercooling = false;
     // List of layers following which the interlayer fields should be printed (will always include final layer of
     // simulation)
     std::vector<int> print_layer_number;
@@ -459,6 +460,9 @@ struct Inputs {
         print.path_to_output = input_data["Printing"]["PathToOutput"];
         // Name of output data
         print.base_filename = input_data["Printing"]["OutputFile"];
+        if (simulation_type == "C")
+            if (input_data["Printing"].contains("PrintFrontUndercooling"))
+                print.print_front_undercooling = input_data["Printing"]["PrintFrontUndercooling"];
         // Should ASCII or binary be used to print vtk data? Defaults to ASCII if not given
         if (input_data["Printing"].contains("PrintBinary"))
             print.print_binary = input_data["Printing"]["PrintBinary"];
@@ -594,7 +598,7 @@ struct Inputs {
             }
             // Should starting undercooling for solidification be stored?
             if ((print.intralayer_undercooling_solidification_start) ||
-                (print.interlayer_undercooling_solidification_start))
+                (print.interlayer_undercooling_solidification_start) || (print.print_front_undercooling))
                 print.store_solidification_start = true;
         }
         if (id == 0)

--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -337,6 +337,9 @@ struct Print {
                 }
                 interlayer_all_layers_ofstream.close();
             }
+            // File of front undercooling at interfa
+            if (_inputs.print_front_undercooling)
+                temperature.writeFrontUndercooling(path_base_filename, id, grid);
 
             // Views where data should be printed only for the layer of the problem that just finished
             if (_inputs.interlayer_current) {
@@ -515,6 +518,20 @@ struct Print {
             if (!(_inputs.print_binary))
                 output_fstream << std::endl;
         }
+    }
+
+    // Called on rank 0 to write solidification undercooling data to a file
+    template <typename Print1DViewType>
+    void printSolidificationFrontUndercooling(const int nz, Print1DViewType front_undercooling) {
+
+        std::string front_undercooling_filename = path_base_filename + "_FrontUndercooling.csv";
+        std::ofstream und_ofstream;
+        und_ofstream.open(front_undercooling_filename);
+        for (int coord_z = 0; coord_z < nz - 1; coord_z++) {
+            und_ofstream << front_undercooling(coord_z) << std::endl;
+        }
+        und_ofstream << front_undercooling(nz - 1);
+        und_ofstream.close();
     }
 
     // On rank 0, print grain misorientation, 0-62 for epitaxial grains and 100-162 for nucleated grains, to a vtk

--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -530,8 +530,8 @@ struct Print {
         und_ofstream.open(front_undercooling_filename);
         und_ofstream << "Z (micrometers), Initial Undercooling, Final Undercooling" << std::endl;
         for (int coord_z = 0; coord_z < nz - 1; coord_z++) {
-            und_ofstream << coord_z * deltax * pow(10, 6) << "," << front_undercooling(coord_z, 0) << ","
-                         << front_undercooling(coord_z, 1) << std::endl;
+            und_ofstream << static_cast<double>(coord_z) * deltax * pow(10, 6) << "," << front_undercooling(coord_z, 0)
+                         << "," << front_undercooling(coord_z, 1) << std::endl;
         }
         und_ofstream << static_cast<double>(nz - 1) * deltax * pow(10, 6) << "," << front_undercooling(nz - 1, 0) << ","
                      << front_undercooling(nz - 1, 1);

--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -340,7 +340,8 @@ struct Print {
             // File of front undercooling at interface
             if (_inputs.print_front_undercooling) {
                 auto start_end_solidification_z = temperature.getFrontUndercoolingStartFinish(id, grid);
-                printSolidificationFrontUndercooling(grid.deltax, grid.nz, start_end_solidification_z);
+                if (id == 0)
+                    printSolidificationFrontUndercooling(grid.deltax, grid.nz, start_end_solidification_z);
             }
             // Views where data should be printed only for the layer of the problem that just finished
             if (_inputs.interlayer_current) {

--- a/src/CAtemperature.hpp
+++ b/src/CAtemperature.hpp
@@ -29,6 +29,7 @@ struct Temperature {
     using view_type_double_2d = Kokkos::View<double **, memory_space>;
     using view_type_float_3d = Kokkos::View<float ***, memory_space>;
     using view_type_int_host = typename view_type_int::HostMirror;
+    using view_type_float_host = typename view_type_float::HostMirror;
     using view_type_double_host = typename view_type_double::HostMirror;
     using view_type_double_2d_host = typename view_type_double_2d::HostMirror;
     using view_type_float_3d_host = typename view_type_float_3d::HostMirror;
@@ -602,6 +603,56 @@ struct Temperature {
     // undercooling reset to 0 and recalculated)
     void getCurrentLayerStartingUndercooling(std::pair<int, int> layer_range) {
         undercooling_solidification_start = Kokkos::subview(undercooling_solidification_start_all_layers, layer_range);
+    }
+
+    // For each Z coordinate, find the smallest undercooling at which solidification started and finished, writing this
+    // data to an output file
+    void writeFrontUndercooling(std::string path_base_filename, const int id, const Grid &grid) {
+        view_type_float start_solidification_z(Kokkos::ViewAllocateWithoutInitializing("start_solidification_z"),
+                                               grid.nz);
+        view_type_float end_solidification_z(Kokkos::ViewAllocateWithoutInitializing("end_solidification_z"), grid.nz);
+        auto _undercooling_solidification_start = undercooling_solidification_start;
+        auto _undercooling_current = undercooling_current;
+        Kokkos::parallel_for(
+            "GetMinUndercooling", grid.nz, KOKKOS_LAMBDA(const int &coord_z) {
+                float min_start_undercooling = Kokkos::Experimental::finite_max_v<float>;
+                float min_end_undercooling = Kokkos::Experimental::finite_max_v<float>;
+                for (int coord_x = 0; coord_x < grid.nx; coord_x++) {
+                    for (int coord_y = 1; coord_y < grid.ny_local - 1; coord_y++) {
+                        int index = grid.get1DIndex(coord_x, coord_y, coord_z);
+                        if (_undercooling_solidification_start(index) < min_start_undercooling)
+                            min_start_undercooling = _undercooling_solidification_start(index);
+                        if (_undercooling_current(index) < min_end_undercooling)
+                            min_end_undercooling = _undercooling_current(index);
+                    }
+                }
+                start_solidification_z(coord_z) = min_start_undercooling;
+                end_solidification_z(coord_z) = min_end_undercooling;
+            });
+
+        // Rank 0 - collect min values from all ranks to get the global start/end solidification undercoolings
+        view_type_float start_solidification_z_reduced(
+            Kokkos::ViewAllocateWithoutInitializing("start_solidification_z_red"), grid.nz);
+        view_type_float end_solidification_z_reduced(
+            Kokkos::ViewAllocateWithoutInitializing("end_solidification_z_red"), grid.nz);
+        MPI_Reduce(start_solidification_z.data(), start_solidification_z_reduced.data(), grid.nz, MPI_FLOAT, MPI_MIN, 0,
+                   MPI_COMM_WORLD);
+        MPI_Reduce(end_solidification_z.data(), end_solidification_z_reduced.data(), grid.nz, MPI_FLOAT, MPI_MIN, 0,
+                   MPI_COMM_WORLD);
+        auto start_z_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), start_solidification_z_reduced);
+        auto end_z_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), end_solidification_z_reduced);
+        // Rank 0 - write to file
+        if (id == 0) {
+            std::string frontfilename = path_base_filename + "_FrontUndercooling.csv";
+            std::ofstream frontofstream;
+            frontofstream.open(frontfilename);
+            frontofstream << "Z (micrometers), Initial Undercooling, Final Undercooling" << std::endl;
+            for (int coord_z = 0; coord_z < grid.nz; coord_z++) {
+                frontofstream << grid.deltax * coord_z * pow(10, 6) << ", " << start_z_host(coord_z) << ", "
+                              << end_z_host(coord_z) << std::endl;
+            }
+            frontofstream.close();
+        }
     }
 
     // Reset local cell undercooling (and if needed, the cell's starting undercooling) to 0

--- a/src/CAtemperature.hpp
+++ b/src/CAtemperature.hpp
@@ -615,8 +615,9 @@ struct Temperature {
         view_type_float end_solidification_z(Kokkos::ViewAllocateWithoutInitializing("end_solidification_z"), grid.nz);
         auto _undercooling_solidification_start = undercooling_solidification_start;
         auto _undercooling_current = undercooling_current;
+        auto policy = Kokkos::RangePolicy<execution_space>(0, grid.nz);
         Kokkos::parallel_for(
-            "GetMinUndercooling", grid.nz, KOKKOS_LAMBDA(const int &coord_z) {
+            "GetMinUndercooling", policy, KOKKOS_LAMBDA(const int &coord_z) {
                 float min_start_undercooling = Kokkos::Experimental::finite_max_v<float>;
                 float min_end_undercooling = Kokkos::Experimental::finite_max_v<float>;
                 for (int coord_x = 0; coord_x < grid.nx; coord_x++) {
@@ -637,6 +638,8 @@ struct Temperature {
             Kokkos::ViewAllocateWithoutInitializing("start_solidification_z_red"), grid.nz);
         view_type_float end_solidification_z_reduced(
             Kokkos::ViewAllocateWithoutInitializing("end_solidification_z_red"), grid.nz);
+        // Could potentially perform these reductions on the 2D view storing both start and end values, but depends on
+        // 2D view data layout
         MPI_Reduce(start_solidification_z.data(), start_solidification_z_reduced.data(), grid.nz, MPI_FLOAT, MPI_MIN, 0,
                    MPI_COMM_WORLD);
         MPI_Reduce(end_solidification_z.data(), end_solidification_z_reduced.data(), grid.nz, MPI_FLOAT, MPI_MIN, 0,


### PR DESCRIPTION
Optionally prints a separate file consisting of "Z (µm), undercooling start, undercooling end" values for the leading edge of the solidification front for directional solidification simulations