### PR TITLE
Throw error if deprecated input PowderDensity is set to 0

### DIFF
--- a/src/CAinputs.hpp
+++ b/src/CAinputs.hpp
@@ -377,7 +377,7 @@ struct Inputs {
                     else {
                         double powder_density_input = input_data["Substrate"]["PowderDensity"];
                         double powder_active_fraction = powder_density_input * pow(10, 12) * pow(domain.deltax, 3);
-                        if ((powder_active_fraction < 0.0) || (powder_active_fraction > 1.0))
+                        if ((powder_active_fraction <= 0.0) || (powder_active_fraction > 1.0))
                             throw std::runtime_error(
                                 "Error: Density of powder surface sites active must be larger than 0 and less "
                                 "than 1/(CA cell volume)");


### PR DESCRIPTION
If the deprecated input `PowderDensity` is used, it must be a value greater than 0 or less than/equal to 1. Previously, a value of exactly 0 was allowed but shouldn't have been.