### PR TITLE
Fix buffer unpack edge case where liquid cell data is unpacked into an existing liquid cell

### DIFF
--- a/src/CAupdate.hpp
+++ b/src/CAupdate.hpp
@@ -638,7 +638,8 @@ void haloUpdate(const int, const int, const Grid &grid, CellData<MemorySpace> &c
                         // Two possibilities: buffer data with non-zero diagonal length was loaded, and a liquid
                         // cell may have to be updated to active - or zero diagonal length data was loaded, and an
                         // active cell may have to be updated to liquid
-                        if (celldata.cell_type(index) == Liquid) {
+                        if ((celldata.cell_type(index) == Liquid) &&
+                            (interface.buffer_south_recv(buf_position, 7) > 0.0)) {
                             place = true;
                             int my_grain_orientation = static_cast<int>(interface.buffer_south_recv(buf_position, 2));
                             int my_grain_number = static_cast<int>(interface.buffer_south_recv(buf_position, 3));
@@ -664,7 +665,8 @@ void haloUpdate(const int, const int, const Grid &grid, CellData<MemorySpace> &c
                         // Two possibilities: buffer data with non-zero diagonal length was loaded, and a liquid
                         // cell may have to be updated to active - or zero diagonal length data was loaded, and an
                         // active cell may have to be updated to liquid
-                        if (celldata.cell_type(index) == Liquid) {
+                        if ((celldata.cell_type(index) == Liquid) &&
+                            (interface.buffer_north_recv(buf_position, 7) > 0.0)) {
                             place = true;
                             int my_grain_orientation = static_cast<int>(interface.buffer_north_recv(buf_position, 2));
                             int my_grain_number = static_cast<int>(interface.buffer_north_recv(buf_position, 3));


### PR DESCRIPTION
Previously, it was assumed that if a halo region cell is liquid and data from another MPI rank is received, that the received data must correspond to active cell data. This guards against an edge case where this is not true (i.e., attempting to unpack liquid cell data but the cell is already liquid) by checking that the unpacked octahedron diagonal length > 0.