### PR TITLE
Shared Voronoi functionality between baseplate and powder init

### DIFF
--- a/examples/Inp_Finch.json
+++ b/examples/Inp_Finch.json
@@ -18,7 +18,7 @@
       "TrimUnmeltedRegion": true
    },
    "Substrate": {
-      "MeanSize": 50
+      "MeanBaseplateGrainSize": 50
    },
    "Printing": {
       "PathToOutput": "./",

--- a/examples/Inp_FinchTranslate.json
+++ b/examples/Inp_FinchTranslate.json
@@ -15,7 +15,7 @@
       "StDev": 0.5
    },
    "Substrate": {
-      "MeanSize": 50
+      "MeanBaseplateGrainSize": 50
    },
    "TemperatureData": {
        "TranslationCount": 2,

--- a/examples/Inp_SingleLine.json
+++ b/examples/Inp_SingleLine.json
@@ -19,8 +19,8 @@
        "TemperatureFiles": ["examples/Temperatures/Line.txt"]
    },
    "Substrate": {
-      "MeanSize": 25,
-      "PowderDensity": 64000,
+      "MeanBaseplateGrainSize": 25,
+      "MeanPowderGrainSize": 2.5,
       "BaseplateTopZ": -0.000020
    },
    "Printing": {

--- a/examples/Inp_SingleLineTranslate.json
+++ b/examples/Inp_SingleLineTranslate.json
@@ -25,8 +25,8 @@
        "AlternatingDirection": true
    },
    "Substrate": {
-      "MeanSize": 25,
-      "PowderDensity": 64000,
+      "MeanBaseplateGrainSize": 25,
+      "MeanPowderGrainSize": 2.5,
       "BaseplateTopZ": -0.000020
    },
    "Printing": {

--- a/examples/Inp_SmallFinch.json
+++ b/examples/Inp_SmallFinch.json
@@ -15,7 +15,7 @@
       "StDev": 0.5
    },
    "Substrate": {
-      "MeanSize": 75
+      "MeanBaseplateGrainSize": 75
    },
    "Printing": {
       "PathToOutput": "./",

--- a/examples/Inp_SmallSpotMelt.json
+++ b/examples/Inp_SmallSpotMelt.json
@@ -18,8 +18,8 @@
       "R": 300000
    },
    "Substrate": {
-      "MeanSize": 25,
-      "PowderDensity": 1000000
+      "MeanBaseplateGrainSize": 25,
+      "MeanPowderGrainSize": 1000000
    },
    "Printing": {
        "PathToOutput": "./",

--- a/examples/Inp_SpotMelt.json
+++ b/examples/Inp_SpotMelt.json
@@ -18,8 +18,8 @@
       "R": 300000
    },
    "Substrate": {
-      "MeanSize": 25,
-      "PowderDensity": 1000000
+      "MeanBaseplateGrainSize": 25,
+      "MeanPowderGrainSize": 1
    },
    "Printing": {
       "PathToOutput": "./",

--- a/examples/Inp_TwoLineTwoLayer.json
+++ b/examples/Inp_TwoLineTwoLayer.json
@@ -19,8 +19,8 @@
        "TemperatureFiles": ["examples/Temperatures/TwoLine.txt"]
    },
    "Substrate": {
-      "MeanSize": 25,
-      "PowderDensity": 64000
+      "MeanBaseplateGrainSize": 25,
+      "MeanPowderGrainSize": 2.5
    },
    "Printing": {
       "PathToOutput": "./",

--- a/examples/README.md
+++ b/examples/README.md
@@ -106,9 +106,9 @@ The .json files in the examples subdirectory are provided on the command line to
 |GrainLocationsY     | Directional      | List of grain locations in Y on the bottom surface of the domain (see note (b-iii))
 |GrainIDs            | Directional      | GrainID values for each grain in (X,Y) (see note (b3))
 |FillBottomSurface   | Directional      | Optionally assign all cells on the bottom surface the grain ID of the closest grain (defaults to false)
-|MeanSize            | Spot, FromFile, FromFinch       | Mean spacing between grain centers in the baseplate/substrate (in microns) (see note (a))
+|MeanBaseplateGrainSize | Spot, FromFile, FromFinch       | Mean spacing between grain centers in the baseplate/substrate (in microns) (see note (a))
 |SubstrateFilename   |  Spot, FromFile, FromFinch  | Path to and filename for substrate data in vtk format (see note (a))
-|PowderDensity       | Spot, FromFile, FromFinch       | Density of sites in the powder layer to be assigned as the home of a unique grain, normalized by 1 x 10^12 m^-3 (default value is 1/(CA cell size ^3) (see note (a))
+|MeanPowderGrainSize | Spot, FromFile, FromFinch    | Mean spacing between grain centers in the powder layer (in microns). Defaults to one grain per cell
 |ExtendSubstrateThroughPowder| FromFile, FromFinch  | true/false value: Whether to use the baseplate microstructure as the boundary condition for the entire height of the simulation (defaults to false) (see note (a))
 | BaseplateTopZ      | FromFile, FromFinch          | The Z coordinate that marks the top of the baseplate/boundary of the baseplate with the powder. If not given, Z = 0 microns will be assumed to be the baseplate top if ExtendSubstrateThroughPowder = false (If ExtendSubstrateThroughPowder = true, the entire domain will be initialized with the baseplate grain structure)
 |GrainOrientation | SingleGrain           | Which orientation from the orientation's file is assigned to the grain (starts at 0). Default is 0 

--- a/src/CAinputdata.hpp
+++ b/src/CAinputdata.hpp
@@ -95,9 +95,8 @@ struct SubstrateInputs {
     bool use_substrate_file = false;
     bool baseplate_through_powder = false;
     std::string substrate_filename = "";
-    double substrate_grain_spacing = 0.0;
-    // defaults to all sites in powder layer initialized with a new grain
-    double powder_active_fraction = 1.0;
+    double baseplate_grain_spacing = 0.0;
+    double powder_grain_spacing = 1.0;
     // Top of baseplate assumed at Z = 0 if not otherwise given
     double baseplate_top_z = 0.0;
     // Initial size of octahedra during initialization of an active cell

--- a/src/CAnucleation.hpp
+++ b/src/CAnucleation.hpp
@@ -155,9 +155,9 @@ struct Nucleation {
         std::shuffle(nuclei_grain_id_whole_domain_v.begin(), nuclei_grain_id_whole_domain_v.end(), generator);
         std::shuffle(nuclei_undercooling_whole_domain_v.begin(), nuclei_undercooling_whole_domain_v.end(), generator);
         if ((id == 0) && (nuclei_this_layer > 0))
-            std::cout << "Range of Grain IDs from which layer " << layernumber
-                      << " nucleation events were selected: " << nuclei_whole_domain + 1 << " through "
-                      << nuclei_whole_domain + nuclei_this_layer << std::endl;
+            std::cout << "Range of Grain IDs from which layer " << layernumber << " nucleation events were selected: -"
+                      << nuclei_whole_domain + 1 << " through -" << nuclei_whole_domain + nuclei_this_layer
+                      << std::endl;
         // Update number of nuclei counter for whole domain based on the number of nuclei in this layer
         nuclei_whole_domain += nuclei_this_layer;
 

--- a/src/runCA.hpp
+++ b/src/runCA.hpp
@@ -24,10 +24,6 @@ void runExaCA(int id, int np, Inputs inputs, Timers timers, Grid grid, Temperatu
     // Material response function
     InterfacialResponseFunction irf(inputs.domain.deltat, grid.deltax, inputs.irf);
 
-    // Ensure that input powder layer init options are compatible with this domain size, if needed for this problem type
-    if (simulation_type == "FromFile")
-        inputs.checkPowderOverflow(grid.nx, grid.ny, grid.layer_height, grid.number_of_layers);
-
     // Read temperature data if necessary
     if (simulation_type == "FromFile")
         temperature.readTemperatureData(id, grid, 0);

--- a/unit_test/tstCellData.hpp
+++ b/unit_test/tstCellData.hpp
@@ -270,9 +270,9 @@ void testCellDataInit(bool powder_first_layer) {
     // baseplate. This grain spacing ensures that there will be 1 grain per number of MPI ranks present (larger when
     // powder layer is present as the baseplate will only have a third as many cells)
     if (powder_first_layer)
-        inputs.substrate.substrate_grain_spacing = 2.62;
+        inputs.substrate.baseplate_grain_spacing = 2.62;
     else
-        inputs.substrate.substrate_grain_spacing = 3.0;
+        inputs.substrate.baseplate_grain_spacing = 3.0;
     inputs.rng_seed = 0.0;
 
     // Create dummy temperature data
@@ -295,10 +295,10 @@ void testCellDataInit(bool powder_first_layer) {
     CellData<memory_space> celldata(grid, inputs.substrate);
     // Check that substrate inputs were copied from inputs struct correctly
     EXPECT_DOUBLE_EQ(inputs.substrate.baseplate_top_z, celldata._inputs.baseplate_top_z);
-    EXPECT_DOUBLE_EQ(inputs.substrate.substrate_grain_spacing, celldata._inputs.substrate_grain_spacing);
+    EXPECT_DOUBLE_EQ(inputs.substrate.baseplate_grain_spacing, celldata._inputs.baseplate_grain_spacing);
     EXPECT_FALSE(celldata._inputs.use_substrate_file);
     EXPECT_FALSE(celldata._inputs.baseplate_through_powder);
-    EXPECT_DOUBLE_EQ(celldata._inputs.powder_active_fraction, 1.0);
+    EXPECT_DOUBLE_EQ(celldata._inputs.powder_grain_spacing, grid.deltax * pow(10, 6));
     // Initialize baseplate grain structure
     celldata.initSubstrate(id, grid, inputs.rng_seed, number_of_solidification_events);
 

--- a/unit_test/tstInputs.hpp
+++ b/unit_test/tstInputs.hpp
@@ -43,7 +43,8 @@ void writeTestData(std::string input_filename, int print_version) {
                    << std::endl;
     test_data_file << "   }," << std::endl;
     test_data_file << "   \"Substrate\": {" << std::endl;
-    // Note: old input used here to check that the expected mean powder grain spacing ends up correct
+    // FIXME: old input PowderDensity used here to check that the expected mean powder grain spacing ends up correct,
+    // change this to MeanPowderGrainSize when deprecated input compatibility is removed
     test_data_file << "      \"SubstrateFilename\": \"DummySubstrate.vtk\"," << std::endl;
     test_data_file << "      \"PowderDensity\": 1000," << std::endl;
     test_data_file << "      \"BaseplateTopZ\": -0.00625" << std::endl;

--- a/unit_test/tstInputs.hpp
+++ b/unit_test/tstInputs.hpp
@@ -43,6 +43,7 @@ void writeTestData(std::string input_filename, int print_version) {
                    << std::endl;
     test_data_file << "   }," << std::endl;
     test_data_file << "   \"Substrate\": {" << std::endl;
+    // Note: old input used here to check that the expected mean powder grain spacing ends up correct
     test_data_file << "      \"SubstrateFilename\": \"DummySubstrate.vtk\"," << std::endl;
     test_data_file << "      \"PowderDensity\": 1000," << std::endl;
     test_data_file << "      \"BaseplateTopZ\": -0.00625" << std::endl;
@@ -209,7 +210,7 @@ void testInputs(int print_version) {
             EXPECT_EQ(inputs.domain.spot_radius, 75);
             EXPECT_FALSE(inputs.substrate.use_substrate_file);
             EXPECT_FALSE(inputs.substrate.baseplate_through_powder);
-            EXPECT_FLOAT_EQ(inputs.substrate.substrate_grain_spacing, 25.0);
+            EXPECT_FLOAT_EQ(inputs.substrate.baseplate_grain_spacing, 25.0);
             EXPECT_TRUE(inputs.print.base_filename == "TestProblemSpot");
             EXPECT_TRUE(inputs.print.intralayer);
             EXPECT_EQ(inputs.print.intralayer_increment, 2000);
@@ -249,7 +250,7 @@ void testInputs(int print_version) {
             EXPECT_EQ(inputs.domain.layer_height, 1);
             EXPECT_TRUE(inputs.substrate.use_substrate_file);
             EXPECT_FALSE(inputs.temperature.layerwise_temp_read);
-            EXPECT_DOUBLE_EQ(inputs.substrate.powder_active_fraction, 0.001);
+            EXPECT_DOUBLE_EQ(inputs.substrate.powder_grain_spacing, 10.0);
             // -0.00625 was input
             EXPECT_DOUBLE_EQ(inputs.substrate.baseplate_top_z, -0.00625);
             EXPECT_TRUE(inputs.print.base_filename == "Test");


### PR DESCRIPTION
An edge case was previously possible in ExaCA where, due to the fact that the powder layer initialization left some cells with a "zero" GrainID, simulations of FromFile and FromFinch problems could get locked in a loop where no valid grain could claim the liquid cells in some melt pools for many time steps, often leading to simulation timeout. It also lead to unnatural grain shapes as grains stretch across multiple melt pools.

This changeset uses Voronoi helper functions to initialize both the baseplate (which previously used a Voronoi tessellation to assigned GrainIDs to cells) and each powder layer, so that no cells have a GrainID of 0 following initialization. The PowderDensity input is replaced with a MeanPowderGrainSize input, and for consistency, the MeanSize input is renamed MeanBaseplateGrainSize. Minor changes to the std::cout statements are also made to log which GrainID values are being used for which parts of the simulation (baseplate, powder layers, nucleated grains)