### PR TITLE
Ability to trim ExaCA domain based on the bounds of the Finch solidification data

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -116,8 +116,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ORNL-MDF/Finch
-          # This is post-release 0.1
-          ref: 765a7cef4bded27fd5b2a475454aa045bced85c1
+          # This is after the ability to extract data bounds was added
+          ref: ca46415b3cc1edc7cd6959e744e47d785c1d0e2a
           path: finch
       - name: Build Finch
         if: ${{ matrix.heat_transfer == 'Finch' }}

--- a/examples/Inp_Finch.json
+++ b/examples/Inp_Finch.json
@@ -14,6 +14,9 @@
       "MeanUndercooling": 5,
       "StDev": 0.5
    },
+   "TemperatureData": {
+      "TrimUnmeltedRegion": true
+   },
    "Substrate": {
       "MeanSize": 50
    },

--- a/src/CAinputdata.hpp
+++ b/src/CAinputdata.hpp
@@ -66,6 +66,8 @@ struct TemperatureInputs {
     // solidification front
     double G = 0, R = 0;
     double init_undercooling = 0.0;
+    // Used for FromFinch problem type
+    bool trim_unmelted_region = false;
 };
 
 struct SubstrateInputs {

--- a/src/CAinputs.hpp
+++ b/src/CAinputs.hpp
@@ -150,7 +150,16 @@ struct Inputs {
                     temperature.temp_paths.push_back(input_data["TemperatureData"]["TemperatureFiles"][filename]);
             }
         }
-        else if (simulation_type != "FromFinch") {
+        else if (simulation_type == "FromFinch") {
+            // See if temperature data translation instructions are given
+            if (input_data.contains("TemperatureData")) {
+                // Option to trim bounds of Finch data around the region that underwent solidification. If not given,
+                // defaults to false
+                if (input_data["TemperatureData"].contains("TrimUnmeltedRegion"))
+                    temperature.trim_unmelted_region = input_data["TemperatureData"]["TrimUnmeltedRegion"];
+            }
+        }
+        else {
             // Temperature data uses fixed thermal gradient (K/m) and cooling rate (K/s)
             temperature.G = input_data["TemperatureData"]["G"];
             temperature.R = input_data["TemperatureData"]["R"];


### PR DESCRIPTION
Previously, ExaCA used the same domain bounds as Finch, leading to unnecessary memory allocation by ExaCA as much of the Finch domain does not undergo melting or solidification.

Closes #348 