### PR TITLE
Nix Build

### DIFF
--- a/NIX.md
+++ b/NIX.md
@@ -13,6 +13,10 @@ To get a shell with ExaCA temporarily installed, run:
 To install this permanently, run:
 
     $ nix profile install github:LLNL/ExaCA
+	
+To get the latest stable release, use:
+
+    $ nix shell github:LLNL/ExaCA#stable
 
 To build from a working copy use `nix develop` and run CMake manually:
 

--- a/NIX.md
+++ b/NIX.md
@@ -1,0 +1,26 @@
+## Nix
+
+First install the [Nix package manager][NIX] and then enable [Flakes][Flakes].
+Alternatively, check out the [Determinate Systems Installer][Determinate] for
+an out of the box experience. See [nix.dev][nix.dev] for more help with Nix.
+
+To get a shell with ExaCA temporarily installed, run:
+
+    $ nix shell github:LLNL/ExaCA
+    # ExaCA now available
+    $ ExaCA --help
+
+To install this permanently, run:
+
+    $ nix profile install github:LLNL/ExaCA
+
+To build from a working copy use `nix develop` and run CMake manually:
+
+    $ nix develop
+    $ cmake -B build
+    $ cmake --build build
+
+[NIX]: https://nixos.org/download.html
+[Flakes]: https://nixos.wiki/wiki/Flakes
+[nix.dev]: https://nix.dev
+[Determinate]: https://github.com/DeterminateSystems/nix-installer

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1750005367,
+        "narHash": "sha256-h/aac1dGLhS3qpaD2aZt25NdKY7b+JT0ZIP2WuGsJMU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "6c64dabd3aa85e0c02ef1cdcb6e1213de64baee3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,71 @@
+## See NIX.md for help getting started with Nix
+
+{
+  description = "An exascale-capable cellular automaton for nucleation and grain growth";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    utils.url   = "github:numtide/flake-utils";
+  };
+
+  outputs = inputs @ { self, utils, ... }: utils.lib.eachDefaultSystem (system: rec {
+    config = rec {
+      pkgs = import inputs.nixpkgs {
+        inherit system;        
+        config.cudaSupport = true;
+        config.allowUnfree = true;
+      };
+    };
+
+    exaca = with config; pkgs.stdenv.mkDerivation rec {
+      pname = "exaca";
+      version = "latest";
+
+      src = self;
+
+      CMAKE_TLS_VERIFY=0;
+      
+      nativeBuildInputs = [
+        pkgs.cmake
+      ];
+
+      buildInputs = [
+        pkgs.kokkos
+        pkgs.openmpi
+      ];
+
+      propagatedBuildInputs = [
+        pkgs.openmpi
+      ];
+
+    };
+      
+    packages = rec {
+      default = exaca;
+    };
+
+    devShells = with config; rec {
+      default = exacaDev;
+
+      exacaDev = pkgs.mkShell rec {
+        name = "exaca-dev";
+
+        packages = with pkgs; [
+          git
+          clang-tools
+        ] ++ self.outputs.packages.${system}.default.buildInputs
+          ++ self.outputs.packages.${system}.default.nativeBuildInputs
+          ++ self.outputs.packages.${system}.default.propagatedBuildInputs
+          ++ pkgs.lib.optionals (pkgs.stdenv.hostPlatform.isLinux) [gdb cntr];
+
+        # Ensure the locales point at the correct archive location.
+        LOCALE_ARCHIVE = pkgs.lib.optional (pkgs.stdenv.hostPlatform.isLinux) (
+          "${pkgs.glibcLocales}/lib/locale/locale-archive"
+        );
+        
+      };
+    };
+    
+  });
+
+}

--- a/flake.nix
+++ b/flake.nix
@@ -17,11 +17,10 @@
       };
     };
 
-    exaca = with config; pkgs.stdenv.mkDerivation rec {
+    exaca = { src, version}: with config; pkgs.stdenv.mkDerivation {
       pname = "exaca";
-      version = "latest";
-
-      src = self;
+      inherit version;
+      inherit src;
 
       CMAKE_TLS_VERIFY=0;
       
@@ -37,11 +36,24 @@
       propagatedBuildInputs = [
         pkgs.openmpi
       ];
-
     };
+
+    packages = with config; rec {
+      default = exaca {
+        src = self;
+        version = self.shortRev or self.dirtyShortRev;
+      };
+
+      stable = exaca (rec {
+        src = pkgs.fetchFromGitHub {
+          owner = "LLNL";
+          repo  = "ExaCA";
+          rev   = "${version}";
+          hash  = "sha256-X21yP+sqxR/iM/4N/qKucB2hMmBLf00bVtlCS0QGVQw=";
+        };
+        version = "2.0.2";
+      });
       
-    packages = rec {
-      default = exaca;
     };
 
     devShells = with config; rec {


### PR DESCRIPTION
Implement Nix build for ExaCA. This mirrors the [Nix build for Adamantine](https://github.com/adamantine-sim/adamantine/blob/master/flake.nix). This will give the option to have reproducible and customizable builds for the ORNL / LLNL AM software alongside other scientific software tools. A few things:

 - Currently, this I've only tested this by running `mpiexec -n 1 ./build/install/bin/ExaCA examples/Inp_DirSolidification.json`. Would it be a good idea to have the tests run as part of the build?
 - Tagging @cadkin to possibly help clean this up if necessary.
 - Just for reference here is the [PR from Adamantin](https://github.com/adamantine-sim/adamantine/pull/365) as this discusses some of the design decisions and problems encountered.
 - Haven't tried CUDA with this build. 
 - No attempt was made to build Finch.
 - The 'json' library might be imported as part of the build process. I'm not sure what this means for Nix purity, but I'm not worrying about it unless it presents a problem.