### PR TITLE
Make sure all grid inputs for json write/read test are initialized

### DIFF
--- a/unit_test/tstInputs.hpp
+++ b/unit_test/tstInputs.hpp
@@ -320,6 +320,8 @@ void testInputs(int print_version) {
         grid.y_min = 0.0;
         grid.z_min = 0.0;
         grid.x_max = 0.0;
+        grid.y_max = 0.0;
+        grid.z_max = 0.0;
         Timers timers(0);
 
         // Print log file


### PR DESCRIPTION
Bug fix introduced when fixing bug in #344 