### PR TITLE
Additional customization of problem type C substrate init

### DIFF
--- a/examples/Inp_SmallDirSolidification.json
+++ b/examples/Inp_SmallDirSolidification.json
@@ -20,7 +20,7 @@
       "R": 300000
    },
    "Substrate": {
-      "FractionSurfaceSitesActive": 0.25
+      "SurfaceSiteDensity": 0.25
    },
    "Printing": {
       "PathToOutput": "./",

--- a/examples/README.md
+++ b/examples/README.md
@@ -90,10 +90,11 @@ The .json files in the examples subdirectory are provided on the command line to
 ## Substrate inputs
 | Input        | Relevant problem type(s))| Details |
 |--------------| -------------------------|---------|
-|FractionSurfaceSitesActive | C           | What fraction of cells at the bottom surface of the domain are the source of a grain? (see note (b))
-|GrainLocationsX | C           | List of grain locations in X on the bottom surface of the domain (see note (b))
-|GrainLocationsY | C           | List of grain locations in Y on the bottom surface of the domain (see note (b))
-|GrainIDs | C           | GrainID values for each grain in (X,Y) (see note (b))
+|FractionSurfaceSitesActive | C           | What fraction of cells at the bottom surface of the domain are the source of a grain? (see note (b-i))
+|SurfaceSiteDensity         | C           | Density, in nuclei/µm^2, of grains at the bottom surface of the domain (see note (b-ii))
+|GrainLocationsX | C           | List of grain locations in X on the bottom surface of the domain (see note (b-iii))
+|GrainLocationsY | C           | List of grain locations in Y on the bottom surface of the domain (see note (b-iii))
+|GrainIDs | C           | GrainID values for each grain in (X,Y) (see note (b3))
 |FillBottomSurface | C  | Optionally assign all cells on the bottom surface the grain ID of the closest grain (defaults to false)
 |MeanSize      | Spot, R                  | Mean spacing between grain centers in the baseplate/substrate (in microns) (see note (a))
 |SubstrateFilename |  Spot, R             | Path to and filename for substrate data (see note (a))
@@ -103,7 +104,7 @@ The .json files in the examples subdirectory are provided on the command line to
 |GrainOrientation | SingleGrain           | Which orientation from the orientation's file is assigned to the grain (starts at 0). Default is 0 
 
 (a) One of these inputs must be provided, but not both
-(b) If GrainLocationsX, GrainLocationsY, and GrainIDs are provided, FractionSurfaceSitesActive should not be given. Conversely, if FractionSurfaceSitesActive is not given, each of GrainLocationsX, GrainLocationsY, and GrainIDs must be provided
+(b) These represent 3 different ways of initializing the interface. Only the inputs corresponding to one mode (i, ii, or iii) should be given. Mode (i) assigns a GrainID value to randomly selected cells at the domain's bottom surface according to the input fixed fraction of sites active. However, this does not guarantee the same grains to be at the same physical (x,y) location if the cell size or domain size are changed. Mode (ii) determines a number of grains based on the input density, and assigns physical (x,y) locations. As only one GrainID per cell is allowed, a large density with a large cell size may lead to underresolution of the desired density - however, this approach does guarantee that the same grains will be initialized at the same physical (x,y) locations in the simulation with changes to cell size or domain size. Mode (iii) requires 3 inputs and allows manual initialization of the substrate with of lists of cell coordinates in X, cell coordinates in Y, and GrainID values.
 
 ## Printing inputs
 | Input        | Relevant problem type(s))| Details |

--- a/src/CAcelldata.hpp
+++ b/src/CAcelldata.hpp
@@ -93,31 +93,56 @@ struct CellData {
     }
 
     // Get the X, Y coordinates and grain ID values for grains at the bottom surface for problem type C
-    view_type_int_2d_host getSurfaceActiveCellData(int &substrate_act_cells, const int nx, const int ny,
+    view_type_int_2d_host getSurfaceActiveCellData(int &substrate_act_cells, const Grid &grid,
                                                    const unsigned long rng_seed) {
-        // First get number of substrate grains
-        if (_inputs.custom_grain_locations_ids)
+
+        // Number of cells at the bottom surface that could potentially be assigned GrainID values
+        const int bottom_surface_size = grid.nx * grid.ny;
+
+        // First get number of substrate grains for each initialization condition
+        if (_inputs.surface_init_mode == "FractionSurfaceSitesActive")
+            substrate_act_cells = Kokkos::round(_inputs.fract_surface_sites_active * bottom_surface_size);
+        else if (_inputs.surface_init_mode == "SurfaceSiteDensity")
+            substrate_act_cells =
+                Kokkos::round(_inputs.surface_site_density * static_cast<double>(bottom_surface_size) * grid.deltax *
+                              grid.deltax * pow(10, 12));
+        if (_inputs.surface_init_mode == "Custom")
             substrate_act_cells = _inputs.grain_locations_x.size();
-        else
-            substrate_act_cells = Kokkos::round(_inputs.fract_surface_sites_active * nx * ny);
+
         // View for storing surface grain locations and IDs
         view_type_int_2d_host act_cell_data_host(Kokkos::ViewAllocateWithoutInitializing("ActCellData_Host"),
                                                  substrate_act_cells, 3);
-        if (_inputs.custom_grain_locations_ids) {
-            // Values were already given in the inputs struct, copy these to the view
+        if (_inputs.surface_init_mode == "FractionSurfaceSitesActive") {
+            // Fraction of surface sites active was given - ensure the appropriate number of cells are assigned
+            // GrainIDs. Note that the physical locations of these sites (x,y) will vary based on the domain size/cell
+            // size Create list of grain IDs and shuffle - leave 0s for cells without substrate grains
+            std::vector<int> grain_locations_1d(bottom_surface_size, 0);
             for (int n = 0; n < substrate_act_cells; n++) {
-                act_cell_data_host(n, 0) = _inputs.grain_locations_x[n];
-                act_cell_data_host(n, 1) = _inputs.grain_locations_y[n];
-                act_cell_data_host(n, 2) = _inputs.grain_ids[n];
+                grain_locations_1d[n] = n + 1; // grain ID for epitaxial seeds must be > 0
+            }
+            std::mt19937_64 gen(rng_seed);
+            std::shuffle(grain_locations_1d.begin(), grain_locations_1d.end(), gen);
+            // Fill act_cell_data_host with the non-zero grain IDs and their associated X and Y based on the position in
+            // the 1D vector
+            int act_cell_count = 0;
+            for (int n = 0; n < bottom_surface_size; n++) {
+                if (grain_locations_1d[n] != 0) {
+                    act_cell_data_host(act_cell_count, 0) = grid.getCoordXGlobal(n);
+                    act_cell_data_host(act_cell_count, 1) = grid.getCoordYGlobal(n);
+                    act_cell_data_host(act_cell_count, 2) = grain_locations_1d[n];
+                    act_cell_count++;
+                }
             }
         }
-        else {
+        else if (_inputs.surface_init_mode == "SurfaceSiteDensity") {
             // Calls to Xdist(gen) and Y dist(gen) return random locations for grain seeds
             // Since X = 0 and X = nx-1 are the cell centers of the last cells in X, locations are evenly scattered
-            // between X = -0.49999 and X = nx - 0.5, as the cells have a half width of 0.5
+            // between X = -0.49999 and X = nx - 0.5, as the cells have a half width of 0.5. Note that if the number of
+            // grains is large compared to the number of cells, multiple grain IDs may be assigned to one cell and the
+            // total density will be underestimated on the given grid
             std::mt19937_64 gen(rng_seed);
-            std::uniform_real_distribution<double> x_dist(-0.49999, nx - 0.5);
-            std::uniform_real_distribution<double> y_dist(-0.49999, ny - 0.5);
+            std::uniform_real_distribution<double> x_dist(-0.49999, grid.nx - 0.5);
+            std::uniform_real_distribution<double> y_dist(-0.49999, grid.ny - 0.5);
             // Randomly locate substrate grain seeds for cells in the interior of this subdomain (at the k = 0 bottom
             // surface)
             for (int n = 0; n < substrate_act_cells; n++) {
@@ -127,6 +152,14 @@ struct CellData {
                 act_cell_data_host(n, 0) = Kokkos::round(x_location);
                 act_cell_data_host(n, 1) = Kokkos::round(y_location);
                 act_cell_data_host(n, 2) = n + 1; // grain ID for epitaxial seeds must be > 0
+            }
+        }
+        else if (_inputs.surface_init_mode == "Custom") {
+            // Values were already given in the inputs struct, copy these to the view
+            for (int n = 0; n < substrate_act_cells; n++) {
+                act_cell_data_host(n, 0) = _inputs.grain_locations_x[n];
+                act_cell_data_host(n, 1) = _inputs.grain_locations_y[n];
+                act_cell_data_host(n, 2) = _inputs.grain_ids[n];
             }
         }
         return act_cell_data_host;
@@ -140,8 +173,7 @@ struct CellData {
         // TODO: Could generate random numbers on GPU, instead of using host view and copying over - but would also need
         // inputs struct to store device data for grain locations in X, Y, and GrainIDs
         int substrate_act_cells;
-        view_type_int_2d_host act_cell_data_host =
-            getSurfaceActiveCellData(substrate_act_cells, grid.nx, grid.ny, rng_seed);
+        view_type_int_2d_host act_cell_data_host = getSurfaceActiveCellData(substrate_act_cells, grid, rng_seed);
         // Copy views of substrate grain locations and IDs back to the device
         auto act_cell_data = Kokkos::create_mirror_view_and_copy(memory_space(), act_cell_data_host);
 

--- a/unit_test/tstCellData.hpp
+++ b/unit_test/tstCellData.hpp
@@ -79,7 +79,7 @@ void testCellDataInit_SingleGrain() {
     }
 }
 
-void testCellDataInit_ConstrainedGrowthMultiGrain() {
+void testCellDataInit_Constrained_Automatic(std::string input_surface_init_mode) {
 
     using memory_space = TEST_MEMSPACE;
 
@@ -92,11 +92,20 @@ void testCellDataInit_ConstrainedGrowthMultiGrain() {
     // Empty inputs and grid struct
     Inputs inputs;
     Grid grid;
+    inputs.substrate.surface_init_mode = input_surface_init_mode;
+    if (input_surface_init_mode == "SurfaceSiteDensity") {
+        // Set so that there are 4 grains in the domain, regardless of domain size
+        inputs.substrate.surface_site_density = 1.0 / (4.0 * static_cast<double>(np));
+    }
+    else {
+        // Set half of sites active, number of grains will depend on domain size
+        inputs.substrate.fract_surface_sites_active = 0.25;
+    }
     // Create test data
     grid.nz = 2;
     grid.z_layer_bottom = 0;
     grid.nz_layer = 2;
-    grid.nx = 1;
+    grid.nx = 4;
     grid.deltax = 1 * pow(10, -6);
     grid.z_max_layer(0) = (grid.nz - 1) * grid.deltax;
     // Domain size in Y depends on the number of ranks - each rank has 4 cells in Y
@@ -107,8 +116,6 @@ void testCellDataInit_ConstrainedGrowthMultiGrain() {
     grid.domain_size = grid.nx * grid.ny_local * grid.nz_layer;
     grid.domain_size_all_layers = grid.nx * grid.ny_local * grid.nz;
 
-    // Set fract surface cells active to 0.5
-    inputs.substrate.fract_surface_sites_active = 0.5;
     // Construct celldata struct
     CellData<memory_space> celldata(grid.domain_size, grid.domain_size_all_layers, inputs.substrate);
     // Check appropriate initialization of celldata input
@@ -119,6 +126,12 @@ void testCellDataInit_ConstrainedGrowthMultiGrain() {
     auto cell_type_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), celldata.cell_type);
     auto grain_id_all_layers_host =
         Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), celldata.grain_id_all_layers);
+    int max_expected_grain_id;
+    if (input_surface_init_mode == "SurfaceSiteDensity")
+        max_expected_grain_id = 5;
+    else
+        max_expected_grain_id = 4 * np + 1;
+
     for (int index = 0; index < grid.domain_size; index++) {
         if (index >= grid.nx * grid.ny_local) {
             // Not at bottom surface - should be liquid cells with GrainID still equal to 0
@@ -126,11 +139,11 @@ void testCellDataInit_ConstrainedGrowthMultiGrain() {
             EXPECT_EQ(cell_type_host(index), Liquid);
         }
         else {
-            // Check that active cells have GrainIDs > 0, and less than 2 * np + 1 (there are 2 * np different positive
-            // GrainIDs used for epitaxial grain seeds)
+            // Check that active cells have GrainIDs > 0, and less than max_expected_grain_id (GrainIDs 1 through
+            // max_expected_grain_id-1 should've been used)
             if (cell_type_host(index) == FutureActive) {
                 EXPECT_GT(grain_id_all_layers_host(index), 0);
-                EXPECT_LT(grain_id_all_layers_host(index), 2 * np + 1);
+                EXPECT_LT(grain_id_all_layers_host(index), max_expected_grain_id);
             }
             else {
                 // Liquid cells should still have GrainID = 0
@@ -140,7 +153,7 @@ void testCellDataInit_ConstrainedGrowthMultiGrain() {
     }
 }
 
-void testCellDataInit_ConstrainedGrowthTwoGrain() {
+void testCellDataInit_Constrained_Custom() {
 
     using memory_space = TEST_MEMSPACE;
 
@@ -435,8 +448,9 @@ void testCalcVolFractionNucleated() {
 //---------------------------------------------------------------------------//
 TEST(TEST_CATEGORY, cell_init_tests) {
     testCellDataInit_SingleGrain();
-    testCellDataInit_ConstrainedGrowthMultiGrain();
-    testCellDataInit_ConstrainedGrowthTwoGrain();
+    testCellDataInit_Constrained_Automatic("SurfaceSiteDensity");
+    testCellDataInit_Constrained_Automatic("FractionSurfaceSitesActive");
+    testCellDataInit_Constrained_Custom();
     // For non-constrained solidification problems, test w/ and w/o space left for powder layer
     testCellDataInit(true);
     testCellDataInit(false);

--- a/unit_test/tstInputs.hpp
+++ b/unit_test/tstInputs.hpp
@@ -154,7 +154,7 @@ void testInputs(int print_version) {
             if (filename == input_filenames[0]) {
                 EXPECT_DOUBLE_EQ(inputs.substrate.fract_surface_sites_active, 0.08);
                 EXPECT_TRUE(inputs.print.base_filename == "TestProblemDirS");
-                EXPECT_FALSE(inputs.substrate.custom_grain_locations_ids);
+                EXPECT_TRUE(inputs.substrate.surface_init_mode == "FractionSurfaceSitesActive");
                 EXPECT_DOUBLE_EQ(inputs.temperature.init_undercooling, 0.0);
             }
             else {
@@ -165,7 +165,7 @@ void testInputs(int print_version) {
                 EXPECT_EQ(inputs.substrate.grain_locations_y[1], 150);
                 EXPECT_EQ(inputs.substrate.grain_ids[1], 9936);
                 EXPECT_TRUE(inputs.print.base_filename == "TestProblemTwoGrainDirS");
-                EXPECT_TRUE(inputs.substrate.custom_grain_locations_ids);
+                EXPECT_TRUE(inputs.substrate.surface_init_mode == "Custom");
                 EXPECT_DOUBLE_EQ(inputs.temperature.init_undercooling, 10.0);
             }
             EXPECT_TRUE(inputs.print.intralayer);


### PR DESCRIPTION
Options to initialize bottom surface for problem type C using either
- Fraction of sites active: guarantees that each grain is assigned a cell, but the grain locations will change if the domain size is changed) 
Or
- Density of grains: guarantees that grains are placed in the same locations even if the cell size is changed as long as the bottom surface size and proportions remain the same, but some grains will not be assigned a cell if the density is too large to resolve for the given cell size