### PR TITLE
Rename intermediate output for .vtk.series parsing in Paraview

### DIFF
--- a/src/CAinputdata.hpp
+++ b/src/CAinputdata.hpp
@@ -123,6 +123,7 @@ struct PrintInputs {
     bool intralayer = false;
     int intralayer_increment = 1;
     bool intralayer_idle_frames = false;
+    bool intralayer_non_misorientation_fields = false;
     bool intralayer_grain_id = false;
     bool intralayer_layer_id = false;
     bool intralayer_grain_misorientation = false;

--- a/src/CAinputs.hpp
+++ b/src/CAinputs.hpp
@@ -487,6 +487,11 @@ struct Inputs {
                 if (print_fields_intralayer[n])
                     print.intralayer = true;
             }
+            // Will fields other than grain misorientations be printed?
+            for (int n = 0; n < num_print_intralayer_inputs; n++) {
+                if ((n != 2) && (print_fields_intralayer[n]))
+                    print.intralayer_non_misorientation_fields = true;
+            }
         }
         // List of layers following which interlayer data should be printed (will always print after last layer by
         // default)

--- a/src/runCA.hpp
+++ b/src/runCA.hpp
@@ -138,6 +138,10 @@ void runExaCA(int id, int np, Inputs inputs, Timers timers, Grid grid, Temperatu
             }
 
         } while (x_switch == 0);
+
+        // Reset intralayer print counter and print time series file for previous layer's intralayer data (if needed)
+        print.resetIntralayer(id, layernumber);
+
         if (layernumber != grid.number_of_layers - 1) {
             MPI_Barrier(MPI_COMM_WORLD);
 


### PR DESCRIPTION
ExaCA now prints additional ".vtk.series" files for intermediate output datasets (`GrainMisorientations` is still stored in a different file than the other fields), containing the simulation time values for the intermediate datasets. Integers are used in the filenames themselves for compatibility with Paraview file reading