### PR TITLE
Code and example problem cleaup

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,9 @@ mpiexec -n 1 ./build/install/bin/ExaCA examples/Inp_DirSolidification.json
 Alternatively, the `Finch-ExaCA` executable can be used for coupled Finch-ExaCA simulations. Compilation with `ExaCA_ENABLE_FINCH=ON` is required for these examples with [Finch in-memory coupling](https://github.com/ORNL-MDF/Finch):
  * `Inp_SmallFinch.json`: simulates melting and solidification of a small melt pool segment at a coarse resolution
  * `Inp_Finch.json`: simulates melting and solidification of a small melt pool segment at a fine resolution, repeated for 3 layers
- * `Inp_FinchTranslate.json`: simulates melting and solidification of the small melt pool segment translated in space to form 3 overlapping segments
+ * `Inp_FinchTranslate.json`: simulates melting and solidification of the small melt pool segment at the fine resolution translated in space to form 3 overlapping segments
 
-For coupled Finch-ExaCA runs, caution should be taken such that the cell size given in the CA input file matches that given in the Finch input file. Additionally, `scan_path_file` in the Finch input file (for `Inp_Finch.json`, this is `examples/single_line/inputs_small_refined.json` in the Finch repository and for `Inp_SmallFinch.json`, this is `examples/single_line/inputs_small.json` in the Finch repository) should be modified to represent a global path name. Run by calling the created executable with a Finch input file and an ExaCA input file on the command line, with the Finch input file listed first:
+For coupled Finch-ExaCA runs, caution should be taken such that the cell size given in the CA input file matches that given in the Finch input file. Additionally, `scan_path_file` in the Finch input file (for `Inp_Finch.json` and `Inp_FinchTranslate.json`, this is `examples/single_line/inputs_small_refined.json` in the Finch repository and for `Inp_SmallFinch.json`, this is `examples/single_line/inputs_small.json` in the Finch repository) should be modified to represent a global path name. Run by calling the created executable with a Finch input file and an ExaCA input file on the command line, with the Finch input file listed first:
 
 mpiexec -n 1 ./build/install/bin/Finch-ExaCA $PATH_TO_FINCH/examples/single_line/inputs_small.json examples/Inp_SmallFinch.json
 

--- a/analysis/bin/runGA.cpp
+++ b/analysis/bin/runGA.cpp
@@ -18,8 +18,7 @@
 #include <string>
 #include <vector>
 
-// The path to/name of the ExaCA analysis input file and the path to/ name of the base filename for the ExaCA
-// microstructure data (without extension) are given on the command line
+// Given on the command line: Name of analysis input file, name (without file extension) of the ExaCA data
 int main(int argc, char *argv[]) {
 
     // Initialize Kokkos
@@ -43,6 +42,7 @@ int main(int argc, char *argv[]) {
         int nx, ny, nz, number_of_layers;
         std::vector<double> xyz_bounds(6);
         parseLogFile(log_file, nx, ny, nz, deltax, number_of_layers, xyz_bounds, grain_unit_vector_file, false);
+        std::cout << "Parsed log file" << std::endl;
 
         // Allocate memory blocks for grain_id and layer_id data
         Kokkos::View<int ***, Kokkos::HostSpace> grain_id(Kokkos::ViewAllocateWithoutInitializing("grain_id"), nz, nx,
@@ -52,10 +52,12 @@ int main(int argc, char *argv[]) {
 
         // Fill arrays with data from paraview file
         initializeData(microstructure_file, nx, ny, nz, grain_id, layer_id);
+        std::cout << "Parsed ExaCA grain structure" << std::endl;
 
         // Grain unit vectors, grain euler angles, RGB colors for IPF-Z coloring
         // (9*NumberOfOrientations,  3*NumberOfOrientations, and 3*NumberOfOrientations in size, respectively)
         Orientation<memory_space> orientation(0, grain_unit_vector_file, true);
+        std::cout << "Parsed orientation files" << std::endl;
 
         // Representative region creation
         std::ifstream analysis_data_stream(analysis_file);
@@ -99,13 +101,7 @@ int main(int argc, char *argv[]) {
             if (representativeregion.analysis_options_stats_yn[2])
                 representativeregion.printMeanSize(qois);
 
-            // If XExtent, YExtent, ZExtent, or build_trans_aspect_ratio/Extent are toggled for general stats printing
-            // or per grain printing, calculate grain extents for the necessary direction(s) (otherwise don't, since
-            // it can be slow for large volumes) Extents are calculated in microns
-            // If options StatsYN[3] or PerGrainStatsYN[5] is toggled, grain extents are needed
-            // If StatsYN[4] or PerGrainStatsYN[2] is toggled, X extents are needed
-            // If StatsYN[5] or PerGrainStatsYN[3] is toggled, Y extents are needed
-            // If StatsYN[6] or PerGrainStatsYN[4] is toggled, Z extents are needed
+            // Obtain extents of grains in X, Y, Z if necessary for requested analysis
             representativeregion.calcNecessaryGrainExtents(grain_id, deltax);
             std::vector<float> build_trans_aspect_ratio(representativeregion.number_of_grains);
             if ((representativeregion.analysis_options_stats_yn[3]) ||

--- a/analysis/src/GArepresentativeregion.hpp
+++ b/analysis/src/GArepresentativeregion.hpp
@@ -41,8 +41,7 @@ struct RepresentativeRegion {
     int region_size_cells;
     std::vector<float> grain_extent_x, grain_extent_y, grain_extent_z;
 
-    // Analysis options for printing stats to the screen (_Stats), to the file of grainwise statistics (_PerGrainStats),
-    // or to files of layerwise statistics (_LayerwiseStats)
+    // Analysis options for mean quantities
     std::vector<std::string> analysis_options_stats_key = {
         "GrainTypeFractions",    // all regions
         "Misorientation",        // all regions
@@ -54,6 +53,7 @@ struct RepresentativeRegion {
     };
     bool print_stats_yn = false;
     std::vector<bool> analysis_options_stats_yn = std::vector<bool>(7, false);
+    // Analysis options for per-grain stats
     std::vector<std::string> analysis_options_per_grain_stats_key = {
         "Misorientation",        // all regions
         "Size",                  // all regions - volume, area, or length
@@ -64,6 +64,7 @@ struct RepresentativeRegion {
         "IPFZ-RGB"               // all regions
     };
     std::vector<bool> analysis_options_per_grain_stats_yn = std::vector<bool>(7, false);
+    // Analysis options for layerwise stats
     std::vector<std::string> analysis_options_layerwise_stats_key = {
         "MeanGrainArea",        // volume only
         "MeanWeightedGrainArea" // volume only

--- a/examples/Inp_FinchTranslate.json
+++ b/examples/Inp_FinchTranslate.json
@@ -20,7 +20,7 @@
    "TemperatureData": {
        "TranslationCount": 2,
        "OffsetDirection": "Y",
-       "SpatialOffset": 80,
+       "SpatialOffset": 40,
        "TemporalOffset": 1600,
        "AlternatingDirection": true
    },

--- a/examples/Inp_SingleLine.json
+++ b/examples/Inp_SingleLine.json
@@ -15,14 +15,13 @@
       "StDev": 0.5
    },
    "TemperatureData": {
-       "HeatTransferCellSize": 2.5,
        "LayerwiseTempRead": false,
        "TemperatureFiles": ["examples/Temperatures/Line.txt"]
    },
    "Substrate": {
       "MeanSize": 25,
       "PowderDensity": 64000,
-      "PowderFirstLayer": true
+      "BaseplateTopZ": -0.000020
    },
    "Printing": {
       "PathToOutput": "./",

--- a/examples/Inp_SingleLineTranslate.json
+++ b/examples/Inp_SingleLineTranslate.json
@@ -27,7 +27,7 @@
    "Substrate": {
       "MeanSize": 25,
       "PowderDensity": 64000,
-      "PowderFirstLayer": true
+      "BaseplateTopZ": -0.000020
    },
    "Printing": {
       "PathToOutput": "./",

--- a/examples/Inp_SingleLineTranslate.json
+++ b/examples/Inp_SingleLineTranslate.json
@@ -20,7 +20,7 @@
        "TranslationCount": 2,
        "YRegion": [0, 0.000225],
        "OffsetDirection": "Y",
-       "SpatialOffset": 45,
+       "SpatialOffset": 35,
        "TemporalOffset": 10000,
        "AlternatingDirection": true
    },

--- a/examples/Inp_TwoLineTwoLayer.json
+++ b/examples/Inp_TwoLineTwoLayer.json
@@ -15,7 +15,6 @@
       "StDev": 0.5
    },
    "TemperatureData": {
-       "HeatTransferCellSize": 2.5,
        "LayerwiseTempRead": false,
        "TemperatureFiles": ["examples/Temperatures/TwoLine.txt"]
    },

--- a/src/CAinputdata.hpp
+++ b/src/CAinputdata.hpp
@@ -28,7 +28,7 @@ inline void validSimulationType(std::string simulation_type) {
 // Structs to organize data within inputs struct
 struct DomainInputs {
     double deltax = 0.0, deltat = 0.0;
-    // number of CA cells in each direction only initialized here for problem types C, Spot, and SingleGrain
+    // number of CA cells in each direction only initialized here for problem types Directional, Spot, and SingleGrain
     int nx = 0, ny = 0, nz = 0;
     // multilayer problems only
     int number_of_layers = 1, layer_height = 0;
@@ -80,7 +80,7 @@ struct TemperatureInputs {
 };
 
 struct SubstrateInputs {
-    // problem type C only
+    // problem type Directional only
     std::string surface_init_mode = "";
     // Only used for mode (i)
     double fract_surface_sites_active = 0.0;
@@ -91,7 +91,7 @@ struct SubstrateInputs {
     bool fill_bottom_surface = false;
     // problem type SingleGrain only
     int single_grain_orientation = 0;
-    // problem types Spot and R only
+    // problem types Spot and FromFile only
     bool use_substrate_file = false;
     bool baseplate_through_powder = false;
     std::string substrate_filename = "";

--- a/src/CAinputs.hpp
+++ b/src/CAinputs.hpp
@@ -51,15 +51,17 @@ struct Inputs {
         // "FromFile": time-temperature history comes from external files
         if (simulation_type == "C") {
             simulation_type = "Directional";
-            std::cout << "Warning: Problem type \"C\" is now \"Directional\". Previous name will be removed in a "
-                         "future release."
-                      << std::endl;
+            if (id == 0)
+                std::cout << "Warning: Problem type \"C\" is now \"Directional\". Previous name will be removed in a "
+                             "future release."
+                          << std::endl;
         }
         else if (simulation_type == "RM" || simulation_type == "R") {
             simulation_type = "FromFile";
-            std::cout
-                << "Warning: Problem type \"R\" is now \"FromFile\". Previous name will be removed in a future release."
-                << std::endl;
+            if (id == 0)
+                std::cout << "Warning: Problem type \"R\" is now \"FromFile\". Previous name will be removed in a "
+                             "future release."
+                          << std::endl;
         }
         else if ((simulation_type == "S") || (simulation_type == "SM")) {
             throw std::runtime_error("Error: The spot melt array simulation type (Problem type S or SM) was removed "
@@ -99,7 +101,6 @@ struct Inputs {
             domain.nz = input_data["Domain"]["Nz"];
         }
         else if ((simulation_type == "FromFile") || (simulation_type == "FromFinch")) {
-            // Number of layers, layer height are needed for problem type and R
             domain.number_of_layers = input_data["Domain"]["NumberOfLayers"];
             domain.layer_height = input_data["Domain"]["LayerOffset"];
         }
@@ -128,6 +129,7 @@ struct Inputs {
             nucleation.dtsigma = input_data["Nucleation"]["StDev"];
         }
 
+        // Get interfacial response function coefficients and freezing range from the material input file
         parseIRF(id);
 
         // Temperature inputs:
@@ -212,8 +214,8 @@ struct Inputs {
             // Temperature data uses fixed thermal gradient (K/m) and cooling rate (K/s)
             temperature.G = input_data["TemperatureData"]["G"];
             temperature.R = input_data["TemperatureData"]["R"];
-            // Optional initial undercooling for problem type C (required for type SingleGrain). Defaults to 0 for
-            // problem type C if not given, should be a positive number
+            // Optional initial undercooling for problem type Directional (required for type SingleGrain). Defaults to 0
+            // for problem type Directional if not given, should be a positive number
             if (input_data["TemperatureData"].contains("InitUndercooling"))
                 if (input_data["TemperatureData"]["InitUndercooling"] < 0)
                     throw std::runtime_error("Error: optional temperature data argument InitUndercooling should be "
@@ -726,7 +728,7 @@ struct Inputs {
             if (irf.function == irf.cubic)
                 exaca_log << "       \"D\": " << (irf.D) << "," << std::endl;
             exaca_log << "       \"FreezingRange\": " << (irf.freezing_range) << std::endl;
-            exaca_log << "   },";
+            exaca_log << "   }," << std::endl;
             exaca_log << "   \"NumberMPIRanks\": " << np << "," << std::endl;
             exaca_log << "   \"Decomposition\": {" << std::endl;
             exaca_log << "       \"SubdomainYSize\": [";
@@ -744,6 +746,7 @@ struct Inputs {
         }
     }
 
+    // Get interfacial response function coefficients and freezing range from the material input file
     void parseIRF(const int id) {
         if (id == 0)
             std::cout << "Parsing material file using json input format" << std::endl;
@@ -772,6 +775,9 @@ struct Inputs {
             throw std::runtime_error("Error: Unrecognized functional form for interfacial response function, currently "
                                      "supported options are quadratic, cubic, and exponential");
         irf.freezing_range = data["freezing_range"];
+        MPI_Barrier(MPI_COMM_WORLD);
+        if (id == 0)
+            std::cout << "Successfully parsed material input file" << std::endl;
     }
 };
 

--- a/src/CAorientation.hpp
+++ b/src/CAorientation.hpp
@@ -134,7 +134,7 @@ struct Orientation {
         grain_rgb_ipfz_host = getOrientationsFromFile(rgb_filename, 3, true);
     }
 
-    // Create a view of size "NumberOfOrientations" of the misorientation of each possible grain orientation with the X,
+    // Create a view of size "n_grain_orientations" of the misorientation of each possible grain orientation with the X,
     // Y, or Z directions (dir = 0, 1, or 2, respectively)
     view_type_float_host misorientationCalc(const int dir) {
 

--- a/src/CAprint.hpp
+++ b/src/CAprint.hpp
@@ -175,7 +175,7 @@ struct Print {
     // For intralayer print (current_layer_only = true):
     // Creates a file "Basefilename_layer[layernumber]_[time].vtk" containing the portions of data structures
     // corresponding to the current layer of a multilayer simulation The exception to this is for print
-    // GrainMisorientation, where data for all layer up to the current layer are printed to a separate file
+    // GrainMisorientation, where data for all layers up to the current layer are printed to a separate file
     // "Basefilename_layer[layernumber]_[time]_Misorientations.vtk"
     template <typename MemorySpace>
     void printIntralayer(const int id, const int np, const int layernumber, const double deltat, const int cycle,

--- a/unit_test/tstGrid.hpp
+++ b/unit_test/tstGrid.hpp
@@ -39,7 +39,7 @@ void testCalcZLayerBottom() {
     // Call function for each layernumber with simulation type and "FromFile"
     EXPECT_EQ(z_layer_bottom, 0);
     for (int layernumber = 0; layernumber < grid.number_of_layers; layernumber++) {
-        // Set ZMinLayer for each layer to be offset by LayerHeight cells from the previous one (lets solution for
+        // Set z_min_layer for each layer to be offset by layer_height cells from the previous one (lets solution for
         // both problem types by the same)
         grid.z_min_layer(layernumber) = grid.z_min + layernumber * grid.layer_height * grid.deltax;
         int z_layer_bottom = grid.calcZLayerBottom("FromFile", layernumber);
@@ -49,7 +49,6 @@ void testCalcZLayerBottom() {
 
 void testCalcZLayerTop() {
 
-    // A separate function is now used for ZBound_High calculation
     // Default initialized inputs and grid structs with manually set values for tests
     Inputs inputs;
     inputs.domain.layer_height = 10;
@@ -62,12 +61,12 @@ void testCalcZLayerTop() {
     }
     grid.nz = 111;
     for (int layernumber = 0; layernumber < grid.number_of_layers; layernumber++) {
-        // Set ZMaxLayer for each layer to be offset by LayerHeight cells from the previous one, with layer 0 having a
-        // ZMax value of ZMin + SpotRadius (lets solution for both problem types be the same)
+        // Set ZMaxLayer for each layer to be offset by layer_height cells from the previous one, with layer 0 having a
+        // z_max_layer value of z_min + spot_radius (lets solution for both problem types be the same)
         // Call function for each layernumber for simulation types "FromFile"
         int z_layer_top_R = grid.calcZLayerTop("FromFile", layernumber);
         EXPECT_EQ(z_layer_top_R, (grid.z_max_layer(layernumber) - grid.z_min) / grid.deltax);
-        // For simulation type C, should be independent of layernumber
+        // For simulation type Directional, should be independent of layernumber
         int z_layer_top_C = grid.calcZLayerTop("Directional", layernumber);
         EXPECT_EQ(z_layer_top_C, grid.nz - 1);
         int z_layer_top_S = grid.calcZLayerTop("Spot", layernumber);
@@ -167,10 +166,10 @@ void testFindXYZBounds(bool test_binary_input_read) {
     EXPECT_DOUBLE_EQ(grid.z_min, 0.0);
     EXPECT_DOUBLE_EQ(grid.x_max, (nx - 1) * deltax);
     EXPECT_DOUBLE_EQ(grid.y_max, (ny - 1) * deltax);
-    // ZMax is equal to the largest Z coordinate in the file, offset by LayerHeight cells in the build direction due
+    // z_max is equal to the largest Z coordinate in the file, offset by layer_height cells in the build direction due
     // to the second layer
     EXPECT_DOUBLE_EQ(grid.z_max, 4 * grid.deltax);
-    // Bounds for each individual layer - 2nd layer offset by LayerHeight cells from the first
+    // Bounds for each individual layer - 2nd layer offset by layer_height cells from the first
     EXPECT_DOUBLE_EQ(grid.z_min_layer(0), 0.0);
     EXPECT_DOUBLE_EQ(grid.z_max_layer(0), (nz - 1) * deltax);
     EXPECT_DOUBLE_EQ(grid.z_min_layer(1), (nz - 1) * deltax);

--- a/unit_test/tstInputs.hpp
+++ b/unit_test/tstInputs.hpp
@@ -23,7 +23,7 @@ void writeTestData(std::string input_filename, int print_version) {
     test_data_file.open(input_filename);
     // Write required inputs to all files
     test_data_file << "{" << std::endl;
-    test_data_file << "   \"SimulationType\": \"R\"," << std::endl;
+    test_data_file << "   \"SimulationType\": \"FromFile\"," << std::endl;
     test_data_file << "   \"MaterialFileName\": \"Inconel625.json\"," << std::endl;
     test_data_file << "   \"GrainOrientationFile\": \"GrainOrientationVectors.csv\"," << std::endl;
     test_data_file << "   \"RandomSeed\": 2," << std::endl;
@@ -86,8 +86,7 @@ void testInputs(int print_version) {
     // Get individual process ID
     MPI_Comm_rank(MPI_COMM_WORLD, &id);
 
-    // Three input files - one of each type
-    // Inp_DirSolidification.txt and Inp_SpotMelt.txt were installed from the examples directory
+    // DirSolidification, SpotMelt, TwoGrainDirSolidification were installed from the examples directory
     // Since no temperature files exist in the repo, and there is no ability to write temperature files to a different
     // directory ( would need examples/Temperatures) using the C++11 standard, dummy input files are written and parsed
     // to test an example problem that uses temperature data from a file.
@@ -128,7 +127,7 @@ void testInputs(int print_version) {
 
         // Check the results
         // The existence of the specified orientation, substrate, and temperature filenames was already checked within
-        // InputReadFromFile
+        // inputs constructor
         // These should be the same for all test problems (except the 4th one, which has 0 nucleation density)
         EXPECT_DOUBLE_EQ(inputs.domain.deltax, 1.0 * pow(10, -6));
         if (filename == input_filenames[3])

--- a/unit_test/tstInterface.hpp
+++ b/unit_test/tstInterface.hpp
@@ -111,7 +111,7 @@ void testHaloUpdate() {
 
     // Testing of loading of ghost nodes data, sending/receiving, unpacking, and calculations on ghost node data:
     // X = 2, Z = 1 is chosen for active cell placement on all ranks
-    // Active cells will be located at Y = 1 and Y = MyYSlices-2 on each rank... these are located in the halo regions
+    // Active cells will be located at Y = 1 and Y = ny_local-2 on each rank... these are located in the halo regions
     // and should be loaded into the send buffers
     int halo_locations_active_region[2];
     halo_locations_active_region[0] = 1 * grid.nx * grid.ny_local + 2 * grid.ny_local + 1;
@@ -182,7 +182,7 @@ void testHaloUpdate() {
 
     haloUpdate(0, 0, grid, celldata, interface, orientation);
 
-    // Copy CellType, GrainID, DiagonalLength, DOCenter, CritDiagonalLength views to host to check values
+    // Copy views to host to check values
     grain_id = celldata.getGrainIDSubview(grid);
     grain_id_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), grain_id);
     cell_type_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), celldata.cell_type);
@@ -528,7 +528,7 @@ void testFillSteeringVector_Remelt() {
             }
             else {
                 // Cells "melt" at a time step corresponding to their Y location in the overall domain (depends on
-                // MyYOffset of the rank)
+                // y_offset of the rank)
                 temperature.liquidus_time(index, 0, 0) = coord_y + grid.y_offset + 1;
                 // Cells reach liquidus during cooling 2 time steps after melting
                 temperature.liquidus_time(index, 0, 1) = temperature.liquidus_time(index, 0, 0) + 2;
@@ -548,8 +548,7 @@ void testFillSteeringVector_Remelt() {
         fillSteeringVector_Remelt(cycle, grid, celldata, temperature, interface);
     }
 
-    // Copy CellType, SteeringVector, numSteer, UndercoolingCurrent, Buffers back to host to check steering vector
-    // construction results
+    // Copy data back to host to check steering vector construction results
     auto cell_type_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), celldata.cell_type);
     auto steering_vector_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), interface.steering_vector);
     auto num_steer_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), interface.num_steer);
@@ -557,7 +556,7 @@ void testFillSteeringVector_Remelt() {
         Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), temperature.undercooling_current);
     auto liquidus_time_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), temperature.liquidus_time);
 
-    // Check the modified CellType and UndercoolingCurrent values on the host:
+    // Check the modified cell_type and undercooling_current values on the host:
     // Check that the cells corresponding to outside of the "active" portion of the domain have unchanged values
     // Check that the cells corresponding to the "active" portion of the domain have potentially changed values
     // Z = 3: Rank 0, with all cells having GrainID = 0, should have Liquid cells everywhere, with undercooling

--- a/unit_test/tstNucleation.hpp
+++ b/unit_test/tstNucleation.hpp
@@ -139,9 +139,8 @@ void testNucleiInit() {
         Kokkos::create_mirror_view_and_copy(memory_space(), max_solidification_events_host);
 
     // Nucleation data structure, containing views of nuclei locations, time steps, and ids, and nucleation event
-    // counters - initialized with an estimate on the number of nuclei in the layer Without knowing
-    // possible_nuclei_ThisRankThisLayer yet, initialize nucleation data structures to estimated sizes, resize inside of
-    // NucleiInit when the number of nuclei per rank is known
+    // counters - initialized with an estimate on the number of nuclei in the layer
+    // (estimated_nuclei_this_rank_this_layer)
     const double domain_volume = (grid.x_max - grid.x_min) * (grid.y_max - grid.y_min) *
                                  (grid.z_max_layer(1) - grid.z_min_layer(1)) * pow(grid.deltax, 3);
     int estimated_nuclei_this_rank_this_layer = inputs.nucleation.n_max * pow(grid.deltax, 3) * grid.domain_size;
@@ -238,9 +237,9 @@ void testNucleateGrain() {
     view_int_host nuclei_grain_id_host(Kokkos::ViewAllocateWithoutInitializing("nuclei_grain_id_host"),
                                        possible_nuclei);
     for (int n = 0; n < possible_nuclei; n++) {
-        // NucleationTimes values should be in the order in which the events occur - start with setting them between 0
-        // and 9 nuclei_locations are in order starting with 0, through 9 (locations relative to the bottom of the
-        // layer)
+        // nucleation_times_host values should be in the order in which the events occur - start with setting them
+        // between 0 and 9 nuclei_locations are in order starting with 0, through 9 (locations relative to the bottom of
+        // the layer)
         nucleation.nucleation_times_host(n) = n;
         nuclei_locations_host(n) = n;
         // Give these nucleation events grain IDs based on their order, starting with -1 and counting down
@@ -282,7 +281,7 @@ void testNucleateGrain() {
         nucleation.nucleateGrain(cycle, grid, celldata, interface);
     }
 
-    // Copy CellType, SteeringVector, numSteer, grain_id back to host to check nucleation results
+    // Copy views back to host to check nucleation results
     cell_type_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), celldata.cell_type);
     auto steering_vector_host_local =
         Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), interface.steering_vector);

--- a/unit_test/tstTemperature.hpp
+++ b/unit_test/tstTemperature.hpp
@@ -136,7 +136,7 @@ void testReadTemperatureData(int number_of_layers, bool layerwise_temp_read, boo
     EXPECT_TRUE(temperature._inputs.temp_paths[0] == inputs.temperature.temp_paths[0]);
     EXPECT_TRUE(temperature._inputs.temp_paths[1] == inputs.temperature.temp_paths[1]);
 
-    // Read in data to "RawTemperatureData"
+    // Read in data to "raw_temperature_data"
     temperature.readTemperatureData(id, grid, 0);
     // Check the results.
     // Does each rank have the right number of temperature data points? Each rank should have one for each of the 9
@@ -266,7 +266,7 @@ void testInit_UnidirectionalGradient(const std::string simulation_type, const do
             for (int coord_y = 0; coord_y < grid.ny_local; coord_y++) {
                 int index = grid.get1DIndex(coord_x, coord_y, coord_z);
                 // Each cell solidifies once, and counter should start at 0, associated with the zeroth layer
-                // MeltTimeStep should be -1 for all cells
+                // melt time step should be -1 for all cells
                 // Cells cool at 1 K per time step
                 EXPECT_FLOAT_EQ(liquidus_time_host(index, 0, 0), -1.0);
                 EXPECT_FLOAT_EQ(cooling_rate_host(index, 0), R_norm);


### PR DESCRIPTION
Minor changes to comments to ensure they are up to date with the current code, also changed a couple of variable names for consistency with the current capitalization scheme, and changed a few std::cout messages.

Only changes to the actual code functionality are the two commits that are separated out - a portion of the powder layer init is skipped if the number of powder layer cells to be assigned grain ID values is 0 (this also avoids printing a confusing std::cout message about assigning cells non-existent powder layer grain IDs, and the translation increment in the two relevant example files was updated to ensure the temperature data actually overlaps.