### PR TITLE
Fixup calcVolFractionNucleated for multilayer problems

### DIFF
--- a/src/CAcelldata.hpp
+++ b/src/CAcelldata.hpp
@@ -688,7 +688,7 @@ struct CellData {
         auto grain_id_all_layers_local = grain_id_all_layers;
         auto layer_id_all_layers_local = layer_id_all_layers;
         Kokkos::parallel_reduce(
-            "NumSolidifiedCells", grid.domain_size,
+            "NumSolidifiedCells", grid.domain_size_all_layers,
             KOKKOS_LAMBDA(const int index, int &update_meltcount, int &update_nucleatecount) {
                 int coord_y = grid.getCoordY(index);
                 // Is this Y coordinate in the halo region? If so, do not increment counter


### PR DESCRIPTION
For problems with multilayer domains, ExaCA would only use the first layer's data to calculate the volume fraction of nucleated grains