### PR TITLE
Ability to initialize simulations from vtk grain ID data

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -100,7 +100,7 @@ The .json files in the examples subdirectory are provided on the command line to
 |GrainIDs            | Directional      | GrainID values for each grain in (X,Y) (see note (b3))
 |FillBottomSurface   | Directional      | Optionally assign all cells on the bottom surface the grain ID of the closest grain (defaults to false)
 |MeanSize            | Spot, FromFile, FromFinch       | Mean spacing between grain centers in the baseplate/substrate (in microns) (see note (a))
-|SubstrateFilename   |  Spot, FromFile, FromFinch  | Path to and filename for substrate data (see note (a))
+|SubstrateFilename   |  Spot, FromFile, FromFinch  | Path to and filename for substrate data in vtk format (see note (a))
 |PowderDensity       | Spot, FromFile, FromFinch       | Density of sites in the powder layer to be assigned as the home of a unique grain, normalized by 1 x 10^12 m^-3 (default value is 1/(CA cell size ^3) (see note (a))
 |ExtendSubstrateThroughPowder| FromFile, FromFinch  | true/false value: Whether to use the baseplate microstructure as the boundary condition for the entire height of the simulation (defaults to false) (see note (a))
 | BaseplateTopZ      | FromFile, FromFinch          | The Z coordinate that marks the top of the baseplate/boundary of the baseplate with the powder. If not given, Z = 0 microns will be assumed to be the baseplate top if ExtendSubstrateThroughPowder = false (If ExtendSubstrateThroughPowder = true, the entire domain will be initialized with the baseplate grain structure)

--- a/src/CAcelldata.hpp
+++ b/src/CAcelldata.hpp
@@ -329,22 +329,21 @@ struct CellData {
         skipLines(substrate, 1);
 
         // Get nx_s, ny_s, and nz_s
-        std::vector<std::string> dims_read = readVTKTuple(substrate);
-
-        const int nx_s = getInputInt(dims_read[0]);
-        const int ny_s = getInputInt(dims_read[1]);
-        const int nz_s = getInputInt(dims_read[2]);
+        std::vector<std::string> dims_read = splitString(substrate);
+        const int nx_s = getInputInt(dims_read[1]);
+        const int ny_s = getInputInt(dims_read[2]);
+        const int nz_s = getInputInt(dims_read[3]);
 
         // Get origin location
-        std::vector<std::string> org_read = readVTKTuple(substrate);
-        const double x_min_s = getInputDouble(org_read[0]);
-        const double y_min_s = getInputDouble(org_read[1]);
-        const double z_min_s = getInputDouble(org_read[2]);
+        std::vector<std::string> org_read = splitString(substrate);
+        const double x_min_s = getInputDouble(org_read[1]);
+        const double y_min_s = getInputDouble(org_read[2]);
+        const double z_min_s = getInputDouble(org_read[3]);
 
         // Get voxel spacing
-        std::vector<std::string> vox_spacing_read = readVTKTuple(substrate);
-        const double deltax_s = getInputDouble(vox_spacing_read[0]);
-        if ((deltax_s != getInputDouble(vox_spacing_read[1])) || (deltax_s != getInputDouble(vox_spacing_read[2])))
+        std::vector<std::string> vox_spacing_read = splitString(substrate);
+        const double deltax_s = getInputDouble(vox_spacing_read[1]);
+        if ((deltax_s != getInputDouble(vox_spacing_read[2])) || (deltax_s != getInputDouble(vox_spacing_read[3])))
             throw std::runtime_error("Error: substrate data must have same spacing in all directions");
 
         // Ensure substrate dimensions can sufficiently cover the solidification domain

--- a/src/CAinputs.hpp
+++ b/src/CAinputs.hpp
@@ -261,6 +261,8 @@ struct Inputs {
                     "be provided in the input file");
             else if (input_data["Substrate"].contains("SubstrateFilename")) {
                 substrate.substrate_filename = input_data["Substrate"]["SubstrateFilename"];
+                if (substrate.substrate_filename.substr(substrate.substrate_filename.length() - 4) != ".vtk")
+                    throw std::runtime_error("Error: Substrate filename must be a vtk file");
                 substrate.use_substrate_file = true;
             }
             else if (input_data["Substrate"].contains("MeanSize")) {

--- a/src/CAparsefiles.cpp
+++ b/src/CAparsefiles.cpp
@@ -170,3 +170,24 @@ std::size_t checkForHeaderValues(std::string header_line) {
     }
     return header_size;
 }
+
+// Read and discard "n_lines" lines of data from the file
+void skipLines(std::ifstream &input_data_stream, const int n_lines) {
+    std::string dummy_str;
+    for (int line = 0; line < n_lines; line++)
+        getline(input_data_stream, dummy_str);
+}
+
+// Read space-separated tuple from a vtk file header
+std::vector<std::string> readVTKTuple(std::ifstream &input_data_stream) {
+    std::vector<std::string> read_values(3);
+    std::string read_line;
+    getline(input_data_stream, read_line);
+    std::size_t first_separator = read_line.find(' ');
+    std::size_t second_separator = read_line.find(' ', first_separator + 1);
+    std::size_t third_separator = read_line.find(' ', second_separator + 1);
+    read_values[0] = read_line.substr(first_separator, second_separator - first_separator);
+    read_values[1] = read_line.substr(second_separator, third_separator - second_separator);
+    read_values[2] = read_line.substr(third_separator);
+    return read_values;
+}

--- a/src/CAparsefiles.cpp
+++ b/src/CAparsefiles.cpp
@@ -88,26 +88,9 @@ std::vector<std::string> splitString(std::ifstream &input_data_stream, std::size
                                      char separator) {
 
     std::string line;
+    std::vector<std::string> parsed_line;
     getline(input_data_stream, line);
-
-    // Make sure the right number of values are present on the line - one more than the number of separators
-    std::size_t actual_num_values = std::count(line.begin(), line.end(), separator) + 1;
-    if (expected_num_values != actual_num_values) {
-        std::string error = "Error: Expected " + std::to_string(expected_num_values) +
-                            " values while reading file; but " + std::to_string(actual_num_values) + " were found";
-        throw std::runtime_error(error);
-    }
-    // Separate the line into its components, now that the number of values has been checked
-    std::vector<std::string> parsed_line(actual_num_values);
-    std::size_t parsed_line_size = parsed_line.size();
-    // Make a copy that we can modify
-    std::string line_copy = line;
-    for (std::size_t n = 0; n < parsed_line_size - 1; n++) {
-        std::size_t pos = line_copy.find(separator);
-        parsed_line[n] = line_copy.substr(0, pos);
-        line_copy = line_copy.substr(pos + 1, std::string::npos);
-    }
-    parsed_line[parsed_line_size - 1] = line_copy;
+    splitString(line, parsed_line, expected_num_values, separator);
     return parsed_line;
 }
 

--- a/src/CAparsefiles.cpp
+++ b/src/CAparsefiles.cpp
@@ -82,6 +82,35 @@ void splitString(const std::string line, std::vector<std::string> &parsed_line, 
     parsed_line[parsed_line_size - 1] = line_copy;
 }
 
+// Reads a line from an input file stream and outputs the components of the line split at "separator" (spaces used by
+// default). By default, expects 4 components of the line to separate (used in parsing vtk header data)
+std::vector<std::string> splitString(std::ifstream &input_data_stream, std::size_t expected_num_values,
+                                     char separator) {
+
+    std::string line;
+    getline(input_data_stream, line);
+
+    // Make sure the right number of values are present on the line - one more than the number of separators
+    std::size_t actual_num_values = std::count(line.begin(), line.end(), separator) + 1;
+    if (expected_num_values != actual_num_values) {
+        std::string error = "Error: Expected " + std::to_string(expected_num_values) +
+                            " values while reading file; but " + std::to_string(actual_num_values) + " were found";
+        throw std::runtime_error(error);
+    }
+    // Separate the line into its components, now that the number of values has been checked
+    std::vector<std::string> parsed_line(actual_num_values);
+    std::size_t parsed_line_size = parsed_line.size();
+    // Make a copy that we can modify
+    std::string line_copy = line;
+    for (std::size_t n = 0; n < parsed_line_size - 1; n++) {
+        std::size_t pos = line_copy.find(separator);
+        parsed_line[n] = line_copy.substr(0, pos);
+        line_copy = line_copy.substr(pos + 1, std::string::npos);
+    }
+    parsed_line[parsed_line_size - 1] = line_copy;
+    return parsed_line;
+}
+
 bool checkFileExists(const std::string path, const int id, const bool error) {
     std::ifstream stream;
     stream.open(path);
@@ -176,18 +205,4 @@ void skipLines(std::ifstream &input_data_stream, const int n_lines) {
     std::string dummy_str;
     for (int line = 0; line < n_lines; line++)
         getline(input_data_stream, dummy_str);
-}
-
-// Read space-separated tuple from a vtk file header
-std::vector<std::string> readVTKTuple(std::ifstream &input_data_stream) {
-    std::vector<std::string> read_values(3);
-    std::string read_line;
-    getline(input_data_stream, read_line);
-    std::size_t first_separator = read_line.find(' ');
-    std::size_t second_separator = read_line.find(' ', first_separator + 1);
-    std::size_t third_separator = read_line.find(' ', second_separator + 1);
-    read_values[0] = read_line.substr(first_separator, second_separator - first_separator);
-    read_values[1] = read_line.substr(second_separator, third_separator - second_separator);
-    read_values[2] = read_line.substr(third_separator);
-    return read_values;
 }

--- a/src/CAparsefiles.hpp
+++ b/src/CAparsefiles.hpp
@@ -113,4 +113,8 @@ void readIgnoreBinaryField(std::ifstream &input_data_stream, int nx, int ny, int
     }
 }
 
+// Read and discard "n_lines" lines of data from the file
+void skipLines(std::ifstream &input_data_stream, const int n_lines);
+std::vector<std::string> readVTKTuple(std::ifstream &input_data_stream);
+
 #endif

--- a/src/CAparsefiles.hpp
+++ b/src/CAparsefiles.hpp
@@ -22,6 +22,8 @@ float getInputFloat(std::string val_input, int factor = 0);
 double getInputDouble(std::string val_input, int factor = 0);
 void splitString(std::string line, std::vector<std::string> &parsed_line, std::size_t expected_num_values,
                  char separator = ',');
+std::vector<std::string> splitString(std::ifstream &input_data_stream, std::size_t expected_num_values = 4,
+                                     char separator = ' ');
 std::size_t checkForHeaderValues(std::string header_line);
 bool checkFileExists(const std::string path, const int id, const bool error = true);
 std::string checkFileInstalled(const std::string name, const int id);
@@ -115,6 +117,5 @@ void readIgnoreBinaryField(std::ifstream &input_data_stream, int nx, int ny, int
 
 // Read and discard "n_lines" lines of data from the file
 void skipLines(std::ifstream &input_data_stream, const int n_lines);
-std::vector<std::string> readVTKTuple(std::ifstream &input_data_stream);
 
 #endif

--- a/unit_test/tstInputs.hpp
+++ b/unit_test/tstInputs.hpp
@@ -43,7 +43,7 @@ void writeTestData(std::string input_filename, int print_version) {
                    << std::endl;
     test_data_file << "   }," << std::endl;
     test_data_file << "   \"Substrate\": {" << std::endl;
-    test_data_file << "      \"SubstrateFilename\": \"DummySubstrate.txt\"," << std::endl;
+    test_data_file << "      \"SubstrateFilename\": \"DummySubstrate.vtk\"," << std::endl;
     test_data_file << "      \"PowderDensity\": 1000," << std::endl;
     test_data_file << "      \"BaseplateTopZ\": -0.00625" << std::endl;
     test_data_file << "   }," << std::endl;


### PR DESCRIPTION
Removed the deprecated ability to read the old substrate grain ID data format and replaced it with the ability to read grain ID data from a vtk file