### PR TITLE
Replaced layer_time_temp_history with liquidus_time and cooling_rate views of the appropriate types

### DIFF
--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -210,20 +210,18 @@ struct Print {
                               undercooling_start_whole_domain);
             }
             if (_inputs.intralayer_melt_time_step) {
-                auto melt_time_step = temperature.template extractTmTlCrData<view_type_int>(0, grid.domain_size);
+                auto melt_time_step = temperature.template extractTmTlData<view_type_int>(0, grid.domain_size);
                 auto melt_time_step_whole_domain = collectViewData(id, np, grid, true, MPI_INT, melt_time_step);
                 printViewData(id, intralayer_ofstream, grid, true, "int", "MeltTimeStep", melt_time_step_whole_domain);
             }
             if (_inputs.intralayer_crit_time_step) {
-                auto crit_time_step = temperature.template extractTmTlCrData<view_type_int>(1, grid.domain_size);
+                auto crit_time_step = temperature.template extractTmTlData<view_type_int>(1, grid.domain_size);
                 auto crit_time_step_whole_domain = collectViewData(id, np, grid, true, MPI_INT, crit_time_step);
                 printViewData(id, intralayer_ofstream, grid, true, "int", "CritTimeStep", crit_time_step_whole_domain);
             }
             if (_inputs.intralayer_undercooling_change) {
-                auto undercooling_change =
-                    temperature.template extractTmTlCrData<view_type_float>(2, grid.domain_size, 0);
-                auto undercooling_change_whole_domain =
-                    collectViewData(id, np, grid, true, MPI_FLOAT, undercooling_change);
+                auto cooling_rate = temperature.template extractCrData<view_type_float>(grid.domain_size);
+                auto undercooling_change_whole_domain = collectViewData(id, np, grid, true, MPI_FLOAT, cooling_rate);
                 printViewData(id, intralayer_ofstream, grid, true, "float", "UndercoolingChange",
                               undercooling_change_whole_domain);
             }
@@ -352,22 +350,21 @@ struct Print {
                     writeHeader(currentlayer_ofstream, vtk_filename_current_layer, grid, true);
                 }
                 if (_inputs.interlayer_melt_time_step) {
-                    auto melt_time_step = temperature.template extractTmTlCrData<view_type_int>(0, grid.domain_size);
+                    auto melt_time_step = temperature.template extractTmTlData<view_type_int>(0, grid.domain_size);
                     auto melt_time_step_whole_domain = collectViewData(id, np, grid, true, MPI_INT, melt_time_step);
                     printViewData(id, currentlayer_ofstream, grid, true, "int", "MeltTimeStep",
                                   melt_time_step_whole_domain);
                 }
                 if (_inputs.interlayer_crit_time_step) {
-                    auto crit_time_step = temperature.template extractTmTlCrData<view_type_int>(1, grid.domain_size);
+                    auto crit_time_step = temperature.template extractTmTlData<view_type_int>(1, grid.domain_size);
                     auto crit_time_step_whole_domain = collectViewData(id, np, grid, true, MPI_INT, crit_time_step);
                     printViewData(id, currentlayer_ofstream, grid, true, "int", "CritTimeStep",
                                   crit_time_step_whole_domain);
                 }
                 if (_inputs.interlayer_undercooling_change) {
-                    auto undercooling_change =
-                        temperature.template extractTmTlCrData<view_type_float>(2, grid.domain_size, 0);
+                    auto cooling_rate = temperature.template extractCrData<view_type_float>(grid.domain_size);
                     auto undercooling_change_whole_domain =
-                        collectViewData(id, np, grid, true, MPI_FLOAT, undercooling_change);
+                        collectViewData(id, np, grid, true, MPI_FLOAT, cooling_rate);
                     printViewData(id, currentlayer_ofstream, grid, true, "float", "UndercoolingChange",
                                   undercooling_change_whole_domain);
                 }

--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -32,7 +32,7 @@ void fillSteeringVector_NoRemelt(const int cycle, const Grid &grid, CellData<Mem
         "FillSV", grid.domain_size, KOKKOS_LAMBDA(const int &index) {
             int cell_type = celldata.cell_type(index);
             bool is_not_solid = (cell_type != Solid);
-            int crit_time_step = temperature.layer_time_temp_history(index, 0, 1);
+            int crit_time_step = temperature.liquidus_time(index, 0, 1);
             bool past_crit_time = (cycle > crit_time_step);
             bool cell_active = ((cell_type == Active) || (cell_type == FutureActive));
             if (is_not_solid && past_crit_time) {
@@ -745,8 +745,8 @@ void jumpTimeStep(int &cycle, int remaining_cells_of_interest, const int local_t
                     // criteria for a cell to be associated with future work (checking this layer's cells only)
                     if (celldata.cell_type(index) == TempSolid) {
                         int solidification_counter_this_cell = temperature.solidification_event_counter(index);
-                        int next_melt_time_step_this_cell = static_cast<int>(
-                            temperature.layer_time_temp_history(index, solidification_counter_this_cell, 0));
+                        int next_melt_time_step_this_cell =
+                            temperature.liquidus_time(index, solidification_counter_this_cell, 0);
                         if (next_melt_time_step_this_cell < tempv)
                             tempv = next_melt_time_step_this_cell;
                     }

--- a/unit_test/tstNucleation.hpp
+++ b/unit_test/tstNucleation.hpp
@@ -82,9 +82,10 @@ void testNucleiInit() {
 
     // Allocate temperature data structures
     Temperature<memory_space> temperature(grid, inputs.temperature);
-    // Resize layer_time_temp_history with the known max number of solidification events
-    Kokkos::resize(temperature.layer_time_temp_history, grid.domain_size, max_solidification_events_count, 3);
-    // Initialize max_solidification_events to 3 for each layer. layer_time_temp_history and
+    // Resize liquidus_time and cooling_rate with the known max number of solidification events
+    Kokkos::resize(temperature.liquidus_time, grid.domain_size, max_solidification_events_count, 2);
+    Kokkos::resize(temperature.cooling_rate, grid.domain_size, max_solidification_events_count);
+    // Initialize max_solidification_events to 3 for each layer. liquidus_time and
     // number_of_solidification_events are initialized for each cell on the host and copied to the device
     Kokkos::View<int *, Kokkos::HostSpace> max_solidification_events_host(
         Kokkos::ViewAllocateWithoutInitializing("max_solidification_events_host"), grid.number_of_layers);
@@ -115,13 +116,13 @@ void testNucleiInit() {
                         int coord_z_all_layers = coord_z + grid.z_layer_bottom;
                         if (n < temperature.number_of_solidification_events(index)) {
                             // melting time step depends on solidification event number
-                            temperature.layer_time_temp_history(index, n, 0) =
+                            temperature.liquidus_time(index, n, 0) =
                                 coord_z_all_layers + coord_y + grid.y_offset + (grid.domain_size * n);
                             // liquidus time stemp depends on solidification event number
-                            temperature.layer_time_temp_history(index, n, 1) =
+                            temperature.liquidus_time(index, n, 1) =
                                 coord_z_all_layers + coord_y + grid.y_offset + 1 + (grid.domain_size * n);
                             // ensures that a cell's nucleation time will be 1 time step after its CritTimeStep value
-                            temperature.layer_time_temp_history(index, n, 2) = 1.2;
+                            temperature.cooling_rate(index, n) = 1.2;
                         }
                     }
                 }


### PR DESCRIPTION
Closes #219  - also ensures that cells do not go above and then back below the liquidus on the same time step