### PR TITLE
Separated steering vector construction for active, other cells

### DIFF
--- a/bin/run.cpp
+++ b/bin/run.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[]) {
             Grid grid(inputs.simulation_type, id, np, inputs.domain.number_of_layers, inputs.domain, inputs.substrate,
                       inputs.temperature);
             // Temperature fields characterized by data in this structure
-            Temperature<memory_space> temperature(grid, inputs.temperature, inputs.print.store_solidification_start);
+            Temperature<memory_space> temperature(grid, inputs.temperature, inputs.print);
 
             runExaCA(id, np, inputs, timers, grid, temperature);
         }

--- a/bin/runCoupled.cpp
+++ b/bin/runCoupled.cpp
@@ -60,8 +60,8 @@ void runCoupled(int id, int np, Finch::Inputs finch_inputs, Inputs exaca_inputs)
     Grid exaca_grid(id, np, exaca_inputs.domain, exaca_inputs.substrate, exaca_inputs.temperature,
                     finch_inputs.space.cell_size, exaca_low_corner, exaca_high_corner);
     // Temperature fields characterized by data in this structure
-    Temperature<memory_space> temperature(id, np, exaca_grid, exaca_inputs.temperature, app.getSolidificationData(),
-                                          exaca_inputs.print.store_solidification_start);
+    Temperature<memory_space> temperature(id, np, exaca_grid, exaca_inputs.temperature, exaca_inputs.print,
+                                          app.getSolidificationData());
 
     // Now run ExaCA
     runExaCA(id, np, exaca_inputs, timers, exaca_grid, temperature);

--- a/src/CAtemperature.hpp
+++ b/src/CAtemperature.hpp
@@ -24,13 +24,17 @@ template <typename MemorySpace>
 struct Temperature {
 
     using memory_space = MemorySpace;
+    using view_type_short = Kokkos::View<short *, memory_space>;
     using view_type_int = Kokkos::View<int *, memory_space>;
+    using view_type_int_2d = Kokkos::View<int **, memory_space>;
     using view_type_int_3d = Kokkos::View<int ***, memory_space>;
     using view_type_double = Kokkos::View<double *, memory_space>;
     using view_type_double_2d = Kokkos::View<double **, memory_space>;
     using view_type_float = Kokkos::View<float *, memory_space>;
     using view_type_float_2d = Kokkos::View<float **, memory_space>;
+    using view_type_short_host = typename view_type_short::host_mirror_type;
     using view_type_int_host = typename view_type_int::host_mirror_type;
+    using view_type_int_2d_host = typename view_type_int_2d::host_mirror_type;
     using view_type_int_3d_host = typename view_type_int_3d::host_mirror_type;
     using view_type_double_host = typename view_type_double::host_mirror_type;
     using view_type_double_2d_host = typename view_type_double_2d::host_mirror_type;
@@ -41,20 +45,24 @@ struct Temperature {
     // Using the default exec space for this memory space.
     using execution_space = typename memory_space::execution_space;
 
-    // Maximum number of times each CA cell in a given layer undergoes solidification
-    view_type_int max_solidification_events;
-    // Each time that a cell (index 0) goes above and below the liquidus time (index 2) for each melt-solidification
-    // event (index 1)
-    view_type_int_3d liquidus_time;
-    // Cooling rate for each cell (index 1) for each solidification event (index 2)
-    view_type_float_2d cooling_rate;
+    int liquidus_time_counter = 0;
+    int num_liquidus_times_this_layer = 0;
+    // Only nonzero in the special case of 0 cooling rate/uniform undercooling
+    float init_undercooling = 0.0;
+    // Times at which each cell crosses the liquidus temperature
+    view_type_int_host liquidus_time_list_host;
+    // Cells associated with each value in liquidus_time_list_host
+    view_type_int liquidus_cell_list;
+    // Cooling rate associated with each value in liquidus_time_list_host (INT_MAX placeholder for cells that are
+    // heating)
+    view_type_float cooling_rate_list;
+    // The last time a given cell cooled below the liquidus (0.0 placeholder if it hasn't cooled below the liquidus)
+    view_type_int last_time_below_liquidus;
+    // Cooling rate currently in use by each cell
+    view_type_float current_cooling_rate;
     // The number of times that each CA cell will traverse the liquidus during this layer
-    view_type_int number_of_solidification_events;
-    // A counter for the number of times each CA cell has undergone solidification so far this layer
-    view_type_int solidification_event_counter;
-    // The current undercooling of a CA cell (if superheated liquid or hasn't undergone solidification yet, equals 0)
-    // Also maintained for the full multilayer domain
-    view_type_float undercooling_current_all_layers, undercooling_current;
+    view_type_int_host number_of_solidification_events;
+    int max_num_solidification_events = 1;
     // Data structure for storing raw temperature data from file(s)
     // Store data as double - needed for small time steps to resolve local differences in solidification conditions
     // Each data point has 6 values (X, Y, Z coordinates, melting time, liquidus time, and cooling rate)
@@ -63,70 +71,116 @@ struct Temperature {
     // These contain "number_of_layers" values corresponding to the location within "raw_temperature_data" of the first
     // data element in each temperature file, if used
     view_type_int_host first_value, last_value;
+    // Layer associated with last time a cell undergoes melting/soldification
+    view_type_short layer_id_all_layers, layer_id;
+    // Number of times in the layer a cell has undergone solidification so far (optional to store based on selected
+    // inputs)
+    bool store_solidification_event_counter = false;
+    view_type_int solidification_event_counter;
     // Undercooling when a solidification first began in a cell (optional to store based on selected inputs)
-    bool _store_solidification_start;
+    bool store_undercooling_current = false;
+    view_type_float undercooling_current_all_layers, undercooling_current;
+    // Undercooling when a solidification ended in a cell (optional to store based on selected inputs)
+    bool store_undercooling_solidification_start = false;
     view_type_float undercooling_solidification_start_all_layers, undercooling_solidification_start;
     // Temperature field inputs from file
     TemperatureInputs _inputs;
 
-    // Constructor creates views with size based on the grid inputs - liquidus_time and cooling_rate are later modified
-    // to account for multiple events if needed, undercooling_current and solidification_event_counter are default
-    // initialized to zeros
-    Temperature(const Grid &grid, TemperatureInputs inputs, const bool store_solidification_start = false,
+    // Constructor creates views with size based on the grid inputs. If any of the output options
+    // solidification_event_counter, undercooling_solidification_start, undercooling_current, and layer_id are toggled,
+    // the associated views are allocated and filled during the simulation
+    Temperature(const Grid &grid, TemperatureInputs inputs, PrintInputs print_inputs,
                 const int est_num_temperature_data_points = 100000)
-        : max_solidification_events(
-              view_type_int(Kokkos::ViewAllocateWithoutInitializing("number_of_layers"), grid.number_of_layers))
-        , liquidus_time(
-              view_type_int_3d(Kokkos::ViewAllocateWithoutInitializing("liquidus_time"), grid.domain_size, 1, 2))
-        , cooling_rate(view_type_float_2d(Kokkos::ViewAllocateWithoutInitializing("cooling_rate"), grid.domain_size, 1))
-        , number_of_solidification_events(view_type_int(
+        : liquidus_time_list_host(
+              view_type_int_host(Kokkos::ViewAllocateWithoutInitializing("liquidus_time_list"), grid.domain_size))
+        , liquidus_cell_list(
+              view_type_int(Kokkos::ViewAllocateWithoutInitializing("liquidus_cell_list"), grid.domain_size))
+        , cooling_rate_list(
+              view_type_float(Kokkos::ViewAllocateWithoutInitializing("cooling_rate_list"), grid.domain_size))
+        , last_time_below_liquidus(view_type_int("last_time_below_liquidus", grid.domain_size))
+        , current_cooling_rate(view_type_float("current_cooling_rate", grid.domain_size))
+        , number_of_solidification_events(view_type_int_host(
               Kokkos::ViewAllocateWithoutInitializing("number_of_solidification_events"), grid.domain_size))
-        , solidification_event_counter(view_type_int("solidification_event_counter", grid.domain_size))
-        , undercooling_current_all_layers(view_type_float("undercooling_current", grid.domain_size_all_layers))
         , raw_temperature_data(view_type_double_2d_host(Kokkos::ViewAllocateWithoutInitializing("raw_temperature_data"),
                                                         est_num_temperature_data_points, num_temperature_components))
         , first_value(view_type_int_host(Kokkos::ViewAllocateWithoutInitializing("first_value"), grid.number_of_layers))
         , last_value(view_type_int_host(Kokkos::ViewAllocateWithoutInitializing("last_value"), grid.number_of_layers))
-        , _store_solidification_start(store_solidification_start)
+        , layer_id_all_layers(view_type_short(Kokkos::ViewAllocateWithoutInitializing("layer_id_all_layers"),
+                                              grid.domain_size_all_layers))
+        , solidification_event_counter(
+              view_type_int(Kokkos::ViewAllocateWithoutInitializing("solidification_event_counter"), 1))
+        , undercooling_current_all_layers(view_type_float(
+              Kokkos::ViewAllocateWithoutInitializing("undercooling_current_all_layers"), grid.domain_size_all_layers))
+        , undercooling_solidification_start_all_layers(
+              view_type_float(Kokkos::ViewAllocateWithoutInitializing("undercooling_current_all_layers"), 1))
+
         , _inputs(inputs) {
 
-        if (_store_solidification_start) {
-            // Default init starting undercooling in cells to zero
-            undercooling_solidification_start_all_layers =
-                view_type_float("undercooling_solidification_start", grid.domain_size_all_layers);
-            getCurrentLayerStartingUndercooling(grid.layer_range);
-        }
-        getCurrentLayerUndercooling(grid.layer_range);
+        Kokkos::deep_copy(layer_id_all_layers, -1);
+        layer_id = getLayerSubview(layer_id_all_layers, grid.layer_range);
+
+        // Allocate views for optional stored data based on print inputs
+        initOptionalViews(grid, print_inputs);
     }
 
     // Constructor using in-memory temperature data from external source (input_temperature_data)
-    Temperature(const int id, const int np, const Grid &grid, TemperatureInputs inputs,
-                view_type_coupled input_temperature_data, const bool store_solidification_start = false)
-        : max_solidification_events(
-              view_type_int(Kokkos::ViewAllocateWithoutInitializing("number_of_layers"), grid.number_of_layers))
-        , liquidus_time(
-              view_type_int_3d(Kokkos::ViewAllocateWithoutInitializing("liquidus_time"), grid.domain_size, 1, 2))
-        , cooling_rate(view_type_float_2d(Kokkos::ViewAllocateWithoutInitializing("cooling_rate"), grid.domain_size, 1))
-        , number_of_solidification_events(view_type_int(
+    Temperature(const int id, const int np, const Grid &grid, TemperatureInputs inputs, PrintInputs print_inputs,
+                view_type_coupled input_temperature_data, const int est_num_temperature_data_points = 100000)
+        : liquidus_time_list_host(
+              view_type_int_host(Kokkos::ViewAllocateWithoutInitializing("liquidus_time_list"), 2 * grid.domain_size))
+        , liquidus_cell_list(
+              view_type_int(Kokkos::ViewAllocateWithoutInitializing("liquidus_cell_list"), 2 * grid.domain_size))
+        , cooling_rate_list(
+              view_type_float(Kokkos::ViewAllocateWithoutInitializing("cooling_rate_list"), 2 * grid.domain_size))
+        , last_time_below_liquidus(view_type_int("last_time_below_liquidus", grid.domain_size))
+        , current_cooling_rate(view_type_float("current_cooling_rate", grid.domain_size))
+        , number_of_solidification_events(view_type_int_host(
               Kokkos::ViewAllocateWithoutInitializing("number_of_solidification_events"), grid.domain_size))
-        , solidification_event_counter(view_type_int("solidification_event_counter", grid.domain_size))
-        , undercooling_current_all_layers(view_type_float("undercooling_current", grid.domain_size_all_layers))
         , raw_temperature_data(view_type_double_2d_host(Kokkos::ViewAllocateWithoutInitializing("raw_temperature_data"),
-                                                        input_temperature_data.extent(0) * (inputs.number_of_copies),
-                                                        num_temperature_components))
+                                                        est_num_temperature_data_points, num_temperature_components))
         , first_value(view_type_int_host(Kokkos::ViewAllocateWithoutInitializing("first_value"), grid.number_of_layers))
         , last_value(view_type_int_host(Kokkos::ViewAllocateWithoutInitializing("last_value"), grid.number_of_layers))
-        , _store_solidification_start(store_solidification_start)
+        , layer_id_all_layers(view_type_short(Kokkos::ViewAllocateWithoutInitializing("layer_id_all_layers"),
+                                              grid.domain_size_all_layers))
+        , solidification_event_counter(
+              view_type_int(Kokkos::ViewAllocateWithoutInitializing("solidification_event_counter"), 1))
+        , undercooling_current_all_layers(view_type_float(
+              Kokkos::ViewAllocateWithoutInitializing("undercooling_current_all_layers"), grid.domain_size_all_layers))
+        , undercooling_solidification_start_all_layers(
+              view_type_float(Kokkos::ViewAllocateWithoutInitializing("undercooling_current_all_layers"), 1))
         , _inputs(inputs) {
 
         copyTemperatureData(id, np, grid, input_temperature_data);
-        if (_store_solidification_start) {
-            // Default init starting undercooling in cells to zero
-            undercooling_solidification_start_all_layers =
-                view_type_float("undercooling_solidification_start", grid.domain_size_all_layers);
-            getCurrentLayerStartingUndercooling(grid.layer_range);
+        initOptionalViews(grid, print_inputs);
+        Kokkos::deep_copy(layer_id_all_layers, -1);
+        layer_id = getLayerSubview(layer_id_all_layers, grid.layer_range);
+    }
+
+    void initOptionalViews(const Grid &grid, PrintInputs print_inputs) {
+        if ((print_inputs.intralayer_solidification_event_counter) ||
+            (print_inputs.interlayer_solidification_event_counter)) {
+            store_solidification_event_counter = true;
+            // Solidification event counter is only stored for the current layer, init to zeros
+            Kokkos::realloc(solidification_event_counter, grid.domain_size);
+            Kokkos::deep_copy(solidification_event_counter, 0);
         }
-        getCurrentLayerUndercooling(grid.layer_range);
+        if ((print_inputs.intralayer_undercooling_current) || (print_inputs.interlayer_undercooling_current)) {
+            store_undercooling_current = true;
+            // Undercooling is stored for all layers, as is the subview for the current layer's undercooling, init both
+            // to zeros
+            Kokkos::realloc(undercooling_current_all_layers, grid.domain_size_all_layers);
+            Kokkos::deep_copy(undercooling_current_all_layers, 0.0);
+            // Subview for current layer
+            undercooling_current = getLayerSubview(undercooling_current_all_layers, grid.layer_range);
+        }
+        if ((print_inputs.intralayer_undercooling_solidification_start) ||
+            (print_inputs.interlayer_undercooling_solidification_start)) {
+            store_undercooling_solidification_start = true;
+            Kokkos::realloc(undercooling_solidification_start_all_layers, grid.domain_size_all_layers);
+            Kokkos::deep_copy(undercooling_solidification_start_all_layers, 0.0);
+            undercooling_solidification_start =
+                getLayerSubview(undercooling_solidification_start_all_layers, grid.layer_range);
+        }
     }
 
     // If using a problem type that involves translating or mirroring temperature data, output a new X or Y value based
@@ -443,60 +497,105 @@ struct Temperature {
         else
             location_liquidus_isotherm =
                 location_init_undercooling + Kokkos::round(_inputs.init_undercooling / (_inputs.G * grid.deltax));
+        // If cooling rate is 0, need to set an initial undercooling
+        if (_inputs.R == 0)
+            init_undercooling = _inputs.init_undercooling;
 
-        // Local copies for lambda capture.
-        auto liquidus_time_local = liquidus_time;
-        auto cooling_rate_local = cooling_rate;
-        auto max_solidification_events_local = max_solidification_events;
-        auto number_solidification_events_local = number_of_solidification_events;
-        auto undercooling_current_local = undercooling_current;
-        double init_undercooling_local = _inputs.init_undercooling;
-        double G_local = _inputs.G;
-        double R_local = _inputs.R;
-        auto policy = Kokkos::RangePolicy<execution_space>(0, grid.domain_size);
-        Kokkos::parallel_for(
-            "TempInitG", policy, KOKKOS_LAMBDA(const int &index) {
-                // All cells past melting time step
-                liquidus_time_local(index, 0, 0) = -1;
-                // Negative dist_from_liquidus and dist_from_init_undercooling values for cells below the liquidus
-                // isotherm
-                int coord_z = grid.getCoordZ(index);
-                int dist_from_liquidus = coord_z - location_liquidus_isotherm;
-                // Cells reach liquidus at a time dependent on their Z coordinate
-                // Cells with negative liquidus time values are already undercooled, should have positive undercooling
-                // and negative liquidus time step
-                if (dist_from_liquidus < 0) {
-                    liquidus_time_local(index, 0, 1) = -1;
-                    int dist_from_init_undercooling = coord_z - location_init_undercooling;
-                    undercooling_current_local(index) =
-                        init_undercooling_local - dist_from_init_undercooling * G_local * grid.deltax;
+        // List of liquidus time events - Since iteration over liqudius time events does not occur for the SingleGrain
+        // and Directional problem types (as they have a single last_time_below_liquidus and current_cooling_rate that
+        // apply to all cells, and the Active cells present are undercooled at the start of the simulation), the
+        // liquidus_time_list_host, liquidus_cell_list, and cooling_rate_list views are filled with data only for
+        // reference in printing temperature field info
+        std::vector<int> liquidus_time_step_read(2 * grid.domain_size), cell_read(2 * grid.domain_size);
+        std::vector<float> cooling_rate_read(2 * grid.domain_size);
+        auto current_cooling_rate_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), current_cooling_rate);
+        auto last_time_below_liquidus_host =
+            Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), last_time_below_liquidus);
+        for (int coord_z = 0; coord_z < grid.nz; coord_z++) {
+            const int dist_from_liquidus = coord_z - location_liquidus_isotherm;
+            for (int coord_x = 0; coord_x < grid.nx; coord_x++) {
+                for (int coord_y = 0; coord_y < grid.ny_local; coord_y++) {
+                    // 1D cell index
+                    const int index = grid.get1DIndex(coord_x, coord_y, coord_z);
+                    // Initially melted (time step 0)
+                    liquidus_time_step_read[num_liquidus_times_this_layer] = 0;
+                    cell_read[num_liquidus_times_this_layer] = index;
+                    cooling_rate_read[num_liquidus_times_this_layer] = -1.0;
+                    num_liquidus_times_this_layer++;
+                    // Cells reach liquidus at a time dependent on their Z coordinate
+                    // Cells with negative last_time_below_liquidus are already undercooled, times may be negative
+                    liquidus_time_step_read[num_liquidus_times_this_layer] =
+                        Kokkos::round(dist_from_liquidus * _inputs.G * grid.deltax / (_inputs.R * deltat));
+                    cell_read[num_liquidus_times_this_layer] = index;
+                    // Cells cool at a constant rate
+                    cooling_rate_read[num_liquidus_times_this_layer] = _inputs.R * deltat;
+                    // Cell will only have one cooling rate/liquidus time
+                    last_time_below_liquidus_host(index) = liquidus_time_step_read[num_liquidus_times_this_layer];
+                    current_cooling_rate_host(index) = cooling_rate_read[num_liquidus_times_this_layer];
+                    num_liquidus_times_this_layer++;
                 }
-                else {
-                    // Cells with positive liquidus time values are not yet tracked - leave current undercooling as
-                    // default zeros and set liquidus time step. R_local will never be zero here, as all cells at a
-                    // fixed undercooling must be below the liquidus (distFromLiquidus < 0)
-                    liquidus_time_local(index, 0, 1) = dist_from_liquidus * G_local * grid.deltax / (R_local * deltat);
-                }
-                // Cells cool at a constant rate
-                cooling_rate_local(index, 0) = R_local * deltat;
-                // All cells solidify once
-                max_solidification_events_local(0) = 1;
-                number_solidification_events_local(index) = 1;
-            });
+            }
+        }
+
+        // From the 3 vectors liquidus_time_step_read, cell_read, cooling_rate_read initialize the views
+        // liquidus_time_list_host, liquidus_cell_list (stored on device), and cooling_rate_list (stored on device)
+        initOrderedTimeTempHistory(liquidus_time_step_read, cell_read, cooling_rate_read,
+                                   num_liquidus_times_this_layer);
+
+        // Counter goes unused since all melting events have occurred and the time at which the cells go below the
+        // liquidus/their cooling rates are also known. Set counter to max value
+        liquidus_time_counter = num_liquidus_times_this_layer;
+
+        // Copy host view data back to device
+        current_cooling_rate = Kokkos::create_mirror_view_and_copy(memory_space(), current_cooling_rate_host);
+        last_time_below_liquidus = Kokkos::create_mirror_view_and_copy(memory_space(), last_time_below_liquidus_host);
+
+        // Each cell solidifies once
+        Kokkos::deep_copy(number_of_solidification_events, 1);
+        Kokkos::deep_copy(layer_id_all_layers, 0);
         MPI_Barrier(MPI_COMM_WORLD);
         if (id == 0) {
-            std::cout << "Temperature field initialized for unidirectional solidification with G = " << G_local
+            std::cout << "Temperature field initialized for unidirectional solidification with G = " << _inputs.G
                       << " K/m, initial undercooling at Z = " << location_init_undercooling << " of "
                       << _inputs.init_undercooling << " K below the liquidus" << std::endl;
             std::cout << "Done with temperature field initialization" << std::endl;
         }
     }
 
-    // Initialize temperature data for a hemispherical spot melt (single layer simulation)
-    void initialize(const int id, const Grid &grid, const double freezing_range, double deltat, double spot_radius) {
+    // From the 3 vectors liquidus_time_step_vec, cell_vec, cooling_rate_vec, initialize the views
+    // liquidus_time_list_host, liquidus_cell_list (stored on device), and cooling_rate_list (stored on device)
+    void initOrderedTimeTempHistory(std::vector<int> liquidus_time_step_vec, std::vector<int> cell_vec,
+                                    std::vector<float> cooling_rate_vec, const int number_vals_stored) {
 
-        // Each cell solidifies at most one time
-        Kokkos::deep_copy(max_solidification_events, 1);
+        // Reorder liquidus time events based on the times at which they occur
+        std::vector<std::tuple<int, int, float>> time_temp_history;
+        time_temp_history.reserve(number_vals_stored);
+        for (int n = 0; n < number_vals_stored; n++) {
+            time_temp_history.push_back(std::make_tuple(liquidus_time_step_vec[n], cell_vec[n], cooling_rate_vec[n]));
+        }
+        std::sort(time_temp_history.begin(), time_temp_history.end());
+
+        // Resize views for number of values in the vectors
+        Kokkos::realloc(liquidus_time_list_host, number_vals_stored);
+        Kokkos::realloc(liquidus_cell_list, number_vals_stored);
+        Kokkos::realloc(cooling_rate_list, number_vals_stored);
+
+        // Copy to host view for liquidus_time_list, temporary host views for list of cells and cooling rates
+        auto liquidus_cell_list_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), liquidus_cell_list);
+        auto cooling_rate_list_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), cooling_rate_list);
+        for (int n = 0; n < num_liquidus_times_this_layer; n++) {
+            liquidus_time_list_host(n) = std::get<0>(time_temp_history[n]);
+            liquidus_cell_list_host(n) = std::get<1>(time_temp_history[n]);
+            cooling_rate_list_host(n) = std::get<2>(time_temp_history[n]);
+        }
+
+        // Copy host view data back to device
+        liquidus_cell_list = Kokkos::create_mirror_view_and_copy(memory_space(), liquidus_cell_list_host);
+        cooling_rate_list = Kokkos::create_mirror_view_and_copy(memory_space(), cooling_rate_list_host);
+    }
+
+    // Store temperature data for a hemispherical spot melt (single layer simulation)
+    void storeSpotData(const int id, const Grid &grid, const double freezing_range, double deltat, double spot_radius) {
 
         // Outer edges of spots are initialized at the liquidus temperature
         // Spots cool at constant rate R, spot thermal gradient = G
@@ -511,171 +610,145 @@ struct Temperature {
             std::cout << "Initializing temperature field for the hemispherical spot, which will take approximately "
                       << spot_time_est << " time steps to fully solidify" << std::endl;
 
-        // Initialize liquidus_time and cooling_rate values for this spot
-        auto liquidus_time_local = liquidus_time;
-        auto cooling_rate_local = cooling_rate;
-        auto number_of_solidification_events_local = number_of_solidification_events;
-        double R_local = _inputs.R;
-        auto md_policy =
-            Kokkos::MDRangePolicy<execution_space, Kokkos::Rank<3, Kokkos::Iterate::Right, Kokkos::Iterate::Right>>(
-                {0, 0, 0}, {grid.nz, grid.nx, grid.ny_local});
-        Kokkos::parallel_for(
-            "SpotTemperatureInit", md_policy, KOKKOS_LAMBDA(const int coord_z, const int coord_x, const int coord_y) {
-                // 1D cell index
-                int index = grid.get1DIndex(coord_x, coord_y, coord_z);
-                // Distance of this cell from the spot center
-                float dist_z = spot_center_z - coord_z;
-                float dist_x = spot_center_x - coord_x;
-                int coord_y_global = coord_y + grid.y_offset;
-                float dist_y = spot_center_y - coord_y_global;
-                float tot_dist = Kokkos::hypot(dist_x, dist_y, dist_z);
-                if (tot_dist <= spot_radius) {
-                    // Melt time step (first time step)
-                    liquidus_time_local(index, 0, 0) = 1;
-                    // Liquidus time step (related to distance to spot edge). Must be at least 1 time step after melt
-                    // time step
-                    liquidus_time_local(index, 0, 1) = Kokkos::round((spot_radius - tot_dist) / isotherm_velocity) + 2;
-                    // Cooling rate per time step
-                    cooling_rate_local(index, 0) = R_local * deltat;
-                    number_of_solidification_events_local(index) = 1;
+        // Add spot data to raw_temperature_data as if read from a file
+        // Ensure raw_temperature_data can store all data
+        Kokkos::realloc(raw_temperature_data, grid.domain_size, 6);
+        // Iterate over cells on this rank, determine if inside of spot
+        for (int coord_z = 0; coord_z < grid.nz; coord_z++) {
+            for (int coord_x = 0; coord_x < grid.nx; coord_x++) {
+                for (int coord_y = 0; coord_y < grid.ny_local; coord_y++) {
+                    // Distance of this cell from the spot center
+                    float dist_z = spot_center_z - coord_z;
+                    float dist_x = spot_center_x - coord_x;
+                    int coord_y_global = coord_y + grid.y_offset;
+                    float dist_y = spot_center_y - coord_y_global;
+                    float tot_dist = Kokkos::hypot(dist_x, dist_y, dist_z);
+                    if (tot_dist <= spot_radius) {
+                        // x, y, z of location in global domain
+                        raw_temperature_data(num_liquidus_times_this_layer, 0) =
+                            grid.x_min + static_cast<double>(coord_x) * grid.deltax;
+                        raw_temperature_data(num_liquidus_times_this_layer, 1) =
+                            grid.y_min + static_cast<double>(coord_y_global) * grid.deltax;
+                        raw_temperature_data(num_liquidus_times_this_layer, 2) =
+                            grid.z_min + static_cast<double>(coord_z) * grid.deltax;
+                        // Melting time in seconds - all cells melt at the start of the simulation
+                        raw_temperature_data(num_liquidus_times_this_layer, 3) = 0.0;
+                        // Liquidus time in seconds (related to distance to spot edge), must be >= deltat
+                        raw_temperature_data(num_liquidus_times_this_layer, 4) =
+                            deltat * (((spot_radius - tot_dist) / isotherm_velocity) + 1.0);
+                        // Cooling rate per time step (K/s)
+                        raw_temperature_data(num_liquidus_times_this_layer, 5) = _inputs.R;
+                        // Increment counter for points on this rank that melt/resolidify
+                        num_liquidus_times_this_layer++;
+                    }
                 }
-                else {
-                    // Dummy layer_time_temp_history data
-                    liquidus_time_local(index, 0, 0) = -1;
-                    liquidus_time_local(index, 0, 1) = -1;
-                    cooling_rate_local(index, 0) = -1.0;
-                    number_of_solidification_events_local(index) = 0;
-                }
-            });
+            }
+        }
+        // Remove empty space in raw_temperature_data
+        Kokkos::resize(raw_temperature_data, num_liquidus_times_this_layer, 6);
+        // Start/end indices of temperature data in raw_temperature_data
+        first_value(0) = 0;
+        last_value(0) = num_liquidus_times_this_layer;
         MPI_Barrier(MPI_COMM_WORLD);
         if (id == 0)
-            std::cout << "Spot melt temperature field initialized" << std::endl;
+            std::cout
+                << "Spot melt temperature field initialized, number of cells to undergo melting/solidification is "
+                << num_liquidus_times_this_layer << std::endl;
     }
 
     // Calculate the number of times that a cell in layer "layernumber" undergoes melting/solidification, and store in
     // max_solidification_events_host
-    void calcMaxSolidificationEvents(const int id, const int layernumber,
-                                     const view_type_int_host max_solidification_events_host, const int start_range,
-                                     const int end_range, const Grid &grid, const std::string simulation_type) {
+    view_type_int_host calcNumberOfSolidificationEvents(const int id, const int layernumber, const int start_range,
+                                                        const int end_range, const Grid &grid) {
 
-        bool calc_remelting_events;
-        if (simulation_type == "FromFile") {
-            if (layernumber > _inputs.temp_files_in_series)
-                calc_remelting_events = false;
-            else
-                calc_remelting_events = true;
+        view_type_int_host _number_of_solidification_events("number_of_solidification_events_temp", grid.domain_size);
+        for (int i = start_range; i < end_range; i++) {
+            // Get the integer X, Y, Z coordinates associated with this data point, with the Y coordinate based on
+            // local MPI rank's grid
+            int coord_x = getTempCoordX(i, grid.x_min, grid.deltax);
+            int coord_y = getTempCoordY(i, grid.y_min, grid.deltax, grid.y_offset);
+            int coord_z = getTempCoordZ(i, grid.deltax, grid.layer_height, layernumber, grid.z_min_layer);
+            // Convert to 1D coordinate in the current layer's domain
+            int index = grid.get1DIndex(coord_x, coord_y, coord_z);
+            _number_of_solidification_events(index)++;
         }
-        else {
-            if (layernumber > 0)
-                calc_remelting_events = false;
-            else
-                calc_remelting_events = true;
+        // Get the max of _number_of_solidification_events across all ranks
+        int max_count = 0;
+        for (int i = 0; i < grid.domain_size; i++) {
+            if (_number_of_solidification_events(i) > max_count)
+                max_count = _number_of_solidification_events(i);
         }
-        if (!calc_remelting_events) {
-            // Use the value from a previously checked layer, since the time-temperature history is reused
-            if ((simulation_type == "FromFinch") || (_inputs.temp_files_in_series == 1)) {
-                // All layers have the same temperature data, max_solidification_events for this layer is the same as
-                // the last
-                max_solidification_events_host(layernumber) = max_solidification_events_host(layernumber - 1);
-            }
-            else {
-                // All layers have different temperature data but in a repeating pattern
-                int repeated_file = layernumber % _inputs.temp_files_in_series;
-                max_solidification_events_host(layernumber) = max_solidification_events_host(repeated_file);
-            }
-        }
-        else {
-            // Need to calculate max_solidification_events(layernumber)
-            // Init to 0
-            view_type_int_host temp_melt_count("temp_melt_count", grid.domain_size);
-
-            for (int i = start_range; i < end_range; i++) {
-
-                // Get the integer X, Y, Z coordinates associated with this data point, with the Y coordinate based on
-                // local MPI rank's grid
-                int coord_x = getTempCoordX(i, grid.x_min, grid.deltax);
-                int coord_y = getTempCoordY(i, grid.y_min, grid.deltax, grid.y_offset);
-                int coord_z = getTempCoordZ(i, grid.deltax, grid.layer_height, layernumber, grid.z_min_layer);
-                // Convert to 1D coordinate in the current layer's domain
-                int index = grid.get1DIndex(coord_x, coord_y, coord_z);
-                temp_melt_count(index)++;
-            }
-            int max_count = 0;
-            for (int i = 0; i < grid.domain_size; i++) {
-                if (temp_melt_count(i) > max_count)
-                    max_count = temp_melt_count(i);
-            }
-            int max_count_global;
-            MPI_Allreduce(&max_count, &max_count_global, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
-            max_solidification_events_host(layernumber) = max_count_global;
-        }
-        MPI_Barrier(MPI_COMM_WORLD);
+        MPI_Allreduce(&max_count, &max_num_solidification_events, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
         if (id == 0)
             std::cout << "The maximum number of melting/solidification events during layer " << layernumber << " is "
-                      << max_solidification_events_host(layernumber) << std::endl;
+                      << max_num_solidification_events << std::endl;
+        return _number_of_solidification_events;
     }
 
     // Read data from storage, and calculate the normalized x value of the data point
-    int getTempCoordX(const int i, const double x_min, const double deltax) {
+    int getTempCoordX(const int i, const double x_min, const double deltax) const {
         int x_coord = Kokkos::round((raw_temperature_data(i, 0) - x_min) / deltax);
         return x_coord;
     }
     // Read data from storage, and calculate the normalized y value of the data point. If the optional offset argument
     // is given, the return value is calculated relative to the edge of the MPI rank's local simulation domain (which is
     // offset by y_offset cells from the global domain edge)
-    int getTempCoordY(const int i, const double y_min, const double deltax, const int y_offset = 0) {
+    int getTempCoordY(const int i, const double y_min, const double deltax, const int y_offset = 0) const {
         int y_coord = Kokkos::round((raw_temperature_data(i, 1) - y_min) / deltax) - y_offset;
         return y_coord;
     }
     // Read data from storage, and calculate the normalized z value of the data point
     int getTempCoordZ(const int i, const double deltax, const int layer_height, const int layer_counter,
-                      const view_type_double_host z_min_layer) {
+                      const view_type_double_host z_min_layer) const {
         int z_coord = Kokkos::round(
             (raw_temperature_data(i, 2) + deltax * layer_height * layer_counter - z_min_layer[layer_counter]) / deltax);
         return z_coord;
     }
     // Read data from storage, obtain melting time
-    double getTempCoordTM(const int i) {
+    double getTempCoordTM(const int i) const {
         double t_melting = raw_temperature_data(i, 3);
         return t_melting;
     }
     // Read data from storage, obtain liquidus time
-    double getTempCoordTL(const int i) {
+    double getTempCoordTL(const int i) const {
         double t_liquidus = raw_temperature_data(i, 4);
         return t_liquidus;
     }
     // Read data from storage, obtain cooling rate
-    double getTempCoordCR(const int i) {
+    double getTempCoordCR(const int i) const {
         double cooling_rate = raw_temperature_data(i, 5);
         return cooling_rate;
     }
 
-    // Initialize temperature fields for layer "layernumber" in case where temperature data comes from file(s)
-    // TODO: This can be performed on the device as the dirS problem is
+    // Initialize temperature fields for layer "layernumber" in case where temperature data comes from file(s), could be
+    // done on device but currently relies on vector/host functions as is the case for the placeNuclei function
     void initialize(const int layernumber, const int id, const Grid &grid, const double freezing_range,
-                    const double deltat, const std::string simulation_type) {
+                    const double deltat) {
 
+        // Counter starts at 0 for each layer
+        liquidus_time_counter = 0;
+        // Resize for new layer's domain size
+        Kokkos::realloc(last_time_below_liquidus, grid.domain_size);
+        Kokkos::realloc(current_cooling_rate, grid.domain_size);
+        // Init values for views updated as heating above/cooling below the liquidus occur
+        Kokkos::deep_copy(last_time_below_liquidus, std::numeric_limits<int>::max());
+        Kokkos::deep_copy(current_cooling_rate, 0.0);
+        // LayerID for the next layer
+        layer_id = getLayerSubview(layer_id_all_layers, grid.layer_range);
         // Data was already read into the "raw_temperature_data" data structure
         // Determine which section of "raw_temperature_data" is relevant for this layer of the overall domain
         int start_range = first_value[layernumber];
         int end_range = last_value[layernumber];
+        num_liquidus_times_this_layer = 2 * (end_range - start_range);
 
-        // Temporary host view for the maximum number of times a cell in a given layer will solidify (different for each
-        // layer)
-        view_type_int_host max_solidification_events_host =
-            Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), max_solidification_events);
-        calcMaxSolidificationEvents(id, layernumber, max_solidification_events_host, start_range, end_range, grid,
-                                    simulation_type);
-        int max_num_solidification_events = max_solidification_events_host(layernumber);
-
-        // Resize liquidus_time now that the max number of solidification events is known for this layer
-        Kokkos::resize(liquidus_time, grid.domain_size, max_num_solidification_events, 2);
-
-        // These views are initialized to zeros on the host, filled with data, and then copied to the device for layer
-        // "layernumber"
-        view_type_int_3d_host liquidus_time_host("LiquidusTime_H", grid.domain_size, max_num_solidification_events, 2);
-        view_type_float_2d_host cooling_rate_host("CoolingRate_H", grid.domain_size, max_num_solidification_events);
-        view_type_int_host number_of_solidification_events_host("NumSEvents_H", grid.domain_size);
+        // Get the number of times each cell goes below the liquidus, and the max number of solidification events in a
+        // cell
+        Kokkos::realloc(number_of_solidification_events, grid.domain_size);
+        number_of_solidification_events =
+            calcNumberOfSolidificationEvents(id, layernumber, start_range, end_range, grid);
+        std::vector<int> liquidus_time_step_read(num_liquidus_times_this_layer),
+            cell_read(num_liquidus_times_this_layer);
+        std::vector<float> cooling_rate_read(num_liquidus_times_this_layer);
 
         double largest_time = 0;
         double largest_time_global = 0;
@@ -696,17 +769,20 @@ struct Temperature {
 
             // 1D cell coordinate on this MPI rank's domain
             int index = grid.get1DIndex(coord_x, coord_y, coord_z);
-            // Store TM, TL, CR values for this solidification event in liquidus_time_host/cooling_rate_host
-            const int n_solidification_events_cell = number_of_solidification_events_host(index);
-            liquidus_time_host(index, n_solidification_events_cell, 0) = Kokkos::round(t_melting / deltat) + 1;
-            liquidus_time_host(index, n_solidification_events_cell, 1) = Kokkos::round(t_liquidus / deltat) + 1;
-            // Cannot go above/below liquidus on same time step - must offset by at least 1
-            if (liquidus_time_host(index, n_solidification_events_cell, 0) ==
-                liquidus_time_host(index, n_solidification_events_cell, 1))
-                liquidus_time_host(index, n_solidification_events_cell, 1)++;
-            cooling_rate_host(index, n_solidification_events_cell) = std::abs(cooling_rate_cell) * deltat;
-            // Increment number of solidification events for this cell
-            number_of_solidification_events_host(index)++;
+
+            // Two events for this cell - going above and then going below liquidus temperature
+            int idx_this_layer = 2 * (i - start_range);
+            liquidus_time_step_read[idx_this_layer] = Kokkos::round(t_melting / deltat) + 1;
+            cell_read[idx_this_layer] = index;
+            cooling_rate_read[idx_this_layer] = -1.0; // heating
+
+            liquidus_time_step_read[idx_this_layer + 1] = Kokkos::round(t_liquidus / deltat) + 1;
+            // Ensure that cell doesn't go above and below liquidus on the same time step
+            if (liquidus_time_step_read[idx_this_layer + 1] == liquidus_time_step_read[idx_this_layer])
+                liquidus_time_step_read[idx_this_layer + 1] = liquidus_time_step_read[idx_this_layer + 1] + 1;
+            cell_read[idx_this_layer + 1] = index;
+            cooling_rate_read[idx_this_layer + 1] = std::abs(cooling_rate_cell) * deltat; // cooling
+
             // Estimate of the time step where the last possible solidification is expected to occur
             double solidus_time = t_liquidus + freezing_range / cooling_rate_cell;
             if (solidus_time > largest_time)
@@ -721,66 +797,21 @@ struct Temperature {
         if (id == 0)
             std::cout << "Layer " << layernumber << " temperatures read" << std::endl;
 
-        // Reorder solidification events in liquidus_time_host(location,event number,component) and
-        // cooling_rate_host(location,event number) so that they are in order based on the melting time values
-        // (component = 0 in liquidus_time_host)
-        for (int index = 0; index < grid.domain_size; index++) {
-            int n_solidification_events_cell = number_of_solidification_events_host(index);
-            if (n_solidification_events_cell > 0) {
-                for (int i = 0; i < n_solidification_events_cell - 1; i++) {
-                    for (int j = (i + 1); j < n_solidification_events_cell; j++) {
-                        if (liquidus_time_host(index, i, 0) > liquidus_time_host(index, j, 0)) {
-                            // Swap these two points - melting event "j" happens before event "i"
-                            float old_melt_val = liquidus_time_host(index, i, 0);
-                            float old_liq_val = liquidus_time_host(index, i, 1);
-                            float old_cr_val = cooling_rate_host(index, i);
-                            liquidus_time_host(index, i, 0) = liquidus_time_host(index, j, 0);
-                            liquidus_time_host(index, i, 1) = liquidus_time_host(index, j, 1);
-                            cooling_rate_host(index, i) = cooling_rate_host(index, j);
-                            liquidus_time_host(index, j, 0) = old_melt_val;
-                            liquidus_time_host(index, j, 1) = old_liq_val;
-                            cooling_rate_host(index, j) = old_cr_val;
-                        }
-                    }
-                }
-            }
-        }
-        // If a cell melts twice before reaching the liquidus temperature, this is a double counted solidification
-        // event and should be removed
-        for (int index = 0; index < grid.domain_size; index++) {
-            int n_solidification_events_cell = number_of_solidification_events_host(index);
-            if (n_solidification_events_cell > 1) {
-                for (int i = 0; i < n_solidification_events_cell - 1; i++) {
-                    if (liquidus_time_host(index, i + 1, 0) < liquidus_time_host(index, i, 1)) {
-                        std::cout << "Cell " << index << " removing anomalous event " << i + 1 << " out of "
-                                  << n_solidification_events_cell - 1 << std::endl;
-                        // Keep whichever event has the larger liquidus time
-                        if (liquidus_time_host(index, i + 1, 1) > liquidus_time_host(index, i, 1)) {
-                            liquidus_time_host(index, i, 0) = liquidus_time_host(index, i + 1, 0);
-                            liquidus_time_host(index, i, 1) = liquidus_time_host(index, i + 1, 1);
-                            cooling_rate_host(index, i) = cooling_rate_host(index, i + 1);
-                        }
-                        liquidus_time_host(index, i + 1, 0) = 0.0;
-                        liquidus_time_host(index, i + 1, 1) = 0.0;
-                        cooling_rate_host(index, i + 1) = 0.0;
-                        // Reshuffle other solidification events over if needed
-                        for (int ii = (i + 1); ii < n_solidification_events_cell - 1; ii++) {
-                            liquidus_time_host(index, ii, 0) = liquidus_time_host(index, ii + 1, 0);
-                            liquidus_time_host(index, ii, 1) = liquidus_time_host(index, ii + 1, 1);
-                            cooling_rate_host(index, ii) = cooling_rate_host(index, ii + 1);
-                        }
-                        number_of_solidification_events_host(index)--;
-                    }
-                }
-            }
-        }
+        // Reorder liquidus time events based on the times at which they occur
+        initOrderedTimeTempHistory(liquidus_time_step_read, cell_read, cooling_rate_read,
+                                   num_liquidus_times_this_layer);
 
-        // Copy host view data back to device
-        max_solidification_events = Kokkos::create_mirror_view_and_copy(memory_space(), max_solidification_events_host);
-        liquidus_time = Kokkos::create_mirror_view_and_copy(memory_space(), liquidus_time_host);
-        cooling_rate = Kokkos::create_mirror_view_and_copy(memory_space(), cooling_rate_host);
-        number_of_solidification_events =
-            Kokkos::create_mirror_view_and_copy(memory_space(), number_of_solidification_events_host);
+        // LayerID data on device for this layer - assign the current LayerID if this cell appears at least once on the
+        // list of melt/solidification events
+        auto _layer_id = layer_id;
+        auto _liquidus_cell_list = liquidus_cell_list;
+        auto policy = Kokkos::RangePolicy<execution_space>(0, num_liquidus_times_this_layer);
+        Kokkos::parallel_for(
+            "LayerIDInit", policy, KOKKOS_LAMBDA(const int &event_num) {
+                const int index = _liquidus_cell_list(event_num);
+                _layer_id(index) = layernumber;
+            });
+        Kokkos::fence();
         MPI_Barrier(MPI_COMM_WORLD);
         if (id == 0) {
             std::cout << "Layer " << layernumber << " temperature field is from Z = " << grid.z_layer_bottom
@@ -789,19 +820,10 @@ struct Temperature {
         }
     }
 
-    // Get the subview associated with the undercooling of cells in the current layer. Do not reset the undercooling of
-    // cells from the prior layer to zero as this information will be stored for a potential print (and a cell that
-    // remelts in the current layer will have its undercooling reset to 0 and recalculated)
-    void getCurrentLayerUndercooling(std::pair<int, int> layer_range) {
-        undercooling_current = Kokkos::subview(undercooling_current_all_layers, layer_range);
-    }
-
-    // (Optional based on selected inputs) Get the subview associated with the initial undercooling of cells during
-    // solidification start in the current layer. Do not reset the undercooling of cells from the prior layer to zero as
-    // this information will be stored for a potential print (and a cell that remelts in the current layer will have its
-    // undercooling reset to 0 and recalculated)
-    void getCurrentLayerStartingUndercooling(std::pair<int, int> layer_range) {
-        undercooling_solidification_start = Kokkos::subview(undercooling_solidification_start_all_layers, layer_range);
+    // Get the subview associated with data from one layer of a multilayer simulation
+    template <typename return_view_type>
+    return_view_type getLayerSubview(return_view_type input_view, std::pair<int, int> layer_range) {
+        return Kokkos::subview(input_view, layer_range);
     }
 
     // For each Z coordinate, find the smallest undercooling at which solidification started and finished, writing this
@@ -858,144 +880,104 @@ struct Temperature {
         return start_end_solidification_z_host;
     }
 
-    // Reset local cell undercooling (and if needed, the cell's starting undercooling) to 0
-    KOKKOS_INLINE_FUNCTION
-    void resetUndercooling(const int index) const {
-        if (_store_solidification_start)
-            undercooling_solidification_start(index) = 0.0;
-        undercooling_current(index) = 0.0;
-    }
-
-    // Update local cell undercooling for the current melt-resolidification event
-    KOKKOS_INLINE_FUNCTION
-    void updateUndercooling(const int index) const {
-        undercooling_current(index) += cooling_rate(index, solidification_event_counter(index));
-    }
-
     // (Optional based on inputs) Set the starting undercooling in the cell for the solidification event that just
-    // started
+    // started. If the cell is still above the liquid, set value to 0
     KOKKOS_INLINE_FUNCTION
-    void setStartingUndercooling(const int index) const {
-        if (_store_solidification_start)
-            undercooling_solidification_start(index) = undercooling_current(index);
+    void setStartingUndercooling(const int cycle, const int index) const {
+        if (store_undercooling_solidification_start)
+            undercooling_solidification_start(index) = Kokkos::fmin(
+                0.0, static_cast<float>(cycle - last_time_below_liquidus(index)) * current_cooling_rate(index));
+    }
+
+    // (Optional based on inputs) Set the undercooling in the cell at which solidification completed
+    KOKKOS_INLINE_FUNCTION
+    void setEndingUndercooling(const int cycle, const int index) const {
+        if (store_undercooling_current)
+            undercooling_current(index) =
+                static_cast<float>(cycle - last_time_below_liquidus(index)) * current_cooling_rate(index);
     }
 
     // Update the solidification event counter for a cell that has not finished the previous solidification event (i.e.,
     // solidification is not complete in this cell as it is not tempsolid or solid type)
     KOKKOS_INLINE_FUNCTION
-    void updateSolidificationCounter(const int index) const { solidification_event_counter(index)++; }
-
-    // Update the solidification event counter for the cell (which is either tempsolid or solid type) and return whether
-    // all solidification events have completed in the cell
-    KOKKOS_INLINE_FUNCTION
-    bool updateCheckSolidificationCounter(const int index) const {
-        bool solidification_complete;
-        solidification_event_counter(index)++;
-        if (solidification_event_counter(index) == number_of_solidification_events(index))
-            solidification_complete = true;
-        else
-            solidification_complete = false;
-        return solidification_complete;
+    void updateSolidificationCounter(const int index) const {
+        if (store_solidification_event_counter)
+            solidification_event_counter(index)++;
     }
 
-    // Reset solidification event counter and get the subview associated with the undercooling field for the next layer
+    // For the optionally stored views, reset solidification event counter and get the subview associated with the
+    // undercooling field for the next layer
     void resetLayerEventsUndercooling(const Grid &grid) {
-        getCurrentLayerUndercooling(grid.layer_range);
-        if (_store_solidification_start)
-            getCurrentLayerStartingUndercooling(grid.layer_range);
-        Kokkos::realloc(solidification_event_counter, grid.domain_size);
-        Kokkos::deep_copy(solidification_event_counter, 0);
-    }
-
-    // Extract the next time that this point undergoes melting
-    KOKKOS_INLINE_FUNCTION
-    int getMeltTimeStep(const int cycle, const int index) const {
-        int melt_time_step;
-        int solidification_event_counter_cell = solidification_event_counter(index);
-        melt_time_step = liquidus_time(index, solidification_event_counter_cell, 0);
-        if (cycle > melt_time_step) {
-            // If the cell has already exceeded the melt time step for the current melt-solidification event, get the
-            // melt time step associated with the next solidification event - or, if there is no next
-            // melt-solidification event, return the max possible int as the cell will not melt again during this layer
-            // of the multilayer problem
-            if (solidification_event_counter_cell < (number_of_solidification_events(index) - 1))
-                melt_time_step = liquidus_time(index, solidification_event_counter_cell + 1, 0);
-            else
-                melt_time_step = INT_MAX;
+        if (store_undercooling_current)
+            undercooling_current = getLayerSubview(undercooling_current_all_layers, grid.layer_range);
+        if (store_undercooling_solidification_start)
+            undercooling_solidification_start =
+                getLayerSubview(undercooling_solidification_start_all_layers, grid.layer_range);
+        if (store_solidification_event_counter) {
+            Kokkos::realloc(solidification_event_counter, grid.domain_size);
+            Kokkos::deep_copy(solidification_event_counter, 0);
         }
-        return melt_time_step;
     }
 
-    // Extract the next time that this point cools below the liquidus
-    // Uses the current value of the solidification event counter
+    // Get undercooling of an active cell (init_undercooling is undercooling of domains with a uniform undercooling and
+    // no cooling rate)
     KOKKOS_INLINE_FUNCTION
-    int getCritTimeStep(const int index) const {
-        int solidification_event_counter_cell = solidification_event_counter(index);
-        int crit_time_step = liquidus_time(index, solidification_event_counter_cell, 1);
-        return crit_time_step;
-    }
-    // Uses a specified solidification event
-    KOKKOS_INLINE_FUNCTION
-    int getCritTimeStep(const int index, const int solidification_event_counter_cell) const {
-        int crit_time_step = liquidus_time(index, solidification_event_counter_cell, 1);
-        return crit_time_step;
+    float getUndercooling(const int cycle, const int index) const {
+        return init_undercooling +
+               static_cast<float>(cycle - last_time_below_liquidus(index)) * current_cooling_rate(index);
     }
 
-    // Extract the cooling rate associated with a specified solidificaiton event
-    KOKKOS_INLINE_FUNCTION
-    float getUndercoolingChange(const int index, const int solidification_event_counter_cell) const {
-        float undercooling_change = cooling_rate(index, solidification_event_counter_cell);
-        return undercooling_change;
-    }
-
-    // Extract either the last time step that all points undergo melting in the layer or the last time they cools below
-    // the liquidus from liquidus_time (corresponds to solidification event number_of_solidification_events-1
-    // for the cell) (can't just use subview here since number_of_solidification_events is different for each cell) If
-    // the cell does not undergo solidification, either print -1 or the specified default value
+    // Extract the last time step that each cell undergoes melting in the layer. If the cell does not undergo
+    // solidification, either print -1 or the specified default value
     template <typename extracted_view_data_type>
-    extracted_view_data_type extractTmTlData(const int extracted_val, const int domain_size,
-                                             const int default_val = -1) {
+    extracted_view_data_type extractTmData(const int domain_size, const int default_val = -1) {
         extracted_view_data_type extracted_data(Kokkos::ViewAllocateWithoutInitializing("extracted_data"), domain_size);
+        Kokkos::deep_copy(extracted_data, default_val);
+        auto liquidus_cell_list_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), liquidus_cell_list);
+        auto cooling_rate_list_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), cooling_rate_list);
 
-        // Local copies for lambda capture.
-        auto liquidus_time_local = liquidus_time;
-        auto number_of_solidification_events_local = number_of_solidification_events;
-
-        auto policy = Kokkos::RangePolicy<execution_space>(0, domain_size);
-        Kokkos::parallel_for(
-            "Extract_tm_tl_data", policy, KOKKOS_LAMBDA(const int &index) {
-                // If this cell doesn't undergo solidification at all, print -1
-                const int num_solidification_events_this_cell = number_of_solidification_events_local(index);
-                if (num_solidification_events_this_cell == 0)
-                    extracted_data(index) = default_val;
-                else
-                    extracted_data(index) =
-                        liquidus_time_local(index, num_solidification_events_this_cell - 1, extracted_val);
-            });
+        for (int n = 0; n < num_liquidus_times_this_layer; n++) {
+            if (cooling_rate_list_host(n) < 0) {
+                const int index = liquidus_cell_list_host(n);
+                extracted_data(index) = liquidus_time_list_host(n);
+            }
+        }
         return extracted_data;
     }
 
-    // Extract the cooling rate corresponding to solidification event number `number_of_solidification_events-1` for the
-    // cell (can't just use subview here since number_of_solidification_events is different for each cell) If the cell
-    // does not undergo solidification, either print -1 or the specified default value
+    // Extract the last time step that each cell cools below the liquidus in the layer. If the cell does not undergo
+    // solidification, either print -1 or the specified default value
+    template <typename extracted_view_data_type>
+    extracted_view_data_type extractTlData(const int domain_size, const int default_val = -1) {
+        extracted_view_data_type extracted_data(Kokkos::ViewAllocateWithoutInitializing("extracted_data"), domain_size);
+        Kokkos::deep_copy(extracted_data, default_val);
+        auto liquidus_cell_list_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), liquidus_cell_list);
+        auto cooling_rate_list_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), cooling_rate_list);
+
+        for (int n = 0; n < num_liquidus_times_this_layer; n++) {
+            if (cooling_rate_list_host(n) >= 0) {
+                const int index = liquidus_cell_list_host(n);
+                extracted_data(index) = liquidus_time_list_host(n);
+            }
+        }
+        return extracted_data;
+    }
+
+    // Extract the cooling rate associated with the final time the cell cools below the liquidus in the layer. If
+    // the cell does not undergo solidification, either print -1 or the specified default value
     template <typename extracted_view_data_type>
     extracted_view_data_type extractCrData(const int domain_size, const int default_val = -1) {
         extracted_view_data_type extracted_data(Kokkos::ViewAllocateWithoutInitializing("extracted_data"), domain_size);
+        Kokkos::deep_copy(extracted_data, default_val);
+        auto liquidus_cell_list_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), liquidus_cell_list);
+        auto cooling_rate_list_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), cooling_rate_list);
 
-        // Local copies for lambda capture.
-        auto cooling_rate_local = cooling_rate;
-        auto number_of_solidification_events_local = number_of_solidification_events;
-
-        auto policy = Kokkos::RangePolicy<execution_space>(0, domain_size);
-        Kokkos::parallel_for(
-            "Extract_tm_tl_data", policy, KOKKOS_LAMBDA(const int &index) {
-                // If this cell doesn't undergo solidification at all, print -1
-                const int num_solidification_events_this_cell = number_of_solidification_events_local(index);
-                if (num_solidification_events_this_cell == 0)
-                    extracted_data(index) = default_val;
-                else
-                    extracted_data(index) = cooling_rate_local(index, num_solidification_events_this_cell - 1);
-            });
+        for (int n = 0; n < num_liquidus_times_this_layer; n++) {
+            if (cooling_rate_list_host(n) >= 0) {
+                const int index = liquidus_cell_list_host(n);
+                extracted_data(index) = cooling_rate_list_host(n);
+            }
+        }
         return extracted_data;
     }
 };

--- a/src/CAtimers.hpp
+++ b/src/CAtimers.hpp
@@ -51,7 +51,7 @@ struct Timers {
 
     int id;
     Timer init, run, output;
-    Timer nucl, create_sv, capture, ghost;
+    Timer nucl, melt_act, create_sv, capture, ghost;
     Timer layer;
     Timer heat_transfer;
 
@@ -61,6 +61,7 @@ struct Timers {
         , run()
         , output()
         , nucl()
+        , melt_act()
         , create_sv()
         , capture()
         , ghost()
@@ -84,6 +85,9 @@ struct Timers {
 
     void startNucleation() { nucl.start(); }
     void stopNucleation() { nucl.stop(); }
+
+    void startMeltAct() { melt_act.start(); }
+    void stopMeltAct() { melt_act.stop(); }
 
     void startSV() { create_sv.start(); }
     void stopSV() { create_sv.stop(); }
@@ -122,6 +126,8 @@ struct Timers {
             << "]," << std::endl;
         log << "       \"MaxMinInitTime\": [" << init.maxTime() << "," << init.minTime() << "]," << std::endl;
         log << "       \"MaxMinNucleationTime\": [" << nucl.maxTime() << "," << nucl.minTime() << "]," << std::endl;
+        log << "       \"MaxMinMeltingActivationTime\": [" << melt_act.maxTime() << "," << melt_act.minTime() << "],"
+            << std::endl;
         log << "       \"MaxMinSteeringVectorCreationTime\": [" << create_sv.maxTime() << "," << create_sv.minTime()
             << "]," << std::endl;
         log << "       \"MaxMinCellCaptureTime\": [" << capture.maxTime() << "," << capture.minTime() << "],"
@@ -137,6 +143,7 @@ struct Timers {
         // Reduce all times across MPI ranks
         init.reduceMPI();
         nucl.reduceMPI();
+        melt_act.reduceMPI();
         create_sv.reduceMPI();
         capture.reduceMPI();
         ghost.reduceMPI();
@@ -160,14 +167,13 @@ struct Timers {
         std::cout << init.print("initializing data");
         std::cout << run.print("performing CA calculations");
         std::cout << output.print("collecting and printing output data");
-
         std::cout << init.printMinMax("initializing data");
         std::cout << nucl.printMinMax("in CA nucleation");
+        std::cout << melt_act.printMinMax("in CA melting and reactivation of cells");
         std::cout << create_sv.printMinMax("in CA steering vector creation");
         std::cout << capture.printMinMax("in CA cell capture");
         std::cout << ghost.printMinMax("in CA cell communication");
         std::cout << output.printMinMax("exporting data");
-
         std::cout << "===================================================================================" << std::endl;
     }
 };

--- a/src/runCA.hpp
+++ b/src/runCA.hpp
@@ -20,20 +20,28 @@ void runExaCA(int id, int np, Inputs inputs, Timers timers, Grid grid, Temperatu
     using memory_space = MemorySpace;
 
     std::string simulation_type = inputs.simulation_type;
+    // Full domain solidification - all cells initially liquid or active and end up solid
+    bool full_domain_solidification;
+    if ((simulation_type == "Directional") || (simulation_type == "SingleGrain"))
+        full_domain_solidification = true;
+    else
+        full_domain_solidification = false;
 
     // Material response function
     InterfacialResponseFunction irf(inputs.domain.deltat, grid.deltax, inputs.irf);
 
-    // Read temperature data if necessary
+    // Read temperature data if necessary. For the spot problem, store spot melt data as if it were read from a file
     if (simulation_type == "FromFile")
         temperature.readTemperatureData(id, grid, 0);
-    // Initialize the temperature fields for the simulation type of interest
-    if ((simulation_type == "Directional") || (simulation_type == "SingleGrain"))
-        temperature.initialize(id, simulation_type, grid, inputs.domain.deltat);
     else if (simulation_type == "Spot")
-        temperature.initialize(id, grid, irf.freezingRange(), inputs.domain.deltat, inputs.domain.spot_radius);
-    else if ((simulation_type == "FromFile") || (simulation_type == "FromFinch"))
-        temperature.initialize(0, id, grid, irf.freezingRange(), inputs.domain.deltat, simulation_type);
+        temperature.storeSpotData(id, grid, irf.freezingRange(), inputs.domain.deltat, inputs.domain.spot_radius);
+
+    // Initialize the temperature fields for the simulation type of interest. These are either simple unidirectional
+    // fields, or more complex data stored in a view in the temperature struct
+    if (full_domain_solidification)
+        temperature.initialize(id, simulation_type, grid, inputs.domain.deltat);
+    else
+        temperature.initialize(0, id, grid, irf.freezingRange(), inputs.domain.deltat);
     MPI_Barrier(MPI_COMM_WORLD);
 
     // Initialize grain orientations
@@ -44,16 +52,19 @@ void runExaCA(int id, int np, Inputs inputs, Timers timers, Grid grid, Temperatu
     // Initialize cell types, grain IDs, and layer IDs
     CellData<memory_space> celldata(grid, inputs.substrate, inputs.print.store_melt_pool_edge);
     if (simulation_type == "Directional")
-        celldata.initSubstrate(id, grid, inputs.rng_seed);
+        celldata.initSubstrate_Directional(id, grid, inputs.rng_seed);
     else if (simulation_type == "SingleGrain")
-        celldata.initSubstrate(id, grid);
+        celldata.initSubstrate_SingleGrain(id, grid);
     else
-        celldata.initSubstrate(id, grid, inputs.rng_seed, temperature.number_of_solidification_events);
+        celldata.initSubstrate_BaseplatePowder(id, grid, inputs.rng_seed);
     MPI_Barrier(MPI_COMM_WORLD);
 
     // Variables characterizing the active cell region within each rank's grid, including buffers for ghost node data
     // (fixed size) and the steering vector/steering vector size on host/device
     Interface<memory_space> interface(id, grid.domain_size, inputs.substrate.init_oct_size);
+    // Initialize octahedra for initial active cells, if necessary for this problem type
+    if (full_domain_solidification)
+        createOctahedra_NoRemelt(grid, celldata, temperature, orientation, interface);
     MPI_Barrier(MPI_COMM_WORLD);
 
     // Nucleation data structure, containing views of nuclei locations, time steps, and ids, and nucleation event
@@ -66,7 +77,7 @@ void runExaCA(int id, int np, Inputs inputs, Timers timers, Grid grid, Temperatu
     // Fill in nucleation data structures, and assign nucleation undercooling values to potential nucleation events
     // Potential nucleation grains are only associated with liquid cells in layer 0 - they will be initialized for each
     // successive layer when layer 0 is complete
-    nucleation.placeNuclei(temperature, irf, inputs.rng_seed, 0, grid, id);
+    nucleation.placeNuclei(simulation_type, temperature, irf, inputs.rng_seed, 0, grid, id, inputs.domain.deltat);
 
     // Initialize printing struct from inputs
     Print print(grid, np, inputs.print);
@@ -97,14 +108,16 @@ void runExaCA(int id, int np, Inputs inputs, Timers timers, Grid grid, Temperatu
             nucleation.nucleateGrain(cycle, grid, celldata, interface);
             timers.stopNucleation();
 
-            // Cells that have a successful nucleation event, and other cells that are at the solid-liquid interface are
-            // added to a steering vector. Logic in fillSteeringVector_NoRemelt is a simpified version of
-            // fillSteeringVector_Remelt
+            // Melt cells above the liquidus, activate cells at the solid-liquid interface below the liquidus
+            if (!full_domain_solidification) {
+                timers.startMeltAct();
+                remeltActivateCells(cycle, grid, irf, celldata, temperature, interface);
+                timers.stopMeltAct();
+            }
+
+            // Create steering vector of cells that are active and undercooled on this time step
             timers.startSV();
-            if ((simulation_type == "Directional") || (simulation_type == "SingleGrain"))
-                fillSteeringVector_NoRemelt(cycle, grid, celldata, temperature, interface);
-            else
-                fillSteeringVector_Remelt(cycle, grid, irf, celldata, temperature, interface);
+            fillSteeringVector(cycle, grid, celldata, temperature, interface);
             timers.stopSV();
 
             // Iterate over the steering vector to perform active cell creation and capture operations, and if needed,
@@ -156,8 +169,7 @@ void runExaCA(int id, int np, Inputs inputs, Timers timers, Grid grid, Temperatu
                 temperature.readTemperatureData(id, grid, layernumber + 1);
             MPI_Barrier(MPI_COMM_WORLD);
             // Initialize next layer's temperature data
-            temperature.initialize(layernumber + 1, id, grid, irf.freezingRange(0), inputs.domain.deltat,
-                                   simulation_type);
+            temperature.initialize(layernumber + 1, id, grid, irf.freezingRange(0), inputs.domain.deltat);
 
             // Reset solidification event counter of all cells to zeros for the next layer, resizing to number of cells
             // associated with the next layer, and get the subview for undercooling
@@ -168,14 +180,14 @@ void runExaCA(int id, int np, Inputs inputs, Timers timers, Grid grid, Temperatu
             MPI_Barrier(MPI_COMM_WORLD);
 
             // Sets up views, powder layer (if necessary), and cell types for the next layer of a multilayer problem
-            celldata.initNextLayer(layernumber + 1, id, grid, inputs.rng_seed,
-                                   temperature.number_of_solidification_events);
+            celldata.initNextLayer(layernumber + 1, id, grid, inputs.rng_seed);
 
             // Initialize potential nucleation event data for next layer "layernumber + 1"
             // Views containing nucleation data will be resized to the possible number of nuclei on a given MPI rank for
             // the next layer
             nucleation.resetNucleiCounters(); // start counters at 0
-            nucleation.placeNuclei(temperature, irf, inputs.rng_seed, layernumber + 1, grid, id);
+            nucleation.placeNuclei(simulation_type, temperature, irf, inputs.rng_seed, layernumber + 1, grid, id,
+                                   inputs.domain.deltat);
 
             x_switch = 0;
             MPI_Barrier(MPI_COMM_WORLD);
@@ -196,7 +208,7 @@ void runExaCA(int id, int np, Inputs inputs, Timers timers, Grid grid, Temperatu
                           interface, orientation);
 
     // Calculate volume fraction of solidified domain consisting of nucleated grains
-    float vol_fraction_nucleated = celldata.calcVolFractionNucleated(id, grid);
+    float vol_fraction_nucleated = celldata.calcVolFractionNucleated(id, grid, temperature);
     // Get MPI timing statisticss
     timers.stopOutput();
     timers.reduceMPI();

--- a/unit_test/tstUpdate.hpp
+++ b/unit_test/tstUpdate.hpp
@@ -43,7 +43,7 @@ void testSmallDirS() {
     Grid grid(inputs.simulation_type, id, np, inputs.domain.number_of_layers, inputs.domain, inputs.substrate,
               inputs.temperature);
     // Temperature fields characterized by data in this structure
-    Temperature<memory_space> temperature(grid, inputs.temperature, inputs.print.store_solidification_start);
+    Temperature<memory_space> temperature(grid, inputs.temperature, inputs.print);
 
     // Run SmallDirS problem and check volume fraction of nucleated grains with 1% tolerance of expected value (to
     // account for the non-deterministic nature of the cell capture)
@@ -75,7 +75,7 @@ void testSmallEquiaxedGrain() {
     Grid grid(inputs.simulation_type, id, np, inputs.domain.number_of_layers, inputs.domain, inputs.substrate,
               inputs.temperature);
     // Temperature fields characterized by data in this structure
-    Temperature<memory_space> temperature(grid, inputs.temperature, inputs.print.store_solidification_start);
+    Temperature<memory_space> temperature(grid, inputs.temperature, inputs.print);
 
     // Run Small equiaxed grain problem and check time step at which the grain reaches the domain edge
     runExaCA(id, np, inputs, timers, grid, temperature);
@@ -86,7 +86,8 @@ void testSmallEquiaxedGrain() {
     std::ifstream log_data_stream(log_file);
     nlohmann::json log_data = nlohmann::json::parse(log_data_stream);
     int time_step_of_output = log_data["TimeStepOfOutput"];
-    // FIXME: Output time step is usually 4820, but may be 4821 - need to investigate this possible race condition
+    // FIXME: Output time step is usually 4820, but may be 1 time step larger - need to investigate this possible race
+    // condition. Finishes 1 time step earlier now after update to active cell init for no remelting case
     EXPECT_NEAR(time_step_of_output, 4820, 1);
 }
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Separating the melting/activation of cells above/below the liquidus (which is now faster as only the relevant cells are iterated over on a given time step) from the iterations over the list of undercooled active cells, thread divergence was significantly reduced. Speedup of around 3-4x on CPU and around 10-25% on GPU, with larger speedups for larger problems, particularly those with many melting/solidification events in the same cell on a given time step. This change also reduces memory usage for problems where the number of times a cell melts/solidifies is highly variable across a given domain.