### PR TITLE
fixup: Reset counter to print time for each layer

### DIFF
--- a/src/CAtimers.hpp
+++ b/src/CAtimers.hpp
@@ -22,6 +22,7 @@ class Timer {
         _time += MPI_Wtime() - start_time;
         num_calls++;
     }
+    void reset() { _time = 0.0; }
     auto time() { return _time; }
     auto numCalls() { return num_calls; }
     auto minTime() { return max_time; }
@@ -99,6 +100,7 @@ struct Timers {
         if (id == 0)
             std::cout << "Time for layer number " << layernumber << " was " << layer.time() << " s, starting layer "
                       << layernumber + 1 << std::endl;
+        layer.reset();
     }
     void stopLayer() {
         layer.stop();


### PR DESCRIPTION
Only the time from the previous layer (not the cumulative runtime of all layers) is printed at the conclusion of said layer for multilayer problems. Fixup of #298 