### PR TITLE
Fixed naming error in per Z coordinate grain analysis option

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -11,10 +11,10 @@ The analysis files, such as `examples/AnalyzeDirS.json`, allow analysis of multi
 
 1D, 2D, and 3D regions can be analyzed depending on the bounds provided. The `units` input for each region should be either Meters or Cells, depending on the values used as the bounds. For example, if `xBounds`, `yBounds`, and `zBounds` are all provided (in the form `[lower, upper]`), and the lower and upper bounds for each direction do not match, the region is analyzed as a volume. If one direction has equivalent lower and upper bounds, the region is analyzed as an area, and if two directions have equivalent lower and upper bounds, the region is analyzed as a line. If no bounds are given for a direction, the analysis will default to including the entire domain extent in said direction.
 
-Once the bounds of each region are identified, the analysis options can be specified within JSON arrays under `printAvgStats`, `printPerGrainStats`, and `printPerLayerStats`. 
+Once the bounds of each region are identified, the analysis options can be specified within JSON arrays under `printAvgStats`, `printPerGrainStats`, and `printPerZCoordinateStats`. 
 * Values specified in `printStats` will print average quantities to the console as well as to a file names `[MicrostructureBaseFilename]_[RegionName]_QoIs.txt`
 * Values specified in `printPerGrainStats` will print data for each individual grain ID to a csv file of per-grain data named `[MicrostructureBaseFilename]_[RegionName]_grains.csv`
-* Values specified in `printLayerwiseData` will be printed in additional separate files.
+* Values specified in `printPerZCoordinateStats` will be printed in additional separate files.
 
 | Output                | Compatible options            | Details
 |=======================|===============================|====================
@@ -26,8 +26,8 @@ Once the bounds of each region are identified, the analysis options can be speci
 | YExtent               | printAvgStats/printPerGrainStats | Prints the extent of the grain (in microns) in the Y direction
 | ZExtent               | printAvgStats/printPerGrainStats | Prints the extent of the grain (in microns) in the Z direction
 | IPFZ-RGB              | printPerGrainStats            | Prints the R,G,B values (each between 0 and 1) corresponding to the inverse pole figure mapping of the grain orientation, relative to the build (Z) direction
-| MeanGrainArea         | printPerLayerStats            | Prints the mean grain cross-sectional (XY) area for each Z coordinate in the simulation to a file `[MicrostructureBaseFilename]_GrainAreas.csv`
-| MeanWeightedGrainArea | printPerLayerStats            | Prints the mean grain cross-sectional (XY) area, weighted by the grain area itself, for each 5th Z coordinate in the simulation to a file `[MicrostructureBaseFilename]_WeightedGrainAreas.csv` (Note: this option will be removed in a future release)
+| MeanGrainArea         | printPerZCoordinateStats            | Prints the mean grain cross-sectional (XY) area for each Z coordinate in the simulation to a file `[MicrostructureBaseFilename]_GrainAreas.csv`
+| MeanWeightedGrainArea | printPerZCoordinateStats            | Prints the mean grain cross-sectional (XY) area, weighted by the grain area itself, for each 5th Z coordinate in the simulation to a file `[MicrostructureBaseFilename]_WeightedGrainAreas.csv` (Note: this option will be removed in a future release)
 
 Additional analysis options for certain region types can be specified by setting them to `true` in the analysis input file (if the option does not appear in the input file, it is turned off by default)
 

--- a/analysis/bin/runGA.cpp
+++ b/analysis/bin/runGA.cpp
@@ -126,8 +126,8 @@ int main(int argc, char *argv[]) {
             // toggled, writing to files
             // "[base_filename_this_region]_WeightedGrainAreas.csv" and "[base_filename_this_region]_GrainAreas.csv",
             // respectively
-            if ((representativeregion.analysis_options_layerwise_stats_yn[0]) ||
-                (representativeregion.analysis_options_layerwise_stats_yn[1]))
+            if ((representativeregion.analysis_options_per_z_stats_yn[0]) ||
+                (representativeregion.analysis_options_per_z_stats_yn[1]))
                 representativeregion.writeAreaSeries(base_filename_this_region, deltax, grain_id);
             if (representativeregion.print_stats_yn)
                 qois.close();

--- a/analysis/examples/AnalyzeDirS.json
+++ b/analysis/examples/AnalyzeDirS.json
@@ -9,7 +9,7 @@
             "printPoleFigureData": true,
             "printAvgStats": ["GrainTypeFractions","Misorientation","Size", "BuildTransAspectRatio","Extent"],
             "printPerGrainStats": ["Misorientation","Size","ZExtent"],
-            "printPerLayerStats": ["MeanGrainArea","MeanWeightedGrainArea"]
+            "printPerZCoordinateStats": ["MeanGrainArea","MeanWeightedGrainArea"]
         },
         "XYCross": {
             "units": "cells",

--- a/analysis/examples/AnalyzeSmallDirS.json
+++ b/analysis/examples/AnalyzeSmallDirS.json
@@ -9,7 +9,7 @@
             "printPoleFigure": true,
             "printAvgStats": ["GrainTypeFractions","Misorientation","Size", "BuildTransAspectRatio","Extent"],
             "printPerGrainStats": ["Misorientation","Size","ZExtent"],
-            "printPerLayerStats": ["MeanGrainArea","MeanWeightedGrainArea"]
+            "printPerZCoordinateStats": ["MeanGrainArea","MeanWeightedGrainArea"]
         },
         "XYCross": {
             "units": "Cells",

--- a/analysis/src/GArepresentativeregion.hpp
+++ b/analysis/src/GArepresentativeregion.hpp
@@ -131,7 +131,7 @@ struct RepresentativeRegion {
             }
         }
         if ((layerwise_label == "printLayerwiseData") || (layerwise_label == "printPerLayerStats"))
-            std::cout << "Note: " << layerwise_label
+            std::cout << "Warning: " << layerwise_label
                       << " option has been deprecated and replaced with printPerZCoordinateStats; compatibility will "
                          "be removed in a future release"
                       << std::endl;

--- a/analysis/unit_test/tstRepresentativeRegion.hpp
+++ b/analysis/unit_test/tstRepresentativeRegion.hpp
@@ -56,7 +56,7 @@ void writeTestVolume() {
                  "\"BuildTransAspectRatio\", \"XExtent\", \"YExtent\", \"ZExtent\"],"
               << std::endl;
     test_data << "          \"printPerGrainStats\": [\"IPFZ-RGB\", \"Size\"]," << std::endl;
-    test_data << "          \"printLayerwiseData\": [\"MeanGrainArea\", \"MeanWeightedGrainArea\"]" << std::endl;
+    test_data << "          \"printPerZCoordinateStats\": [\"MeanGrainArea\", \"MeanWeightedGrainArea\"]" << std::endl;
     test_data << "      }" << std::endl;
     test_data << "   }" << std::endl;
     test_data << "}" << std::endl;
@@ -123,9 +123,9 @@ void testConstructRepresentativeRegion_Volume() {
         else
             EXPECT_FALSE(representativeregion.analysis_options_per_grain_stats_yn[i]);
     }
-    int num_analysis_options_layerwise_stats = representativeregion.analysis_options_layerwise_stats_yn.size();
-    for (int i = 0; i < num_analysis_options_layerwise_stats; i++)
-        EXPECT_TRUE(representativeregion.analysis_options_layerwise_stats_yn[i]);
+    int num_analysis_options_per_z_stats = representativeregion.analysis_options_per_z_stats_yn.size();
+    for (int i = 0; i < num_analysis_options_per_z_stats; i++)
+        EXPECT_TRUE(representativeregion.analysis_options_per_z_stats_yn[i]);
     EXPECT_TRUE(representativeregion.print_per_grain_stats_yn);
     EXPECT_TRUE(representativeregion.print_pole_figure_yn);
     EXPECT_FALSE(representativeregion.print_exaconstit_yn);
@@ -193,9 +193,9 @@ void testConstructRepresentativeRegion_Area() {
         else
             EXPECT_FALSE(representativeregion.analysis_options_per_grain_stats_yn[i]);
     }
-    int num_analysis_options_layerwise_stats = representativeregion.analysis_options_layerwise_stats_yn.size();
+    int num_analysis_options_layerwise_stats = representativeregion.analysis_options_per_z_stats_yn.size();
     for (int i = 0; i < num_analysis_options_layerwise_stats; i++)
-        EXPECT_FALSE(representativeregion.analysis_options_layerwise_stats_yn[i]);
+        EXPECT_FALSE(representativeregion.analysis_options_per_z_stats_yn[i]);
     EXPECT_TRUE(representativeregion.print_per_grain_stats_yn);
     EXPECT_TRUE(representativeregion.print_pole_figure_yn);
     EXPECT_FALSE(representativeregion.print_exaconstit_yn);

--- a/analysis/unit_test/tstRepresentativeRegion.hpp
+++ b/analysis/unit_test/tstRepresentativeRegion.hpp
@@ -193,8 +193,8 @@ void testConstructRepresentativeRegion_Area() {
         else
             EXPECT_FALSE(representativeregion.analysis_options_per_grain_stats_yn[i]);
     }
-    int num_analysis_options_layerwise_stats = representativeregion.analysis_options_per_z_stats_yn.size();
-    for (int i = 0; i < num_analysis_options_layerwise_stats; i++)
+    int num_analysis_options_per_z_stats = representativeregion.analysis_options_per_z_stats_yn.size();
+    for (int i = 0; i < num_analysis_options_per_z_stats; i++)
         EXPECT_FALSE(representativeregion.analysis_options_per_z_stats_yn[i]);
     EXPECT_TRUE(representativeregion.print_per_grain_stats_yn);
     EXPECT_TRUE(representativeregion.print_pole_figure_yn);


### PR DESCRIPTION
Resolved inconsistency between analysis input files, analysis README, and analysis post-processing code for printing grain area statistics for a volume on a Z coordinate basis. The updated code allows all naming options for what is now called `perZCoodinateStats`, but prints a warning if more than one is given (with one overwriting the other) or a deprecation warning if an old name is given