### PR TITLE
Fix device print usage

### DIFF
--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -557,27 +557,18 @@ void refillBuffers(const Grid &grid, CellData<MemorySpace> &celldata, Interface<
                     float ghost_diagonal_length = interface.diagonal_length(index_south_buffer);
                     // Collect data for the ghost nodes, if necessary
                     // Data loaded into the ghost nodes is for the cell that was just captured
-                    bool data_fits_in_buffer = interface.loadGhostNodes(
-                        ghost_grain_id, ghost_octahedron_center_x, ghost_octahedron_center_y, ghost_octahedron_center_z,
-                        ghost_diagonal_length, grid.ny_local, coord_x, 1, coord_z, grid.at_north_boundary,
-                        grid.at_south_boundary, n_grain_orientations);
+                    interface.loadGhostNodes(ghost_grain_id, ghost_octahedron_center_x, ghost_octahedron_center_y,
+                                             ghost_octahedron_center_z, ghost_diagonal_length, grid.ny_local, coord_x,
+                                             1, coord_z, grid.at_north_boundary, grid.at_south_boundary,
+                                             n_grain_orientations);
                     celldata.cell_type(index_south_buffer) = Active;
-                    // If data doesn't fit in the buffer after the resize, warn that buffer data may have been lost
-                    if (!(data_fits_in_buffer))
-                        printf("Error: Send/recv buffer resize failed to include all necessary data, predicted "
-                               "results at MPI processor boundaries may be inaccurate\n");
                 }
                 else if (celldata.cell_type(index_south_buffer) == LiquidFailedBufferLoad) {
                     // Dummy values for first 4 arguments (Grain ID and octahedron center coordinates), 0 for
                     // diagonal length
-                    bool data_fits_in_buffer =
-                        interface.loadGhostNodes(-1, -1.0, -1.0, -1.0, 0.0, grid.ny_local, coord_x, 1, coord_z,
-                                                 grid.at_north_boundary, grid.at_south_boundary, n_grain_orientations);
+                    interface.loadGhostNodes(-1, -1.0, -1.0, -1.0, 0.0, grid.ny_local, coord_x, 1, coord_z,
+                                             grid.at_north_boundary, grid.at_south_boundary, n_grain_orientations);
                     celldata.cell_type(index_south_buffer) = Liquid;
-                    // If data doesn't fit in the buffer after the resize, warn that buffer data may have been lost
-                    if (!(data_fits_in_buffer))
-                        printf("Error: Send/recv buffer resize failed to include all necessary data, predicted "
-                               "results at MPI processor boundaries may be inaccurate\n");
                 }
                 if (celldata.cell_type(index_north_buffer) == ActiveFailedBufferLoad) {
                     int ghost_grain_id = grain_id(index_north_buffer);
@@ -587,27 +578,19 @@ void refillBuffers(const Grid &grid, CellData<MemorySpace> &celldata, Interface<
                     float ghost_diagonal_length = interface.diagonal_length(index_north_buffer);
                     // Collect data for the ghost nodes, if necessary
                     // Data loaded into the ghost nodes is for the cell that was just captured
-                    bool data_fits_in_buffer = interface.loadGhostNodes(
-                        ghost_grain_id, ghost_octahedron_center_x, ghost_octahedron_center_y, ghost_octahedron_center_z,
-                        ghost_diagonal_length, grid.ny_local, coord_x, grid.ny_local - 2, coord_z,
-                        grid.at_north_boundary, grid.at_south_boundary, n_grain_orientations);
+                    interface.loadGhostNodes(ghost_grain_id, ghost_octahedron_center_x, ghost_octahedron_center_y,
+                                             ghost_octahedron_center_z, ghost_diagonal_length, grid.ny_local, coord_x,
+                                             grid.ny_local - 2, coord_z, grid.at_north_boundary, grid.at_south_boundary,
+                                             n_grain_orientations);
                     celldata.cell_type(index_north_buffer) = Active;
-                    // If data doesn't fit in the buffer after the resize, warn that buffer data may have been lost
-                    if (!(data_fits_in_buffer))
-                        printf("Error: Send/recv buffer resize failed to include all necessary data, predicted "
-                               "results at MPI processor boundaries may be inaccurate\n");
                 }
                 else if (celldata.cell_type(index_north_buffer) == LiquidFailedBufferLoad) {
                     // Dummy values for first 4 arguments (Grain ID and octahedron center coordinates), 0 for
                     // diagonal length
-                    bool data_fits_in_buffer = interface.loadGhostNodes(
-                        -1, -1.0, -1.0, -1.0, 0.0, grid.ny_local, coord_x, grid.ny_local - 2, coord_z,
-                        grid.at_north_boundary, grid.at_south_boundary, n_grain_orientations);
+                    interface.loadGhostNodes(-1, -1.0, -1.0, -1.0, 0.0, grid.ny_local, coord_x, grid.ny_local - 2,
+                                             coord_z, grid.at_north_boundary, grid.at_south_boundary,
+                                             n_grain_orientations);
                     celldata.cell_type(index_north_buffer) = Liquid;
-                    // If data doesn't fit in the buffer after the resize, warn that buffer data may have been lost
-                    if (!(data_fits_in_buffer))
-                        printf("Error: Send/recv buffer resize failed to include all necessary data, predicted "
-                               "results at MPI processor boundaries may be inaccurate\n");
                 }
             }
         });


### PR DESCRIPTION
Only print with Kokkos::printf (introduced in version 4.2)

Previously broke with SYCL backend