### PR TITLE
ci: use external json for most jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
         backend: ['SERIAL', 'OPENMP']
         cmake_build_type: ['Debug', 'Release']
         kokkos_ver: ['4.0.01']
-        json: ['Internal']
+        json: ['External']
         heat_transfer: ['None']
         include:
           - distro: 'ubuntu:intel'
@@ -46,7 +46,7 @@ jobs:
             backend: 'SERIAL'
             cmake_build_type: 'Debug'
             kokkos_ver: '4.0.01'
-            json: External
+            json: Internal
             heat_transfer: 'None'
           - distro: 'ubuntu:latest'
             cxx: 'g++'


### PR DESCRIPTION
There are occasional failures for the internal json download in the CI; switch the matrix to use externally built json instead, but retain one job to check the fetch still works. Will likely still fail, but less often 