### PR TITLE
Avoid assigning color to non-existent phase in MTEX plotting utility

### DIFF
--- a/utilities/MTEX/PlotIPFColoredSection.m
+++ b/utilities/MTEX/PlotIPFColoredSection.m
@@ -57,7 +57,8 @@ function [] = PlotIPFColoredSection(MTEXFile, Phaselist)
         figure(fig_counter);
         ebsd(pname1).color = [0 0 0];
         % only assign white color to second phase if ebsd object is multiphase
-        if (sum(ebsd.phase) ~= length(ebsd.phase))
+        second_phase_present = any(ebsd.phase == 2, 'all');
+        if (second_phase_present)
             ebsd(pname2).color = [1 1 1];
         end
         plot(ebsd);

--- a/utilities/MTEX/PlotIPFColoredSection.m
+++ b/utilities/MTEX/PlotIPFColoredSection.m
@@ -56,7 +56,10 @@ function [] = PlotIPFColoredSection(MTEXFile, Phaselist)
     if (numphases == 2)
         figure(fig_counter);
         ebsd(pname1).color = [0 0 0];
-        ebsd(pname2).color = [1 1 1];
+        % only assign white color to second phase if ebsd object is multiphase
+        if (sum(ebsd.phase) ~= length(ebsd.phase))
+            ebsd(pname2).color = [1 1 1];
+        end
         plot(ebsd);
         OutputFileName = strcat(BaseFileName,'_SolidifiedPhases.png');
         export_fig(OutputFileName,'-r150');


### PR DESCRIPTION
For the edge case where two phases are given on the command line but no pixels are assigned to the second phase, this change avoids a Matlab error where the color attribute is assigned to the second phase of a single-phase EBSD object 