### PR TITLE
Option for custom initial octahedron size

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -101,6 +101,7 @@ The .json files in the examples subdirectory are provided on the command line to
 |ExtendSubstrateThroughPowder| R          | true/false value: Whether to use the baseplate microstructure as the boundary condition for the entire height of the simulation (defaults to false) (see note (a))
 | BaseplateTopZ   | R                     | The Z coordinate that marks the top of the baseplate/boundary of the baseplate with the powder. If not given, Z = 0 microns will be assumed to be the baseplate top if ExtendSubstrateThroughPowder = false (If ExtendSubstrateThroughPowder = true, the entire domain will be initialized with the baseplate grain structure)
 |GrainOrientation | SingleGrain           | Which orientation from the orientation's file is assigned to the grain (starts at 0). Default is 0 
+|InitOctahedronSize | All           | Initial size of the octahedra that represent the solid-liquid interface when solidifiation first begins locally. Given as a fraction of a cell size, must be at least 0 and smaller than 1. Default is 0.01
 
 (a) One of these inputs must be provided, but not both
 (b) If GrainLocationsX, GrainLocationsY, and GrainIDs are provided, FractionSurfaceSitesActive should not be given. Conversely, if FractionSurfaceSitesActive is not given, each of GrainLocationsX, GrainLocationsY, and GrainIDs must be provided

--- a/src/CAinputs.hpp
+++ b/src/CAinputs.hpp
@@ -65,6 +65,8 @@ struct SubstrateInputs {
     double powder_active_fraction = 1.0;
     // Top of baseplate assumed at Z = 0 if not otherwise given
     double baseplate_top_z = 0.0;
+    // Initial size of octahedra during initialization of an active cell
+    float init_oct_size = 0.01;
 };
 
 struct PrintInputs {
@@ -367,6 +369,12 @@ struct Inputs {
                     throw std::runtime_error(
                         "Error: if the option to extend the baseplate through the powder layers is "
                         "toggled, a powder layer density cannot be given");
+            }
+            // Optional input for initial size of octhedra when a cell begins solidification (in units of CA cells)
+            if (input_data["Substrate"].contains("InitOctahedronSize")) {
+                substrate.init_oct_size = input_data["Substrate"]["InitOctahedronSize"];
+                if ((substrate.init_oct_size < 0.0) || (substrate.init_oct_size >= 1.0))
+                    throw std::runtime_error("Error: InitOctahedronSize should be at least 0, and less than 1");
             }
         }
 

--- a/src/CAinterface.hpp
+++ b/src/CAinterface.hpp
@@ -43,6 +43,8 @@ struct Interface {
     view_type_buffer buffer_south_send, buffer_north_send, buffer_south_recv, buffer_north_recv;
     view_type_int send_size_south, send_size_north, steering_vector, num_steer;
     view_type_int_host send_size_south_host, send_size_north_host, num_steer_host;
+    // Initial size of new octahedra
+    float _init_oct_size;
 
     // Neighbor lists
     neighbor_list_type neighbor_x, neighbor_y, neighbor_z;
@@ -52,7 +54,7 @@ struct Interface {
 
     // Constructor for views and view bounds for current layer
     // Use default initialization to 0 for num_steer_host and num_steer and buffer counts
-    Interface(const int id, const int domain_size, const int buf_size_initial_estimate = 25,
+    Interface(const int id, const int domain_size, const float init_oct_size, const int buf_size_initial_estimate = 25,
               const int buf_components_temp = 8)
         : diagonal_length(view_type_float(Kokkos::ViewAllocateWithoutInitializing("diagonal_length"), domain_size))
         , octahedron_center(
@@ -73,7 +75,8 @@ struct Interface {
         , num_steer(view_type_int("steering_vector_size", 1))
         , send_size_south_host(view_type_int_host("send_size_south_host", 1))
         , send_size_north_host(view_type_int_host("send_size_north_host", 1))
-        , num_steer_host(view_type_int_host("steering_vector_size_host", 1)) {
+        , num_steer_host(view_type_int_host("steering_vector_size_host", 1))
+        , _init_oct_size(init_oct_size) {
 
         // Set initial buffer size to the estimate
         buf_size = buf_size_initial_estimate;
@@ -188,7 +191,7 @@ struct Interface {
     KOKKOS_INLINE_FUNCTION
     void createNewOctahedron(const int index, const int coord_x, const int coord_y, const int y_offset,
                              const int coord_z) const {
-        diagonal_length(index) = 0.01;
+        diagonal_length(index) = _init_oct_size;
         octahedron_center(3 * index) = coord_x + 0.5;
         octahedron_center(3 * index + 1) = coord_y + y_offset + 0.5;
         octahedron_center(3 * index + 2) = coord_z + 0.5;

--- a/src/runCA.cpp
+++ b/src/runCA.cpp
@@ -63,7 +63,7 @@ void runExaCA(int id, int np, std::string input_file) {
 
     // Variables characterizing the active cell region within each rank's grid, including buffers for ghost node data
     // (fixed size) and the steering vector/steering vector size on host/device
-    Interface<memory_space> interface(id, grid.domain_size);
+    Interface<memory_space> interface(id, grid.domain_size, inputs.substrate.init_oct_size);
     MPI_Barrier(MPI_COMM_WORLD);
 
     // Nucleation data structure, containing views of nuclei locations, time steps, and ids, and nucleation event

--- a/unit_test/tstInterface.hpp
+++ b/unit_test/tstInterface.hpp
@@ -98,7 +98,7 @@ void testHaloUpdate() {
     // Interface struct
     // Initial size large enough to hold all data
     int buf_size_initial_estimate = grid.nx * grid.nz_layer;
-    Interface<memory_space> interface(id, grid.domain_size, buf_size_initial_estimate);
+    Interface<memory_space> interface(id, grid.domain_size, 0.01, buf_size_initial_estimate);
     // Copy to host for initialization
     auto diagonal_length_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), interface.diagonal_length);
     auto octahedron_center_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), interface.octahedron_center);
@@ -282,7 +282,7 @@ void testResizeRefillBuffers() {
 
     // Interface struct - set buffer size to 1
     int buf_size_initial_estimate = 1;
-    Interface<memory_space> interface(id, grid.domain_size, buf_size_initial_estimate);
+    Interface<memory_space> interface(id, grid.domain_size, 0.01, buf_size_initial_estimate);
 
     // Start with 2 cells in the current layer active (one in each buffer), GrainID equal to the X coordinate, Diagonal
     // length equal to the Y coordinate, octahedron center at (x + 0.5, y + 0.5, z + 0.5)
@@ -450,7 +450,7 @@ void testResizeBuffers() {
     int domain_size = 50;
     int buf_size_initial_estimate = 50;
     // Init buffers to large size
-    Interface<memory_space> interface(id, domain_size, 50);
+    Interface<memory_space> interface(id, domain_size, 0.01, 50);
 
     // Fill buffers with test data
     Kokkos::parallel_for(
@@ -540,7 +540,7 @@ void testFillSteeringVector_Remelt() {
     // Interface struct
     int id;
     MPI_Comm_rank(MPI_COMM_WORLD, &id);
-    Interface<memory_space> interface(id, grid.domain_size);
+    Interface<memory_space> interface(id, grid.domain_size, 0.01);
 
     int numcycles = 15;
     for (int cycle = 1; cycle <= numcycles; cycle++) {
@@ -629,7 +629,7 @@ void testCalcCritDiagonalLength() {
     // Initialize interface struct
     int id;
     MPI_Comm_rank(MPI_COMM_WORLD, &id);
-    Interface<memory_space> interface(id, domain_size);
+    Interface<memory_space> interface(id, domain_size, 0.01);
 
     // Load octahedron centers into test view
     view_type octahedron_center_test(Kokkos::ViewAllocateWithoutInitializing("DOCenter"), 3 * domain_size);
@@ -684,7 +684,7 @@ void testCreateNewOctahedron() {
     // Create interface struct
     int id;
     MPI_Comm_rank(MPI_COMM_WORLD, &id);
-    Interface<memory_space> interface(id, grid.domain_size);
+    Interface<memory_space> interface(id, grid.domain_size, 0.01);
 
     // Octahedra now use the layer coordinates, not the coordinates of the multilayer domain
     for (int coord_z = 0; coord_z < grid.nz_layer; coord_z++) {

--- a/unit_test/tstNucleation.hpp
+++ b/unit_test/tstNucleation.hpp
@@ -266,7 +266,7 @@ void testNucleateGrain() {
     nucleation.nuclei_grain_id = Kokkos::create_mirror_view_and_copy(TEST_MEMSPACE(), nuclei_grain_id_host);
 
     // Interface struct
-    Interface<memory_space> interface(id, grid.domain_size);
+    Interface<memory_space> interface(id, grid.domain_size, 0.01);
     // Take enough time steps such that every nucleation event has a chance to occur
     for (int cycle = 0; cycle < 10; cycle++) {
         nucleation.nucleateGrain(cycle, grid, celldata, interface);


### PR DESCRIPTION
Defaults to the previously used value of 0.01 - but the option to select an initial size allows for better comparisons when changing cell sizes (for example, a size of 0.01 could be used with a cell size of 1 µm, and a size of 0.005 could be used with a cell size of 2 µm)