### PR TITLE
Increment nucleation counter as necessary when time steps are skipped

### DIFF
--- a/src/CAnucleation.hpp
+++ b/src/CAnucleation.hpp
@@ -315,6 +315,17 @@ struct Nucleation {
             }
         }
     }
+
+    // If the time step jumped from an older value to a newer value of "cycle", update nucleation_counter accordingly as
+    // no nucleation events were possible over time steps without liquid cells
+    void advanceCounterSkippedTimeSteps(const int cycle) {
+
+        if (cycle > nucleation_times_host(nucleation_counter)) {
+            while (cycle > nucleation_times_host(nucleation_counter)) {
+                nucleation_counter++;
+            }
+        }
+    }
 };
 
 #endif

--- a/src/runCA.hpp
+++ b/src/runCA.hpp
@@ -124,8 +124,8 @@ void runExaCA(int id, int np, Inputs inputs, Timers timers, Grid grid, Temperatu
             // Check on progress of solidification simulation of the current layer, setting x_switch = 1 if complete
             if ((cycle % 1000 == 0) && (simulation_type != "SingleGrain")) {
                 intermediateOutputAndCheck(id, np, cycle, grid, nucleation.successful_nucleation_counter, x_switch,
-                                           celldata, temperature, inputs.simulation_type, layernumber, orientation,
-                                           print, inputs.domain.deltat, interface);
+                                           nucleation, celldata, temperature, inputs.simulation_type, layernumber,
+                                           orientation, print, inputs.domain.deltat, interface);
             }
             else if (simulation_type == "SingleGrain") {
                 intermediateOutputAndCheck(id, cycle, grid, x_switch, celldata.cell_type);


### PR DESCRIPTION
Fixes edge case bug for large mean nucleation undercooling and standard deviations where a candidate nucleation event can be assigned to a time step that is "skipped" by ExaCA due to no liquid cells existing on said time step - in turn this would lead to the nucleation event counter being unable to advance.