### PR TITLE
Correct name of analysis input option printAvgStats

### DIFF
--- a/analysis/src/GArepresentativeregion.hpp
+++ b/analysis/src/GArepresentativeregion.hpp
@@ -101,7 +101,8 @@ struct RepresentativeRegion {
         setUnitDimension();
 
         // Check which overall stats and per grain stats should be printed for this region
-        readAnalysisOptionsFromList(region_data, "printAvgStats", analysis_options_stats_key, analysis_options_stats_yn);
+        readAnalysisOptionsFromList(region_data, "printAvgStats", analysis_options_stats_key,
+                                    analysis_options_stats_yn);
         // print_stats_yn = true if any one of the options are toggled
         int num_analysis_options_stats = analysis_options_stats_yn.size();
         for (int n = 0; n < num_analysis_options_stats; n++) {

--- a/analysis/src/GArepresentativeregion.hpp
+++ b/analysis/src/GArepresentativeregion.hpp
@@ -101,7 +101,7 @@ struct RepresentativeRegion {
         setUnitDimension();
 
         // Check which overall stats and per grain stats should be printed for this region
-        readAnalysisOptionsFromList(region_data, "printStats", analysis_options_stats_key, analysis_options_stats_yn);
+        readAnalysisOptionsFromList(region_data, "printAvgStats", analysis_options_stats_key, analysis_options_stats_yn);
         // print_stats_yn = true if any one of the options are toggled
         int num_analysis_options_stats = analysis_options_stats_yn.size();
         for (int n = 0; n < num_analysis_options_stats; n++) {

--- a/analysis/unit_test/tstRepresentativeRegion.hpp
+++ b/analysis/unit_test/tstRepresentativeRegion.hpp
@@ -31,7 +31,7 @@ void writeTestArea() {
     test_data << "          \"zBounds\": [0.000005,0.000005]," << std::endl;
     test_data << "          \"printPoleFigureData\": true," << std::endl;
     test_data << "          \"printInversePoleFigureData\": true," << std::endl;
-    test_data << "          \"printStats\": [\"GrainTypeFractions\"]," << std::endl;
+    test_data << "          \"printAvgStats\": [\"GrainTypeFractions\"]," << std::endl;
     test_data << "          \"printPerGrainStats\": [\"IPFZ-RGB\", \"Size\"]" << std::endl;
     test_data << "      }" << std::endl;
     test_data << "   }" << std::endl;
@@ -52,7 +52,7 @@ void writeTestVolume() {
     test_data << "          \"zBounds\": [0, 9]," << std::endl;
     test_data << "          \"printExaConstit\": false," << std::endl;
     test_data << "          \"printPoleFigureData\": true," << std::endl;
-    test_data << "          \"printStats\": [\"GrainTypeFractions\", \"Misorientation\", \"Size\", "
+    test_data << "          \"printAvgStats\": [\"GrainTypeFractions\", \"Misorientation\", \"Size\", "
                  "\"BuildTransAspectRatio\", \"XExtent\", \"YExtent\", \"ZExtent\"],"
               << std::endl;
     test_data << "          \"printPerGrainStats\": [\"IPFZ-RGB\", \"Size\"]," << std::endl;


### PR DESCRIPTION
The incorrect name `printStats` was erroneously used in place of the analysis input argument `printAvgStats`