### PR TITLE
Remove redundant simulation type check

### DIFF
--- a/src/CAgrid.hpp
+++ b/src/CAgrid.hpp
@@ -126,9 +126,6 @@ struct Grid {
         , _inputs(inputs)
         , _t_inputs(t_inputs) {
 
-        // Check for valid simulation type.
-        validSimulationType(simulation_type);
-
         // Copy from inputs structs
         deltax = _inputs.deltax;
         layer_height = _inputs.layer_height;

--- a/src/CAtemperature.hpp
+++ b/src/CAtemperature.hpp
@@ -432,9 +432,6 @@ struct Temperature {
     // problem types
     void initialize(const int id, const std::string simulation_type, const Grid &grid, const double deltat) {
 
-        // Check for valid simulation type.
-        validSimulationType(simulation_type);
-
         // Initialize temperature field in Z direction with thermal gradient G set in input file
         // Liquidus front (InitUndercooling = 0) is at domain bottom for directional solidification, is at domain center
         // (with custom InitUndercooling value) for single grain solidification

--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -790,8 +790,6 @@ void intermediateOutputAndCheck(const int id, const int np, int &cycle, const Gr
                                 Temperature<MemorySpace> &temperature, std::string simulation_type,
                                 const int layernumber, Orientation<MemorySpace> &orientation, Print print,
                                 const double deltat, Interface<MemorySpace> &interface) {
-    // Check for valid simulation type.
-    validSimulationType(simulation_type);
 
     auto grain_id = celldata.getGrainIDSubview(grid);
     int local_superheated_cells, local_undercooled_cells, local_active_cells, local_temp_solid_cells,


### PR DESCRIPTION
Not sure how this got into the intermediate output subroutine to begin with, the simulation type only needs to be checked during the input read since it doesn't change at all during a run