### PR TITLE
Default to number of layers = 1 for single layer problem types

### DIFF
--- a/analysis/src/GAutils.cpp
+++ b/analysis/src/GAutils.cpp
@@ -35,15 +35,20 @@ void parseLogFile(std::string log_file, int &nx, int &ny, int &nz, double &delta
     ny = logdata["Domain"]["Ny"];
     nz = logdata["Domain"]["Nz"];
     std::string simulation_type = logdata["SimulationType"];
-    if (simulation_type == "Directional" || simulation_type == "C") {
+    // Directional, Spot, SingleGrain problem types are single layer
+    if (simulation_type == "FromFinch" || simulation_type == "FromFile")
+        number_of_layers = logdata["Domain"]["NumberOfLayers"];
+    else {
         number_of_layers = 1;
         if (simulation_type == "C")
             std::cout << "Warning: Problem type \"C\" is now \"Directional\". Previous name will be removed in a "
                          "future release."
                       << std::endl;
+        else if (simulation_type == "S")
+            std::cout << "Warning: Problem type \"S\" is now \"Spot\". Previous name will be removed in a "
+                         "future release."
+                      << std::endl;
     }
-    else
-        number_of_layers = logdata["Domain"]["NumberOfLayers"];
     if (orientation_files_in_input)
         std::cout << "Note: orientation filename specified in log file will be used, overriding value from analysis "
                      "input file"


### PR DESCRIPTION
Fixed issue where running analysis on `Spot` or `SingleGrain` problem type output would throw an error due to a lack of a default for number of layers. Also added a warning on deprecated problem type `S`