### PR TITLE
Revert "Outer steering vector (#333)"

### DIFF
--- a/examples/Inp_TwoLineTwoLayer.json
+++ b/examples/Inp_TwoLineTwoLayer.json
@@ -3,7 +3,6 @@
    "MaterialFileName": "Inconel625.json",
    "GrainOrientationFile": "GrainOrientationVectors.csv",
    "RandomSeed": 0,
-   "SteeringVectorRebuildFrequency": 5000,
    "Domain": {
        "CellSize": 2.5,
        "TimeStep": 0.0825,

--- a/examples/README.md
+++ b/examples/README.md
@@ -55,7 +55,6 @@ The .json files in the examples subdirectory are provided on the command line to
 | MaterialFileName       | Name of material file in examples/Materials used
 | GrainOrientationFile   | File listing rotation matrix components used in assigning orientations to grains ([see below](#substrate-inputs))
 | RandomSeed             | Value of type double used as the seed to generate baseplate, powder, and nuclei details (default value is 0.0 if not provided)
-| SteeringVectorRebuildFrequency | Used for problem types `Spot`, `FromFile`, and `FromFinch`, this is the number of time steps between rebuilding of the steering vector listing cells that will undergo a future type transition (default value is 5000 if not provided). Depending on the solidification rate in the problem of interest, tuning this may lead to small performance improvements
 | Domain                 | Section for parameters that describe the simulation domain for the given problem type ([see below](#domain-inputs))
 | Nucleation             | Section for parameters that describe nucleation ([see below](#nucleation-inputs))
 | TemperatureData        | Section for parameters/files governing the temperature field for the given problem type ([see below](#temperature-inputs)). Section is unused if temperature data is given from Finch

--- a/src/CAinputs.hpp
+++ b/src/CAinputs.hpp
@@ -26,7 +26,6 @@ struct Inputs {
 
     std::string simulation_type = "", material_filename = "", grain_orientation_file = "";
     unsigned long rng_seed = 0.0;
-    int build_increment_outer = 5000;
     DomainInputs domain;
     NucleationInputs nucleation;
     InterfacialResponseInputs irf;
@@ -85,9 +84,6 @@ struct Inputs {
         // Seed for random number generator (defaults to 0 if not given)
         if (input_data.contains("RandomSeed"))
             rng_seed = input_data["RandomSeed"];
-        // Increment for resizing the outer steering vector used to iterate over cells of interest each time step
-        if (input_data.contains("SteeringVectorRebuildFrequency"))
-            build_increment_outer = input_data["SteeringVectorRebuildFrequency"];
 
         // Domain inputs:
         // Cell size - given in meters, stored in micrometers

--- a/src/CAinterface.hpp
+++ b/src/CAinterface.hpp
@@ -40,16 +40,13 @@ struct Interface {
     int buf_size, buf_components;
     view_type_float diagonal_length, octahedron_center, crit_diagonal_length;
     view_type_buffer buffer_south_send, buffer_north_send, buffer_south_recv, buffer_north_recv;
-    view_type_int send_size_south, send_size_north, steering_vector, steering_vector_outer, num_steer, num_steer_outer;
-    view_type_int_host send_size_south_host, send_size_north_host, num_steer_host, num_steer_outer_host;
+    view_type_int send_size_south, send_size_north, steering_vector, num_steer;
+    view_type_int_host send_size_south_host, send_size_north_host, num_steer_host;
     // Initial size of new octahedra
     float _init_oct_size;
 
     // Neighbor lists
     neighbor_list_type neighbor_x, neighbor_y, neighbor_z;
-
-    // Increment to rebuild outer steering vector
-    int build_increment_outer;
 
     // Parallel dispatch tags.
     struct RefillBuffersTag {};
@@ -57,7 +54,7 @@ struct Interface {
     // Constructor for views and view bounds for current layer
     // Use default initialization to 0 for num_steer_host and num_steer and buffer counts
     Interface(const int id, const int domain_size, const float init_oct_size, const int buf_size_initial_estimate = 25,
-              const int buf_components_temp = 8, const int build_increment_outer_input = 5000)
+              const int buf_components_temp = 8)
         : diagonal_length(view_type_float(Kokkos::ViewAllocateWithoutInitializing("diagonal_length"), domain_size))
         , octahedron_center(
               view_type_float(Kokkos::ViewAllocateWithoutInitializing("octahedron_center"), 3 * domain_size))
@@ -74,16 +71,11 @@ struct Interface {
         , send_size_south(view_type_int("send_size_south", 1))
         , send_size_north(view_type_int("send_size_north", 1))
         , steering_vector(view_type_int(Kokkos::ViewAllocateWithoutInitializing("steering_vector"), domain_size))
-        , steering_vector_outer(
-              view_type_int(Kokkos::ViewAllocateWithoutInitializing("steering_vector_outer"), domain_size))
         , num_steer(view_type_int("steering_vector_size", 1))
-        , num_steer_outer(view_type_int("outer_steering_vector_size", 1))
         , send_size_south_host(view_type_int_host("send_size_south_host", 1))
         , send_size_north_host(view_type_int_host("send_size_north_host", 1))
         , num_steer_host(view_type_int_host("steering_vector_size_host", 1))
-        , num_steer_outer_host(view_type_int_host("outer_steering_vector_size_host", 1))
-        , _init_oct_size(init_oct_size)
-        , build_increment_outer(build_increment_outer_input) {
+        , _init_oct_size(init_oct_size) {
 
         // Set initial buffer size to the estimate
         buf_size = buf_size_initial_estimate;


### PR DESCRIPTION
While the outer steering vector appeared to yield a very small performance improvement for some problems, careful selection of the rebuild increment was needed and improper selection often yielded a performance slowdown. The change doesn't appear to be worth the increase in code complexity or need to tune the rebuild increment

This reverts commit 36ab28df122e382f1e75adbcec16f02f0cf1031e.W

