### PR TITLE
Only print interlayer data for specified layers

### DIFF
--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -302,7 +302,7 @@ struct Print {
 
         using view_type_float = Kokkos::View<float *, MemorySpace>;
         using view_type_int = Kokkos::View<int *, MemorySpace>;
-        if ((!_inputs.skip_all_printing) || (layernumber == _inputs.print_layer_number[interlayer_file_count])) {
+        if ((!_inputs.skip_all_printing) && (layernumber == _inputs.print_layer_number[interlayer_file_count])) {
             std::string vtk_filename_base;
             if (layernumber != grid.number_of_layers - 1)
                 vtk_filename_base = path_base_filename + "_layer" + std::to_string(layernumber);


### PR DESCRIPTION
Fixup of #352 - interlayer data is only printed if the "skip all printing" variable is set to false and the just-finished layer number is a specified layer for intermediate printing.