### PR TITLE
More strict parsing of printing section of inputs file

### DIFF
--- a/examples/Inp_SpotMelt.json
+++ b/examples/Inp_SpotMelt.json
@@ -25,7 +25,7 @@
       "PathToOutput": "./",
       "OutputFile": "TestProblemSpot",
       "PrintBinary": false,
-      "printExaConstitSize": 0,
+      "PrintExaConstitSize": 0,
       "Intralayer": {
           "Increment": 2000,
           "Fields": ["GrainMisorientation", "MeltTimeStep", "CritTimeStep"],

--- a/examples/README.md
+++ b/examples/README.md
@@ -59,7 +59,7 @@ The .json files in the examples subdirectory are provided on the command line to
 | Nucleation             | Section for parameters that describe nucleation ([see below](#nucleation-inputs))
 | TemperatureData        | Section for parameters/files governing the temperature field for the given problem type ([see below](#temperature-inputs)). Section is unused if temperature data is given from Finch
 | Substrate              | Section for parameters/files governing the edge boundary conditions ([see below](#substrate-inputs))
-| Printing               | Section for parameters/file names for output data ([see below](#printing-inputs))
+| Printing               | Section for parameters/file names for output data ([see below](#printing-inputs)). If this section is not given, only the log file from the run will be printed
 
 ## Domain inputs
 | Input        |Relevant problem type(s)| Details |
@@ -112,18 +112,18 @@ The .json files in the examples subdirectory are provided on the command line to
 ## Printing inputs
 | Input        | Relevant problem type(s))| Details |
 |--------------| -------------------------|---------|
-| PathToOutput | All                      | File path location for the output files
-| OutputFile   | All                      | All output files will begin with the string specified on this line
+| PathToOutput | All                      | File path location for the output files (required)
+| OutputFile   | All                      | All output files will begin with the string specified on this line (required)
 | PrintBinary  | All                      | Whether or not ExaCA vtk output data should be printed as big endian binary data, or as ASCII characters (defaults to false)
 | PrintFrontUndercooling | Directional         | Whether or not ExaCA will store and print the undercooling at the solidification front when solidification begins and ends at each Z coordinate
 | PrintExaConstitSize    | FromFile          | Length of the cubic representative volume element (RVE) data for ExaConstit, taken from the domain center in X and Y, and at the domain top in Z excluding the final layer's grain structure. If not given (or given a value of 0), the RVE will not be printed 
 | Intralayer   | All | Optional section for printing the state of the simulation during a given layer of a multilayer problem/during a single layer problem
 | Intralayer: Increment | All | Increment, in time steps, at which intermediate output should be printed. If 0, will only print the state of the system at the start of each layer
 | Intralayer: Fields | All | Fields to print during intralayer increments. Currently supported options are "GrainID", "LayerID", "GrainMisorientation", "UndercoolingCurrent", "UndercoolingSolidificationStart", "MeltTimeStep", "CritTimeStep", "UndercoolingChange", "CellType", "DiagonalLength", "SolidificationEventCounter", "NumberOfSolidificationEvents"
-| Intralayer: PrintIdleFrames | All | Whether or not ExaCA should print intermediate output regardless of whether the simulation has changed from the last frame
+| Intralayer: PrintIdleFrames | All | Whether or not ExaCA should print intermediate output regardless of whether the simulation has changed from the last frame. Defaults to false
 | Interlayer   | All | List of options for printing the state of the system following a given layer, or at the end of the run
 | Interlayer: Layers | All | List of layers (starting at 0 and through "NumberOfLayers-1") following which the state of the simulation should be printed. If not given (or for non-multilayer problems), defaults to printing only after the full simulation has completed
-| Interlayer: Increment | All | If "Interlayer: Layers" is not given, this option enables printing of interlayer output starting at layer 0 and repeating at the specified increment. The full simulation results following the final layer will always be printed.
+| Interlayer: Increment | All | If "Interlayer: Layers" is not given, this option enables printing of interlayer output starting at layer 0 and repeating at the specified increment. The full simulation results following the final layer will always be printed as long as the "Interlayer" section is present in the input file".
 | Interlayer: Fields | All | Fields to print following layers. Currently supported options are "GrainID", "LayerID", "GrainMisorientation", "UndercoolingCurrent", "UndercoolingSolidificationStart", "MeltTimeStep", "CritTimeStep", "UndercoolingChange", "CellType", "DiagonalLength", "SolidificationEventCounter", "NumberOfSolidificationEvents"
 
 Here, GrainMisorientation is not the misorientation of the grain itself, but rather the misorientation of the grain's nearest <100> crystallographic direction with the +Z direction. For cells that are liquid (possible only for intermediate state print, as the final state will only have solid cells), -1 is printed as the misorienatation. Misorientations for grains from the baseplate or powder layer are between 0-62 (degrees, rounded to nearest integer), and cells that are associated with nucleated grains are assigned values between 100-162 to differentiate them. Additionally, 200 is printed as the misorientation for cells in the powder layer that have not been assigned a grain ID.

--- a/src/CAinputdata.hpp
+++ b/src/CAinputdata.hpp
@@ -98,6 +98,12 @@ struct PrintInputs {
     std::string base_filename = "";
     // Path to CA output
     std::string path_to_output = "";
+    // List of valid print outputs and whether or not they are required
+    std::vector<std::string> print_field_label = {"PathToOutput", "OutputFile",          "PrintFrontUndercooling",
+                                                  "PrintBinary",  "PrintExaConstitSize", "Intralayer",
+                                                  "Interlayer"};
+    std::vector<bool> required_print_field = {true, true, false, false, false, false, false};
+
     // Names of output fields that can be printed to files during or at the end of a simulation
     std::vector<std::string> fieldnames_key = {"GrainID",
                                                "LayerID",
@@ -154,6 +160,7 @@ struct PrintInputs {
 
     // Should the default RVE data for ExaConstit be printed? If so, with what size?
     bool print_default_rve = false;
+    bool skip_all_printing = false;
     int rve_size = 0;
 };
 

--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -286,7 +286,7 @@ struct Print {
 
         using view_type_float = Kokkos::View<float *, MemorySpace>;
         using view_type_int = Kokkos::View<int *, MemorySpace>;
-        if (layernumber == _inputs.print_layer_number[interlayer_file_count]) {
+        if ((!_inputs.skip_all_printing) || (layernumber == _inputs.print_layer_number[interlayer_file_count])) {
             std::string vtk_filename_base;
             if (layernumber != grid.number_of_layers - 1)
                 vtk_filename_base = path_base_filename + "_layer" + std::to_string(layernumber);


### PR DESCRIPTION
* Allow simulation without the "Printing" section of input file present (to avoid printing any simulation data to files other than the log)
* Allow "Printing[PrintIntralayer][PrintIdleFrames]" default of false to be used when this field is not given in the input file
* Check for required inputs in "Printing" section of input file, throwing an error if any are not given
* Check that all inputs given in "Printing" section of input file are valid, throwing an error if an unrecognized field is found
* Fixed typo in `examples/Inp_SpotMelt.json`