### PR TITLE
Outer steering vector

### DIFF
--- a/examples/Inp_TwoLineTwoLayer.json
+++ b/examples/Inp_TwoLineTwoLayer.json
@@ -3,6 +3,7 @@
    "MaterialFileName": "Inconel625.json",
    "GrainOrientationFile": "GrainOrientationVectors.csv",
    "RandomSeed": 0,
+   "SteeringVectorRebuildFrequency": 5000,
    "Domain": {
        "CellSize": 2.5,
        "TimeStep": 0.0825,

--- a/examples/README.md
+++ b/examples/README.md
@@ -55,6 +55,7 @@ The .json files in the examples subdirectory are provided on the command line to
 | MaterialFileName       | Name of material file in examples/Materials used
 | GrainOrientationFile   | File listing rotation matrix components used in assigning orientations to grains ([see below](#substrate-inputs))
 | RandomSeed             | Value of type double used as the seed to generate baseplate, powder, and nuclei details (default value is 0.0 if not provided)
+| SteeringVectorRebuildFrequency | Used for problem types `Spot`, `FromFile`, and `FromFinch`, this is the number of time steps between rebuilding of the steering vector listing cells that will undergo a future type transition (default value is 5000 if not provided). Depending on the solidification rate in the problem of interest, tuning this may lead to small performance improvements
 | Domain                 | Section for parameters that describe the simulation domain for the given problem type ([see below](#domain-inputs))
 | Nucleation             | Section for parameters that describe nucleation ([see below](#nucleation-inputs))
 | TemperatureData        | Section for parameters/files governing the temperature field for the given problem type ([see below](#temperature-inputs)). Section is unused if temperature data is given from Finch

--- a/src/CAinputs.hpp
+++ b/src/CAinputs.hpp
@@ -26,6 +26,7 @@ struct Inputs {
 
     std::string simulation_type = "", material_filename = "", grain_orientation_file = "";
     unsigned long rng_seed = 0.0;
+    int build_increment_outer = 5000;
     DomainInputs domain;
     NucleationInputs nucleation;
     InterfacialResponseInputs irf;
@@ -84,6 +85,9 @@ struct Inputs {
         // Seed for random number generator (defaults to 0 if not given)
         if (input_data.contains("RandomSeed"))
             rng_seed = input_data["RandomSeed"];
+        // Increment for resizing the outer steering vector used to iterate over cells of interest each time step
+        if (input_data.contains("SteeringVectorIncrement"))
+            build_increment_outer = input_data["SteeringVectorIncrement"];
 
         // Domain inputs:
         // Cell size - given in meters, stored in micrometers

--- a/src/CAinputs.hpp
+++ b/src/CAinputs.hpp
@@ -86,8 +86,8 @@ struct Inputs {
         if (input_data.contains("RandomSeed"))
             rng_seed = input_data["RandomSeed"];
         // Increment for resizing the outer steering vector used to iterate over cells of interest each time step
-        if (input_data.contains("SteeringVectorIncrement"))
-            build_increment_outer = input_data["SteeringVectorIncrement"];
+        if (input_data.contains("SteeringVectorRebuildFrequency"))
+            build_increment_outer = input_data["SteeringVectorRebuildFrequency"];
 
         // Domain inputs:
         // Cell size - given in meters, stored in micrometers

--- a/src/CAinterface.hpp
+++ b/src/CAinterface.hpp
@@ -40,13 +40,16 @@ struct Interface {
     int buf_size, buf_components;
     view_type_float diagonal_length, octahedron_center, crit_diagonal_length;
     view_type_buffer buffer_south_send, buffer_north_send, buffer_south_recv, buffer_north_recv;
-    view_type_int send_size_south, send_size_north, steering_vector, num_steer;
-    view_type_int_host send_size_south_host, send_size_north_host, num_steer_host;
+    view_type_int send_size_south, send_size_north, steering_vector, steering_vector_outer, num_steer, num_steer_outer;
+    view_type_int_host send_size_south_host, send_size_north_host, num_steer_host, num_steer_outer_host;
     // Initial size of new octahedra
     float _init_oct_size;
 
     // Neighbor lists
     neighbor_list_type neighbor_x, neighbor_y, neighbor_z;
+
+    // Increment to rebuild outer steering vector
+    int build_increment_outer;
 
     // Parallel dispatch tags.
     struct RefillBuffersTag {};
@@ -54,7 +57,7 @@ struct Interface {
     // Constructor for views and view bounds for current layer
     // Use default initialization to 0 for num_steer_host and num_steer and buffer counts
     Interface(const int id, const int domain_size, const float init_oct_size, const int buf_size_initial_estimate = 25,
-              const int buf_components_temp = 8)
+              const int buf_components_temp = 8, const int build_increment_outer_input = 5000)
         : diagonal_length(view_type_float(Kokkos::ViewAllocateWithoutInitializing("diagonal_length"), domain_size))
         , octahedron_center(
               view_type_float(Kokkos::ViewAllocateWithoutInitializing("octahedron_center"), 3 * domain_size))
@@ -71,11 +74,16 @@ struct Interface {
         , send_size_south(view_type_int("send_size_south", 1))
         , send_size_north(view_type_int("send_size_north", 1))
         , steering_vector(view_type_int(Kokkos::ViewAllocateWithoutInitializing("steering_vector"), domain_size))
+        , steering_vector_outer(
+              view_type_int(Kokkos::ViewAllocateWithoutInitializing("steering_vector_outer"), domain_size))
         , num_steer(view_type_int("steering_vector_size", 1))
+        , num_steer_outer(view_type_int("outer_steering_vector_size", 1))
         , send_size_south_host(view_type_int_host("send_size_south_host", 1))
         , send_size_north_host(view_type_int_host("send_size_north_host", 1))
         , num_steer_host(view_type_int_host("steering_vector_size_host", 1))
-        , _init_oct_size(init_oct_size) {
+        , num_steer_outer_host(view_type_int_host("outer_steering_vector_size_host", 1))
+        , _init_oct_size(init_oct_size)
+        , build_increment_outer(build_increment_outer_input) {
 
         // Set initial buffer size to the estimate
         buf_size = buf_size_initial_estimate;

--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -45,6 +45,35 @@ void fillSteeringVector_NoRemelt(const int cycle, const Grid &grid, CellData<Mem
     Kokkos::deep_copy(interface.num_steer_host, interface.num_steer);
 }
 
+// Build an "outer" steering vector for cells that will undergo some transition in the next build_increment_outer time
+// steps, which will be iterated over in the other steering vector
+template <typename MemorySpace>
+void fillOuterSteeringVector_Remelt(const int cycle, const int domain_size, CellData<MemorySpace> &celldata,
+                                    Temperature<MemorySpace> &temperature, Interface<MemorySpace> &interface) {
+
+    // Reset outer steering vector size to 0 on device
+    Kokkos::deep_copy(interface.num_steer_outer, 0);
+    // Add any cells that are currently liquid or active, or any temporarily solid cells that will melt within the next
+    // build_increment_outer time steps, to the outer steering vector
+    Kokkos::parallel_for(
+        "FillOuterSV_RM", domain_size, KOKKOS_LAMBDA(const int &index) {
+            int celltype = celldata.cell_type(index);
+            if ((celltype == Active) || (celltype == Liquid) ||
+                ((celltype == TempSolid) &&
+                 (temperature.getMeltTimeStep(cycle, index) < cycle + interface.build_increment_outer)))
+                interface.steering_vector_outer(Kokkos::atomic_fetch_add(&interface.num_steer_outer(0), 1)) = index;
+        });
+    Kokkos::fence();
+
+    // Copy size of outer steering vector (containing positions of cells of interest within the next
+    // build_increment_outer time steps) to the host
+    Kokkos::deep_copy(interface.num_steer_outer_host, interface.num_steer_outer);
+    // Resize inner steering vector, as its max size is the size of the outer steering vector. Since the inner steering
+    // vector is rebuilt every time step, realloc can be used and the previous values from the inner steering vector do
+    // not need to be preserved
+    Kokkos::realloc(interface.steering_vector, interface.num_steer_outer_host(0));
+}
+
 // For the case where cells may melt and solidify multiple times, determine which cells are associated with the
 // "steering vector" of cells that are either active, or becoming active this time step - version with remelting
 template <typename MemorySpace>
@@ -53,7 +82,8 @@ void fillSteeringVector_Remelt(const int cycle, const Grid &grid, CellData<Memor
 
     auto grain_id = celldata.getGrainIDSubview(grid);
     Kokkos::parallel_for(
-        "FillSV_RM", grid.domain_size, KOKKOS_LAMBDA(const int &index) {
+        "FillSV_RM", interface.num_steer_outer_host(0), KOKKOS_LAMBDA(const int &num_outer) {
+            const int index = interface.steering_vector_outer(num_outer);
             int celltype = celldata.cell_type(index);
             // Only iterate over cells that are not Solid type
             if (celltype != Solid) {
@@ -767,6 +797,8 @@ void jumpTimeStep(int &cycle, int remaining_cells_of_interest, const int local_t
                                       orientation, global_next_melt_time_step);
             // Jump to next time step when solidification starts again
             cycle = global_next_melt_time_step - 1;
+            // Rebuild outer steering vector with cells that are relevant now that time step has been advanced
+            fillOuterSteeringVector_Remelt(cycle, grid.domain_size, celldata, temperature, interface);
             if (id == 0)
                 std::cout << "Jumping to cycle " << cycle + 1 << std::endl;
         }

--- a/src/runCA.hpp
+++ b/src/runCA.hpp
@@ -56,7 +56,8 @@ void runExaCA(int id, int np, Inputs inputs, Timers timers, Grid grid, Temperatu
 
     // Variables characterizing the active cell region within each rank's grid, including buffers for ghost node data
     // (fixed size) and the steering vector/steering vector size on host/device
-    Interface<memory_space> interface(id, grid.domain_size, inputs.substrate.init_oct_size);
+    Interface<memory_space> interface(id, grid.domain_size, inputs.substrate.init_oct_size,
+                                      inputs.build_increment_outer);
     MPI_Barrier(MPI_COMM_WORLD);
 
     // Nucleation data structure, containing views of nuclei locations, time steps, and ids, and nucleation event
@@ -82,6 +83,9 @@ void runExaCA(int id, int np, Inputs inputs, Timers timers, Grid grid, Temperatu
     for (int layernumber = 0; layernumber < grid.number_of_layers; layernumber++) {
 
         int x_switch = 0;
+        // Fill initial outer steering vector for problems with remelting
+        if ((simulation_type != "Directional") && (simulation_type != "SingleGrain"))
+            fillOuterSteeringVector_Remelt(0, grid.domain_size, celldata, temperature, interface);
         timers.startLayer();
 
         // Loop continues until all liquid cells claimed by solid grains
@@ -110,8 +114,11 @@ void runExaCA(int id, int np, Inputs inputs, Timers timers, Grid grid, Temperatu
             timers.startSV();
             if ((simulation_type == "Directional") || (simulation_type == "SingleGrain"))
                 fillSteeringVector_NoRemelt(cycle, grid, celldata, temperature, interface);
-            else
+            else {
+                if (cycle % interface.build_increment_outer == 0)
+                    fillOuterSteeringVector_Remelt(cycle, grid.domain_size, celldata, temperature, interface);
                 fillSteeringVector_Remelt(cycle, grid, celldata, temperature, interface);
+            }
             timers.stopSV();
 
             timers.startCapture();


### PR DESCRIPTION
Slight performance optimization for problem types with remelting to iterate over an "outer" steering vector (created at a time interval of either 5000 time steps or a user input value) rather than over all cells when creating the main steering vector used for cell capture.