### PR TITLE
Remove old executables

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -160,15 +160,15 @@ jobs:
       - name: Test ExaCA
         working-directory: examples
         run: |
-          $HOME/exaca/bin/ExaCA-Kokkos Inp_SmallDirSolidification.json
-          $HOME/exaca/bin/ExaCA-Kokkos Inp_SmallSpotMelt.json
-          mpirun -n 2 --oversubscribe $HOME/exaca/bin/ExaCA-Kokkos Inp_SmallDirSolidification.json
-          mpirun -n 2 --oversubscribe $HOME/exaca/bin/ExaCA-Kokkos Inp_SmallSpotMelt.json
+          $HOME/exaca/bin/ExaCA Inp_SmallDirSolidification.json
+          $HOME/exaca/bin/ExaCA Inp_SmallSpotMelt.json
+          mpirun -n 2 --oversubscribe $HOME/exaca/bin/ExaCA Inp_SmallDirSolidification.json
+          mpirun -n 2 --oversubscribe $HOME/exaca/bin/ExaCA Inp_SmallSpotMelt.json
       - name: Test GA
         working-directory: analysis/examples
         run: |
-           $HOME/exaca/bin/ExaCA-Kokkos ../../examples/Inp_SmallDirSolidification.json
-           $HOME/exaca/bin/grain_analysis AnalyzeSmallDirS.json TestProblemSmallDirS
+           $HOME/exaca/bin/ExaCA ../../examples/Inp_SmallDirSolidification.json
+           $HOME/exaca/bin/ExaCA-GrainAnalysis AnalyzeSmallDirS.json TestProblemSmallDirS
       - name: Test Finch-ExaCA
         if: ${{ matrix.heat_transfer == 'Finch' }}
         working-directory: utilities/Finch

--- a/analysis/bin/CMakeLists.txt
+++ b/analysis/bin/CMakeLists.txt
@@ -1,9 +1,3 @@
 add_executable(ExaCA-GrainAnalysis runGA.cpp)
 target_link_libraries(ExaCA-GrainAnalysis ExaCA-Analysis)
 install(TARGETS ExaCA-GrainAnalysis DESTINATION ${CMAKE_INSTALL_BINDIR})
-
-# Symlink for backwards compatibility
-add_custom_target(grain_analysis ALL COMMAND ${CMAKE_COMMAND} -E create_symlink
-                                             ExaCA-GrainAnalysis grain_analysis)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grain_analysis
-        DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -2,12 +2,6 @@ add_executable(ExaCA run.cpp)
 target_link_libraries(ExaCA ExaCA-Core)
 install(TARGETS ExaCA DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-# Symlink for backwards compatibility
-add_custom_target(ExaCA-Kokkos ALL COMMAND ${CMAKE_COMMAND} -E create_symlink
-                                           ExaCA ExaCA-Kokkos)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ExaCA-Kokkos
-        DESTINATION ${CMAKE_INSTALL_BINDIR})
-
 if(ExaCA_ENABLE_FINCH)
   add_executable(Finch-ExaCA runCoupled.cpp)
   target_link_libraries(Finch-ExaCA ExaCA-Core)


### PR DESCRIPTION
Renamed forever ago; well past time to remove, but a nice reminder of the earliest days of ExaCA 